### PR TITLE
contributing guide remove import check style step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,21 +3,6 @@
 Welcome to EventMesh! This document is a guideline about how to contribute to EventMesh. If you find something incorrect
 or missing, please leave comments / suggestions.
 
-## Before you get started
-
-### Setting up your development environment
-
-You should have JDK installed in your develop environment.
-
-### Code style
-
-Import [EventMesh CheckStyle](./style/checkStyle.xml) file to your IDE.
-
-For IDEA, you can import check style file by:
-```shell
-Editor -> Code Style -> Java -> Scheme -> Import Scheme -> CheckStyle Configuration
-```
-
 ## Contributing
 
 We are always very happy to have contributions, whether for typo fix, bug fix or big new features. Please do not ever

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -2,19 +2,6 @@
 
 欢迎使用EventMesh! 本文档是有关如何为EventMesh做出贡献的指南。 如果发现不正确或缺失的内容，请留下评论/建议。
 
-## 开始之前
-
-### 设置您的开发环境
-
-您应该在开发环境中安装了JDK。
-
-### Code Style
-
-将 [EventMesh CheckStyle](./style/checkStyle.xml) 文件导入开发者工具。如果你使用IDEA，你可以通过以下步骤导入：
-```shell
-Editor -> Code Style -> Java -> Scheme -> Import Scheme -> CheckStyle Configuration
-```
-
 ## 贡献
 
 无论是对于拼写错误，BUG修复还是重要的新功能，我们总是很乐意接受您的贡献。请不要犹豫，在Github Issue上提出或者通过邮件列表进行讨论。


### PR DESCRIPTION
Fixes ISSUE #569.

Motivation
I can't import eventMesh checkStyle file into idea. It shows error message.
And it's also not mandatory for developer, and it's for github cicd.
So We can remove it in Contributing guide.

Modifications
Edit both CONTRIBUTING.md and CONTRIBUTING>zh-CN.md file remove import code style step.