### PR TITLE
[ISSUE #569]Contributing guide edit import check style step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ For IDEA, you can import check style file by:
 ```shell
 Editor -> Code Style -> Java -> Scheme -> Import Scheme -> CheckStyle Configuration
 ```
+If you can't see CheckStyle Configuration section under Import Scheme, you can install CheckStyle-IDEA plugin first, and you will see it.
 
 ## Contributing
 

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -14,6 +14,7 @@
 ```shell
 Editor -> Code Style -> Java -> Scheme -> Import Scheme -> CheckStyle Configuration
 ```
+如果你在Import Scheme下看不到CheckStyle Configuration选项，你可以先安装CheckStyle-IDEA插件，然后你就可以看到这个选项了。
 
 ## 贡献
 


### PR DESCRIPTION
Fixes ISSUE apache#569.

Motivation
Follow the contributing doc, I can't see the CheckStyle Configuration import section, and can't import check style file success.
After I installed the CheckStyle-IDEA plugin, it show the CheckStyle Configuration import section, and I can install success.

Modifications
Edit both CONTRIBUTING.md and CONTRIBUTING>zh-CN.md file edit import code style step add install check style plugin tip.