### PR TITLE
[ISSUE-902] Remove unused interface in eventstore connector producer

### DIFF
--- a/eventmesh-connector-plugin/eventmesh-connector-api/src/main/java/org/apache/eventmesh/api/SendCallback.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-api/src/main/java/org/apache/eventmesh/api/SendCallback.java
@@ -23,7 +23,7 @@ import org.apache.eventmesh.api.producer.Producer;
 import io.cloudevents.CloudEvent;
 
 /**
- * Call back interface used in {@link Producer#sendAsync(CloudEvent, SendCallback)}.
+ * Call back interface used in {@link Producer#publish(CloudEvent, SendCallback)}.
  */
 public interface SendCallback {
 

--- a/eventmesh-connector-plugin/eventmesh-connector-api/src/main/java/org/apache/eventmesh/api/producer/Producer.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-api/src/main/java/org/apache/eventmesh/api/producer/Producer.java
@@ -36,13 +36,9 @@ public interface Producer extends LifeCycle {
 
     void init(Properties properties) throws Exception;
 
-    SendResult publish(final CloudEvent cloudEvent);
-
     void publish(CloudEvent cloudEvent, SendCallback sendCallback) throws Exception;
 
     void sendOneway(final CloudEvent cloudEvent);
-
-    void sendAsync(final CloudEvent cloudEvent, final SendCallback sendCallback);
 
     void request(CloudEvent cloudEvent, RequestReplyCallback rrCallback, long timeout) throws Exception;
 

--- a/eventmesh-connector-plugin/eventmesh-connector-rocketmq/src/main/java/org/apache/eventmesh/connector/rocketmq/producer/RocketMQProducerImpl.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-rocketmq/src/main/java/org/apache/eventmesh/connector/rocketmq/producer/RocketMQProducerImpl.java
@@ -19,7 +19,6 @@ package org.apache.eventmesh.connector.rocketmq.producer;
 
 import org.apache.eventmesh.api.RequestReplyCallback;
 import org.apache.eventmesh.api.SendCallback;
-import org.apache.eventmesh.api.SendResult;
 import org.apache.eventmesh.api.producer.Producer;
 import org.apache.eventmesh.connector.rocketmq.common.EventMeshConstants;
 import org.apache.eventmesh.connector.rocketmq.config.ClientConfiguration;
@@ -84,11 +83,6 @@ public class RocketMQProducerImpl implements Producer {
     }
 
     @Override
-    public SendResult publish(CloudEvent message) {
-        return producer.send(message);
-    }
-
-    @Override
     public void request(CloudEvent message, RequestReplyCallback rrCallback, long timeout)
             throws InterruptedException, RemotingException, MQClientException, MQBrokerException {
         producer.request(message, rrCallback, timeout);
@@ -116,11 +110,4 @@ public class RocketMQProducerImpl implements Producer {
     public void sendOneway(CloudEvent message) {
         producer.sendOneway(message);
     }
-
-    @Override
-    public void sendAsync(CloudEvent message, SendCallback sendCallback) {
-        producer.sendAsync(message, sendCallback);
-    }
-
-
 }

--- a/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/producer/StandaloneProducerAdaptor.java
+++ b/eventmesh-connector-plugin/eventmesh-connector-standalone/src/main/java/org/apache/eventmesh/connector/standalone/producer/StandaloneProducerAdaptor.java
@@ -19,7 +19,6 @@ package org.apache.eventmesh.connector.standalone.producer;
 
 import org.apache.eventmesh.api.RequestReplyCallback;
 import org.apache.eventmesh.api.SendCallback;
-import org.apache.eventmesh.api.SendResult;
 import org.apache.eventmesh.api.producer.Producer;
 
 import java.util.Properties;
@@ -59,11 +58,6 @@ public class StandaloneProducerAdaptor implements Producer {
     }
 
     @Override
-    public SendResult publish(CloudEvent cloudEvent) {
-        return standaloneProducer.publish(cloudEvent);
-    }
-
-    @Override
     public void publish(CloudEvent cloudEvent, SendCallback sendCallback) throws Exception {
         standaloneProducer.publish(cloudEvent, sendCallback);
     }
@@ -71,11 +65,6 @@ public class StandaloneProducerAdaptor implements Producer {
     @Override
     public void sendOneway(CloudEvent cloudEvent) {
         standaloneProducer.sendOneway(cloudEvent);
-    }
-
-    @Override
-    public void sendAsync(CloudEvent cloudEvent, SendCallback sendCallback) {
-        standaloneProducer.sendAsync(cloudEvent, sendCallback);
     }
 
     @Override


### PR DESCRIPTION

<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes ISSUE #<XXX>`.)
-->

Fixes ISSUE #902.

### Motivation

Remove unused interface in eventstore connector producer

### Modifications

Delete these two unused methods:
- SendResult publish(final CloudEvent cloudEvent)
- void sendAsync(final CloudEvent cloudEvent, final SendCallback sendCallback)

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation

Close #902 