### PR TITLE
#3007 [Enhancement] Method manually handles closing an auto-closeable resource [GrpcClientHandler]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/GrpcClientHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/GrpcClientHandler.java
@@ -76,8 +76,7 @@ public class GrpcClientHandler extends AbstractHttpHandler {
      * DELETE /client/grpc
      */
     void delete(HttpExchange httpExchange) throws IOException {
-        OutputStream out = httpExchange.getResponseBody();
-        try {
+        try (OutputStream out = httpExchange.getResponseBody()) {
             String request = HttpExchangeUtils.streamToString(httpExchange.getRequestBody());
             DeleteGrpcClientRequest deleteGrpcClientRequest = JsonUtils.parseObject(request, DeleteGrpcClientRequest.class);
             String url = deleteGrpcClientRequest.getUrl();
@@ -105,14 +104,6 @@ public class GrpcClientHandler extends AbstractHttpHandler {
             String result = JsonUtils.toJSONString(error);
             httpExchange.sendResponseHeaders(500, result.getBytes().length);
             out.write(result.getBytes());
-        } finally {
-            if (out != null) {
-                try {
-                    out.close();
-                } catch (IOException e) {
-                    log.warn("out close failed...", e);
-                }
-            }
         }
     }
 


### PR DESCRIPTION
Fixes #3007  .

### Modifications

Used try-with-resources to manage resources.

### Documentation

- Does this pull request introduce a new feature? **(no)**
- If yes, how is the feature documented? **(not applicable)**
- If a feature is not applicable for documentation, explain why? **(bug fix)**
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation **(not applicable)**
