### PR TITLE
[ISSUE #3160] fix needlessly boxes a boolean constant

### DIFF
--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/admin/handler/QueryRecommendEventMeshHandlerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/admin/handler/QueryRecommendEventMeshHandlerTest.java
@@ -79,7 +79,7 @@ public class QueryRecommendEventMeshHandlerTest {
         outputStream = new ByteArrayOutputStream();
         when(httpExchange.getResponseBody()).thenReturn(outputStream);
         try (MockedStatic<StringUtils> dummyStatic = mockStatic(StringUtils.class)) {
-            dummyStatic.when(() -> StringUtils.isBlank(any())).thenReturn(true);
+            dummyStatic.when(() -> StringUtils.isBlank(any())).thenReturn(Boolean.TRUE);
             handler.handle(httpExchange);
             String response = outputStream.toString();
             Assert.assertEquals("params illegal!", response);


### PR DESCRIPTION


Fixes #<3160>.

### Motivation

Method needlessly boxes a boolean constant



### Modifications

*replace it with Boolean.TRUE *



### Documentation

- Does this pull request introduce a new feature?  no

