### PR TITLE
[ISSUE ##3555] Bump nacos client version from 2.1.0 to 2.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -503,7 +503,7 @@ subprojects {
             dependency "org.yaml:snakeyaml:1.30"
             dependency "org.javassist:javassist:3.24.0-GA"
 
-            dependency "com.alibaba.nacos:nacos-client:2.1.0"
+            dependency "com.alibaba.nacos:nacos-client:2.2.1"
 
             dependency 'org.apache.zookeeper:zookeeper:3.4.6'
             dependency 'org.apache.curator:curator-client:4.0.1'

--- a/tools/dependency-check/known-dependencies.txt
+++ b/tools/dependency-check/known-dependencies.txt
@@ -107,9 +107,9 @@ metrics-annotation-4.1.0.jar
 metrics-core-4.1.0.jar
 metrics-healthchecks-4.1.0.jar
 metrics-json-4.1.0.jar
-nacos-auth-plugin-2.1.0.jar
-nacos-client-2.1.0.jar
-nacos-encryption-plugin-2.1.0.jar
+nacos-auth-plugin-2.2.1.jar
+nacos-client-2.2.1.jar
+nacos-encryption-plugin-2.2.1.jar
 netty-3.7.0.Final.jar
 netty-3.10.6.Final.jar
 netty-all-4.1.79.Final.jar

--- a/tools/dependency-check/known-dependencies.txt
+++ b/tools/dependency-check/known-dependencies.txt
@@ -8,6 +8,8 @@ asm-commons-9.2.jar
 asm-tree-9.2.jar
 asm-util-9.2.jar
 assertj-core-2.6.0.jar
+async-http-client-2.12.0.jar
+async-http-client-netty-utils-2.12.0.jar
 bcpkix-jdk15on-1.69.jar
 bcprov-ext-jdk15on-1.69.jar
 bcprov-ext-jdk15on-1.70.jar
@@ -25,6 +27,7 @@ cloudevents-kafka-2.2.1.jar
 commons-beanutils-1.9.4.jar
 commons-cli-1.2.jar
 commons-codec-1.11.jar
+commons-codec-1.15.jar
 commons-collections-3.2.2.jar
 commons-collections4-4.1.jar
 commons-digester-2.1.jar
@@ -129,6 +132,7 @@ netty-codec-xml-4.1.79.Final.jar
 netty-common-4.1.79.Final.jar
 netty-handler-4.1.79.Final.jar
 netty-handler-proxy-4.1.79.Final.jar
+netty-reactive-streams-2.0.4.jar
 netty-resolver-4.1.79.Final.jar
 netty-resolver-dns-4.1.79.Final.jar
 netty-resolver-dns-classes-macos-4.1.79.Final.jar
@@ -184,6 +188,7 @@ protobuf-java-3.19.2.jar
 protobuf-java-3.19.4.jar
 protobuf-java-3.21.5.jar
 protobuf-java-util-3.17.2.jar
+protobuf-java-util-3.21.5.jar
 protobuf-java-util-3.5.1.jar
 proto-google-common-protos-2.0.1.jar
 pulsar-client-2.10.1.jar


### PR DESCRIPTION
### Motivation
Bump nacos client version from 2.1.0 to 2.2.1. That's a regular update.
