### PR TITLE
Fixed issue with 'Objects.requireNonNull()' where getData() can return null

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendAsyncEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendAsyncEventProcessor.java
@@ -212,7 +212,7 @@ public class SendAsyncEventProcessor implements AsyncHttpProcessor {
             return;
         }
 
-        final String content = new String(event.getData().toBytes(), StandardCharsets.UTF_8);
+        final String content = new String(Objects.requireNonNull(event.getData().toBytes()), StandardCharsets.UTF_8);
         if (Objects.requireNonNull(content).length() > eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshEventSize()) {
             if (log.isErrorEnabled()) {
                 log.error("Event size exceeds the limit: {}",

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendAsyncEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendAsyncEventProcessor.java
@@ -212,7 +212,7 @@ public class SendAsyncEventProcessor implements AsyncHttpProcessor {
             return;
         }
 
-        final String content = new String(Objects.requireNonNull(event.getData().toBytes()), StandardCharsets.UTF_8);
+        final String content = new String(Objects.requireNonNull(event.getData()).toBytes(), StandardCharsets.UTF_8);
         if (Objects.requireNonNull(content).length() > eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshEventSize()) {
             if (log.isErrorEnabled()) {
                 log.error("Event size exceeds the limit: {}",


### PR DESCRIPTION
Fixes #3410.

### Motivation

The issue was that the getData() method in SendAsyncEventProcessor could return null, which could cause a NullPointerException to be thrown. 
To prevent this, the suggested solution is to use Objects.requireNonNull().



### Modifications

The modification made to the code was to add a call to Objects.requireNonNull() around the getData() method call in SendAsyncEventProcessor. This ensures that if getData() returns null, a NullPointerException will be thrown immediately, making it easier to locate and fix the issue.



### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (n/a)
- If a feature is not applicable for documentation, explain why? (n/a)
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation (n/a)
