### PR TITLE
[ISSUE #3483]Replace this call to "replaceAll()" by a call to the "replace()" method.[PushConsumerImpl]

### DIFF
--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/main/java/org/apache/eventmesh/storage/rocketmq/consumer/PushConsumerImpl.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/main/java/org/apache/eventmesh/storage/rocketmq/consumer/PushConsumerImpl.java
@@ -186,7 +186,7 @@ public class PushConsumerImpl {
             for (String sysPropKey : MessageConst.STRING_HASH_SET) {
                 if (StringUtils.isNotEmpty(msg.getProperty(sysPropKey))) {
                     String prop = msg.getProperty(sysPropKey);
-                    sysPropKey = sysPropKey.toLowerCase().replaceAll("_", Constants.MESSAGE_PROP_SEPARATOR);
+                    sysPropKey = sysPropKey.toLowerCase().replace("_", Constants.MESSAGE_PROP_SEPARATOR);
                     cloudEventBuilder = CloudEventBuilder.from(cloudEvent).withExtension(sysPropKey, prop);
                 }
             }
@@ -257,7 +257,7 @@ public class PushConsumerImpl {
             for (String sysPropKey : MessageConst.STRING_HASH_SET) {
                 if (StringUtils.isNotEmpty(msg.getProperty(sysPropKey))) {
                     String prop = msg.getProperty(sysPropKey);
-                    sysPropKey = sysPropKey.toLowerCase().replaceAll("_", Constants.MESSAGE_PROP_SEPARATOR);
+                    sysPropKey = sysPropKey.toLowerCase().replace("_", Constants.MESSAGE_PROP_SEPARATOR);
                     cloudEventBuilder = CloudEventBuilder.from(cloudEvent).withExtension(sysPropKey, prop);
                 }
             }


### PR DESCRIPTION
Fixes #3483 

### Motivation

When String::replaceAll is used, the first argument should be a real regular expression. If it’s not the case, String::replace does exactly the same thing as String::replaceAll without the performance drawback of the regex.

### Modifications

Replaced "replaceAll()" with "replace()"

### Documentation

- Does this pull request introduce a new feature? (yes / no)
 No
