### PR TITLE
[ISSUES #3482]Replace this call to "replaceAll()" by a call to the "replace()" method.[ProducerImpl]

### DIFF
--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/main/java/org/apache/eventmesh/storage/rocketmq/producer/ProducerImpl.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/main/java/org/apache/eventmesh/storage/rocketmq/producer/ProducerImpl.java
@@ -146,7 +146,7 @@ public class ProducerImpl extends AbstractProducer {
 
     private Message supplySysProp(Message msg, CloudEvent cloudEvent) {
         for (String sysPropKey : MessageConst.STRING_HASH_SET) {
-            String ceKey = sysPropKey.toLowerCase().replaceAll("_", Constants.MESSAGE_PROP_SEPARATOR);
+            String ceKey = sysPropKey.toLowerCase().replace("_", Constants.MESSAGE_PROP_SEPARATOR);
             if (cloudEvent.getExtension(ceKey) != null && StringUtils.isNotEmpty(Objects.requireNonNull(cloudEvent.getExtension(ceKey)).toString())) {
                 MessageAccessor.putProperty(msg, sysPropKey, Objects.requireNonNull(cloudEvent.getExtension(ceKey)).toString());
                 msg.getProperties().remove(ceKey);
@@ -163,7 +163,7 @@ public class ProducerImpl extends AbstractProducer {
                 for (String sysPropKey : MessageConst.STRING_HASH_SET) {
                     if (StringUtils.isNotEmpty(message.getProperty(sysPropKey))) {
                         String prop = message.getProperty(sysPropKey);
-                        String tmpPropKey = sysPropKey.toLowerCase().replaceAll("_", Constants.MESSAGE_PROP_SEPARATOR);
+                        String tmpPropKey = sysPropKey.toLowerCase().replace("_", Constants.MESSAGE_PROP_SEPARATOR);
                         MessageAccessor.putProperty(message, tmpPropKey, prop);
                         message.getProperties().remove(sysPropKey);
                     }


### PR DESCRIPTION
Fixes #3482 

### Motivation

When String::replaceAll is used, the first argument should be a real regular expression. If it’s not the case, String::replace does exactly the same thing as String::replaceAll without the performance drawback of the regex.

### Modifications

Replaced "replaceAll()" to "replace()"

### Documentation

- Does this pull request introduce a new feature? (yes / no)
 No
 
