### PR TITLE
[ISSUE #3464]Replace this call to "replaceAll()" by a call to the "replace()" method.[EventMeshVersion]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/constants/EventMeshVersion.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/constants/EventMeshVersion.java
@@ -22,9 +22,9 @@ public class EventMeshVersion {
     public static final String CURRENT_VERSION = Version.V3_0_0.name();
 
     public static String getCurrentVersionDesc() {
-        return CURRENT_VERSION.replaceAll("V", "")
-            .replaceAll("_", ".")
-            .replaceAll("_SNAPSHOT", "-SNAPSHOT");
+        return CURRENT_VERSION.replace("V", "")
+            .replace("_", ".")
+            .replace("_SNAPSHOT", "-SNAPSHOT");
     }
 
     public enum Version {


### PR DESCRIPTION
Fixes #3464 

### Motivation

When String::replaceAll is used, the first argument should be a real regular expression. If it’s not the case, String::replace does exactly the same thing as String::replaceAll without the performance drawback of the regex.

### Modifications

Replaced "replaceAll()" with "replace()"


### Documentation

- Does this pull request introduce a new feature? (yes / no)
 No
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
 Not Applicable
