### PR TITLE
[ISSUE #3503]Replace this call to "replaceAll()" by a call to the "replace()" method.[PravegaClient]

### DIFF
--- a/eventmesh-storage-plugin/eventmesh-storage-pravega/src/main/java/org/apache/eventmesh/storage/pravega/client/PravegaClient.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-pravega/src/main/java/org/apache/eventmesh/storage/pravega/client/PravegaClient.java
@@ -188,7 +188,7 @@ public class PravegaClient {
     }
 
     private String buildReaderId(String instanceName) {
-        return String.format("%s-reader", instanceName).replaceAll("\\(", "-").replaceAll("\\)", "-");
+        return String.format("%s-reader", instanceName).replace("\\(", "-").replace("\\)", "-");
     }
 
     private void createReaderGroup(String topic, String readerGroupName) {


### PR DESCRIPTION
Fixes #3503 

### Motivation

When String::replaceAll is used, the first argument should be a real regular expression. If it’s not the case, String::replace does exactly the same thing as String::replaceAll without the performance drawback of the regex.


### Modifications

Replaced "replaceAll()" with "replace()" at line 191



### Documentation

- Does this pull request introduce a new feature? (yes / no)
 No
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
 Not Applicable