### PR TITLE
[ISSUE #3159] Found reliance on default encoding [RedirectClientByPathHandlerTest]

### DIFF
--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/admin/handler/RedirectClientByPathHandlerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/admin/handler/RedirectClientByPathHandlerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+import org.apache.eventmesh.common.Constants;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
 import org.apache.eventmesh.common.utils.NetUtils;
 import org.apache.eventmesh.runtime.admin.controller.HttpHandlerManager;
@@ -124,7 +125,7 @@ public class RedirectClientByPathHandlerTest {
                 clientMockedStatic.when(() -> EventMeshTcp2Client.redirectClient2NewEventMesh(any(), anyString(), anyInt(), any(),
                     any())).thenThrow(new RuntimeException());
                 redirectClientByPathHandler.handle(mockExchange);
-                String response = outputStream.toString();
+                String response = outputStream.toString(Constants.DEFAULT_CHARSET.name());
                 Assert.assertTrue(response.startsWith("redirectClientByPath fail!"));
             }
         }


### PR DESCRIPTION
Fixes #3159

### Motivation

Found a call to a method which will perform a byte to String (or String to byte) conversion, and will assume that the default platform encoding is suitable. This will cause the application behaviour to vary between platforms.
Above issue is the reason why this change is introduced.
Issue #3159

### Modifications

Modified response variable of RedirectClientByPathHandlerTest class present in Line 127
Earlier value of response variable used to be outputStream.toString()
New value of response variable is outputStream.toString(Constants.DEFAULT_CHARSET.name());



### Documentation

- Does this pull request introduce a new feature?
- Ans: no
- If a feature is not applicable for documentation, explain why?
- Ans: Modified a variable in RedirectClientByPathHandlerTest class.