### PR TITLE
[ISSUE #3416] Used another way to initialize localClients instance [HttpClientGroupMapping]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/HttpClientGroupMapping.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/HttpClientGroupMapping.java
@@ -388,11 +388,13 @@ public final class HttpClientGroupMapping {
             client.setUrl(url);
             client.setLastUpTime(new Date());
             final String groupTopicKey = client.getConsumerGroup() + "@" + client.getTopic();
-            List<Client> localClients = localClientInfoMapping.computeIfAbsent(groupTopicKey, key -> new ArrayList<Client>() {
+            List<Client> localClients = localClientInfoMapping.computeIfAbsent(groupTopicKey, key -> Collections.unmodifiableList(new ArrayList<Client>() {
+                private static final long serialVersionUID = -529919988844134656L;
+
                 {
                     add(client);
                 }
-            });
+            }));
             localClients.stream().filter(o -> StringUtils.equals(o.getUrl(), client.getUrl())).findFirst()
                 .ifPresent(o -> o.setLastUpTime(client.getLastUpTime()));
         }
@@ -446,11 +448,13 @@ public final class HttpClientGroupMapping {
             client.setUrl(url);
             client.setLastUpTime(new Date());
             final String groupTopicKey = client.getConsumerGroup() + "@" + client.getTopic();
-            List<Client> localClients = localClientInfoMapping.computeIfAbsent(groupTopicKey, key -> new ArrayList<Client>() {
+            List<Client> localClients = localClientInfoMapping.computeIfAbsent(groupTopicKey, key -> Collections.unmodifiableList(new ArrayList<Client>() {
+                private static final long serialVersionUID = -529919988844134656L;
+
                 {
                     add(client);
                 }
-            });
+            }));
             localClients.stream().filter(o -> StringUtils.equals(o.getUrl(), client.getUrl())).findFirst()
                 .ifPresent(o -> o.setLastUpTime(client.getLastUpTime()));
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/HttpClientGroupMapping.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/HttpClientGroupMapping.java
@@ -388,12 +388,13 @@ public final class HttpClientGroupMapping {
             client.setUrl(url);
             client.setLastUpTime(new Date());
             final String groupTopicKey = client.getConsumerGroup() + "@" + client.getTopic();
-            List<Client> localClients = localClientInfoMapping.computeIfAbsent(groupTopicKey, key -> Collections.unmodifiableList(new ArrayList<Client>() {
-                private static final long serialVersionUID = -529919988844134656L;
+            List<Client> localClients = localClientInfoMapping.computeIfAbsent(groupTopicKey, 
+                key -> Collections.unmodifiableList(new ArrayList<Client>() {
+                    private static final long serialVersionUID = -529919988844134656L;
 
-                {
-                    add(client);
-                }
+                    {
+                        add(client);
+                    }
             }));
             localClients.stream().filter(o -> StringUtils.equals(o.getUrl(), client.getUrl())).findFirst()
                 .ifPresent(o -> o.setLastUpTime(client.getLastUpTime()));
@@ -448,12 +449,13 @@ public final class HttpClientGroupMapping {
             client.setUrl(url);
             client.setLastUpTime(new Date());
             final String groupTopicKey = client.getConsumerGroup() + "@" + client.getTopic();
-            List<Client> localClients = localClientInfoMapping.computeIfAbsent(groupTopicKey, key -> Collections.unmodifiableList(new ArrayList<Client>() {
-                private static final long serialVersionUID = -529919988844134656L;
+            List<Client> localClients = localClientInfoMapping.computeIfAbsent(groupTopicKey, 
+                key -> Collections.unmodifiableList(new ArrayList<Client>() {
+                    private static final long serialVersionUID = -529919988844134656L;
 
-                {
-                    add(client);
-                }
+                    {
+                        add(client);
+                    }
             }));
             localClients.stream().filter(o -> StringUtils.equals(o.getUrl(), client.getUrl())).findFirst()
                 .ifPresent(o -> o.setLastUpTime(client.getLastUpTime()));


### PR DESCRIPTION
Fixes #3416

### Motivation

*Because Double Brace Initialization (DBI) creates an anonymous class with a reference to the instance of the owning object, its use can lead to memory leaks if the anonymous inner class is returned and held by other objects. Even when there’s no leak, DBI is so obscure that it’s bound to confuse most maintainers.*
*Fixes the above mentioned issue.*
Issue #3416

### Modifications

*Modified the initialization of localClients instance on line 391,451.*

### Documentation

- Does this pull request introduce a new feature?
- Ans: no
- If a feature is not applicable for documentation, explain why?
- Ans: Only changed the method of initialization of an instance.
