### PR TITLE
[ISSUE #2975] removed String.format()

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/metrics/MonitorMetricConstants.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/metrics/MonitorMetricConstants.java
@@ -19,9 +19,9 @@ package org.apache.eventmesh.runtime.metrics;
 
 public class MonitorMetricConstants {
 
-    public static final String EVENTMESH_MONITOR_FORMAT_COMMON = "{\"protocol\":\"%s\",\"s\":\"%s\",\"t\":\"%s\"}";
+    public static final String EVENTMESH_MONITOR_FORMAT_COMMON = "{\"protocol\":\"{}\",\"s\":\"{}\",\"t\":\"{}\"}";
 
-    public static final String EVENTMESH_TCP_MONITOR_FORMAT_THREADPOOL = "{\"threadPoolName\":\"%s\",\"s\":\"%s\",\"t\":\"%s\"}";
+    public static final String EVENTMESH_TCP_MONITOR_FORMAT_THREADPOOL = "{\"threadPoolName\":\"{}\",\"s\":\"{}\",\"t\":\"{}\"}";
 
     public static final String CLIENT_2_EVENTMESH_TPS = "client2eventMeshTPS";
     public static final String EVENTMESH_2_MQ_TPS = "eventMesh2mqTPS";

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/metrics/tcp/EventMeshTcpMonitor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/metrics/tcp/EventMeshTcpMonitor.java
@@ -133,11 +133,11 @@ public class EventMeshTcpMonitor {
 
             //monitor retry queue size
             tcpSummaryMetrics.setRetrySize(eventMeshTCPServer.getEventMeshTcpRetryer().getRetrySize());
-            appLogger.info(String.format(
+            appLogger.info(
                 MonitorMetricConstants.EVENTMESH_MONITOR_FORMAT_COMMON,
                 EventMeshConstants.PROTOCOL_TCP,
                 MonitorMetricConstants.RETRY_QUEUE_SIZE,
-                tcpSummaryMetrics.getRetrySize()));
+                tcpSummaryMetrics.getRetrySize());
 
         }, 10, PRINT_THREADPOOLSTATE_INTERVAL, TimeUnit.SECONDS);
         log.info("EventMeshTcpMonitor started......");


### PR DESCRIPTION
Modified two constants in MonitorMetricConstants (EVENTMESH_MONITOR_FORMAT_COMMON, EVENTMESH_TCP_MONITOR_FORMAT_THREADPOOL) to work without using String.format()

<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
-->

Fixes #2975

### Motivation

removed String.format() and modified the format constants to use {} instead of %s.
using {} doesn't require us to use String.format() and is also supported by the logger.


### Modifications

removed use of String.format()
modified format constants EVENTMESH_TCP_MONITOR_FORMAT_THREADPOOL, EVENTMESH_MONITOR_FORMAT_COMMON



### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
- If a feature is not applicable for documentation, explain why? (it is a simple fix for an issue where we wanted to get rid of using String.format() as it is not required by logger)
