### PR TITLE
[ISSUE #3826]'assertTrue()' can be simplified to 'assertEquals()'

### DIFF
--- a/eventmesh-storage-plugin/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/broker/MessageQueueTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/broker/MessageQueueTest.java
@@ -103,12 +103,12 @@ public class MessageQueueTest {
     public void testGetTakeIndex() throws InterruptedException {
         MessageEntity takeIndexMessageEntity = messageQueue.take();
         Assert.assertNotNull(takeIndexMessageEntity);
-        Assert.assertTrue(messageQueue.getTakeIndex() == 1);
+        Assert.assertEquals(messageQueue.getTakeIndex() == 1);
     }
 
     @Test
     public void testGetPutIndex() {
-        Assert.assertTrue(messageQueue.getPutIndex() == 1);
+        Assert.assertEquals(messageQueue.getPutIndex() == 1);
     }
 
     private void initMessageQueue() throws InterruptedException {


### PR DESCRIPTION
Fixes #3826 

### Modifications

Replaced `assertTrue()` with `assertEquals()` at lines 106,111

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
