### PR TITLE
[ISSUE #3870]Specifying the initial capacity of Map can save resources

### DIFF
--- a/eventmesh-storage-plugin/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/TestUtils.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/TestUtils.java
@@ -39,14 +39,14 @@ public class TestUtils {
     public static final boolean TOPIC_DO_NOT_EXISTS = false;
 
     public static ConcurrentHashMap<TopicMetadata, MessageQueue> createDefaultMessageContainer() {
-        ConcurrentHashMap<TopicMetadata, MessageQueue> messageContainer = new ConcurrentHashMap<>();
+        ConcurrentHashMap<TopicMetadata, MessageQueue> messageContainer = new ConcurrentHashMap<>(1);
         messageContainer.put(new TopicMetadata(TEST_TOPIC), new MessageQueue());
         return messageContainer;
     }
 
     public static ConcurrentHashMap<TopicMetadata, MessageQueue> createMessageContainer(TopicMetadata topicMetadata, MessageEntity messageEntity)
         throws InterruptedException {
-        ConcurrentHashMap<TopicMetadata, MessageQueue> messageContainer = new ConcurrentHashMap<>();
+        ConcurrentHashMap<TopicMetadata, MessageQueue> messageContainer = new ConcurrentHashMap<>(1);
         MessageQueue messageQueue = new MessageQueue();
         messageQueue.put(messageEntity);
         messageContainer.put(topicMetadata, messageQueue);


### PR DESCRIPTION
Fixes #3870.

### Motivation

When we can estimate the size of Map, specifying the initialization size is better.



### Modifications

Specify the initialization size.



### Documentation

- Does this pull request introduce a new feature? no
