### PR TITLE
[ISSUE #3874]Add a load balance strategy: source ip hash

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/loadbalance/LoadBalanceSelector.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/loadbalance/LoadBalanceSelector.java
@@ -21,7 +21,9 @@ package org.apache.eventmesh.common.loadbalance;
  * LoadBalance Interface
  *
  * <p> see {@link RandomLoadBalanceSelector}
+ * <p> see {@link WeightRandomLoadBalanceSelector}
  * <p> see {@link WeightRoundRobinLoadBalanceSelector}
+ * <p> see {@link SourceIPHashLoadBalanceSelector}
  *
  * @param <T> Target type
  */

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/loadbalance/LoadBalanceType.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/loadbalance/LoadBalanceType.java
@@ -22,7 +22,8 @@ package org.apache.eventmesh.common.loadbalance;
 public enum LoadBalanceType {
     RANDOM(0, "random load balance strategy"),
     WEIGHT_ROUND_ROBIN(1, "weight round robin load balance strategy"),
-    WEIGHT_RANDOM(2, "weight random load balance strategy");
+    WEIGHT_RANDOM(2, "weight random load balance strategy"),
+    SOURCE_IP_HASH(3, "source IP hash load balance strategy");
 
     private final int code;
     private final String desc;

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/loadbalance/SourceIPHashLoadBalanceSelector.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/loadbalance/SourceIPHashLoadBalanceSelector.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.common.loadbalance;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Collections;
+import java.util.List;
+
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Source IP Hash LoadBalance: make the same client always accessing the same server.
+ *
+ * @param <T> Target type
+ */
+@Slf4j
+public class SourceIPHashLoadBalanceSelector<T> implements LoadBalanceSelector<T> {
+
+    private final transient List<T> servers;
+
+    private String clientKey;
+
+    public SourceIPHashLoadBalanceSelector(List<T> servers, String clientKey) {
+        this.servers = servers;
+        this.clientKey = clientKey;
+    }
+
+    @Override
+    public T select() {
+        // Avoid servers being changed during select().
+        List<T> targets = Collections.unmodifiableList(servers);
+        if (StringUtils.isBlank(clientKey)) {
+            clientKey = "127.0.0.1";
+            log.warn("Blank client IP has been set default {}", clientKey);
+        }
+        int hashCode = hash(clientKey);
+        int index = hashCode % targets.size();
+        return targets.get(index);
+    }
+
+    @Override
+    public LoadBalanceType getType() {
+        return LoadBalanceType.SOURCE_IP_HASH;
+    }
+
+    /**
+     * FNV hash algorithm that is suitable for hashing some similar strings, like IP.
+     * @return
+     */
+    private int hash(String data) {
+        final int p = 16777619;
+        int hash = (int) 2166136261L;
+        for (int i = 0; i < data.length(); i++) {
+            hash = (hash ^ data.charAt(i)) * p;
+        }
+        hash += hash << 13;
+        hash ^= hash >> 7;
+        hash += hash << 3;
+        hash ^= hash >> 17;
+        hash += hash << 5;
+        if (hash < 0) {
+            hash = Math.abs(hash);
+        }
+        return hash;
+    }
+}

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/CommonStringUtils.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/CommonStringUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.common.utils;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A string utils as supplement of org.apache.commons.lang3.StringUtils
+ */
+public class CommonStringUtils extends StringUtils {
+
+    /**
+     * Compares given string to a CharSequences vararg of searchStrings,
+     * returning true if the string is equal to all of the searchStrings.
+     *
+     * CommonStringUtils.equalsAll("abc", "abc", "def")  = false
+     * CommonStringUtils.equalsAll(null, "abc", "def")  = false
+     * CommonStringUtils.equalsAll(null, (CharSequence[]) null) = true
+     * CommonStringUtils.equalsAll(null, null, null)    = true
+     * CommonStringUtils.equalsAll("abc", "abc", "abc")  = true
+     *
+     * @param string
+     * @param searchStrings
+     * @return
+     */
+    public static boolean equalsAll(final CharSequence string, final CharSequence... searchStrings) {
+        if (ArrayUtils.isNotEmpty(searchStrings)) {
+            for (final CharSequence next : searchStrings) {
+                if (!equals(string, next)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/loadbalance/SourceIPHashLoadBalanceSelectorTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/loadbalance/SourceIPHashLoadBalanceSelectorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.common.loadbalance;
+
+import org.apache.eventmesh.common.utils.CommonStringUtils;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SourceIPHashLoadBalanceSelectorTest {
+
+    private SourceIPHashLoadBalanceSelector<String> loadBalanceSelector;
+
+    private List<String> servers;
+
+    private String client1Key;
+
+    private String client2Key;
+
+    @Before
+    public void init() {
+        servers = Arrays.asList(new String[]{
+            "192.168.1.10", "192.168.1.11",
+            "192.168.1.12", "192.168.1.13",
+            "192.168.1.14", "192.168.1.15"
+        });
+        client1Key = "192.168.1.1-1-tester1-TLSv1.2";
+        client2Key = "192.168.1.2-1-tester2-TLSv1.2";
+        loadBalanceSelector = new SourceIPHashLoadBalanceSelector<>(servers, client1Key);
+    }
+
+    @Test
+    public void testSelect() {
+        String target1 = loadBalanceSelector.select();
+        String target2 = loadBalanceSelector.select();
+        String target3 = loadBalanceSelector.select();
+        Assert.assertTrue(CommonStringUtils.equalsAll(target1, target2, target3));
+
+        loadBalanceSelector = new SourceIPHashLoadBalanceSelector<>(servers, client2Key);
+        String target4 = loadBalanceSelector.select();
+        Assert.assertFalse(StringUtils.equals(target1, target4));
+    }
+
+    @Test
+    public void testType() {
+        Assert.assertEquals(LoadBalanceType.SOURCE_IP_HASH, loadBalanceSelector.getType());
+    }
+}


### PR DESCRIPTION
Fixes #3874.

### Motivation

Add a load balance strategy: source ip hash. Make the same client machine always arrive at the same server.



### Modifications

Add a new LoadBalanceSelector for implementing source ip hash algorithm.
Add unit test for new LoadBalanceSelector.



### Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? JavaDocs
