### PR TITLE
[ISSUE #3926]checkStyle.xml can not check the file header

### DIFF
--- a/eventmesh-runtime/conf/server.env
+++ b/eventmesh-runtime/conf/server.env
@@ -1,18 +1,17 @@
 #
-# Licensed to Apache Software Foundation (ASF) under one or more contributor
-# license agreements. See the NOTICE file distributed with
-# this work for additional information regarding copyright
-# ownership. Apache Software Foundation (ASF) licenses this file to you under
-# the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 APP_START_JVM_OPTION:::-server -Xms128M -Xmx256M -Xmn128m -XX:SurvivorRatio=4 -Duser.language=zh

--- a/style/checkStyle.xml
+++ b/style/checkStyle.xml
@@ -24,7 +24,7 @@
 
   <property name="charset" value="UTF-8"/>
   <property name="severity" value="warning"/>
-  <property name="fileExtensions" value="java, properties, xml, gradle"/>
+  <property name="fileExtensions" value="java, properties, xml, gradle, env, sh"/>
   <module name="SuppressWarningsFilter" />
   <module name="Header">
     <property name="headerFile" value="/checkstyle-header1.txt"/>
@@ -32,7 +32,11 @@
   </module>
   <module name="Header">
     <property name="headerFile" value="/checkstyle-header2.txt"/>
-    <property name="fileExtensions" value="properties"/>
+    <property name="fileExtensions" value="properties, env"/>
+  </module>
+  <module name="Header">
+    <property name="headerFile" value="/checkstyle-header3.txt"/>
+    <property name="fileExtensions" value="sh"/>
   </module>
   <module name="RegexpSingleline">
     <property name="format" value="System\..+\.println"/>

--- a/style/checkStyle.xml
+++ b/style/checkStyle.xml
@@ -26,6 +26,14 @@
   <property name="severity" value="warning"/>
   <property name="fileExtensions" value="java, properties, xml, gradle"/>
   <module name="SuppressWarningsFilter" />
+  <module name="Header">
+    <property name="headerFile" value="/checkstyle-header1.txt"/>
+    <property name="fileExtensions" value="java, gradle"/>
+  </module>
+  <module name="Header">
+    <property name="headerFile" value="/checkstyle-header2.txt"/>
+    <property name="fileExtensions" value="properties"/>
+  </module>
   <module name="RegexpSingleline">
     <property name="format" value="System\..+\.println"/>
     <property name="message" value="Prohibit invoking System.*.println in source code !"/>

--- a/style/checkstyle-header1.txt
+++ b/style/checkstyle-header1.txt
@@ -1,0 +1,16 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/style/checkstyle-header2.txt
+++ b/style/checkstyle-header2.txt
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/style/checkstyle-header2.txt
+++ b/style/checkstyle-header2.txt
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/style/checkstyle-header3.txt
+++ b/style/checkstyle-header3.txt
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.


### PR DESCRIPTION
Fixes #3926.

### Motivation

checkStyle.xml can not check the file header.



### Modifications

Enable checkstyle.xml to check the file header.



### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
