### PR TITLE
[ISSUE #3946]Add unit test method or class for classes: NetUtils, TopicResponse 

### DIFF
--- a/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/response/TopicResponseTest.java
+++ b/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/response/TopicResponseTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.admin.rocketmq.response;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class TopicResponseTest {
+
+    @Test
+    public void testTopicResponse() {
+        String topic = "testtopic";
+        String createdTime = "2023-05-17 10:30:00";
+        TopicResponse topicResponse = new TopicResponse(topic, createdTime);
+
+        assertEquals(topic, topicResponse.getTopic());
+        assertEquals(createdTime, topicResponse.getCreatedTime());
+    }
+
+    @Test
+    public void testTopicResponseSerialization() throws Exception {
+        String topic = "testtopic";
+        String createdTime = "2023-05-17 10:30:00";
+        TopicResponse topicResponse = new TopicResponse(topic, createdTime);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String json = objectMapper.writeValueAsString(topicResponse);
+
+        assertTrue(json.contains("topic"));
+        assertTrue(json.contains("created_time"));
+
+        TopicResponse deserializedResponse = objectMapper.readValue(json, TopicResponse.class);
+
+        assertEquals(topic, deserializedResponse.getTopic());
+        assertEquals(createdTime, deserializedResponse.getCreatedTime());
+    }
+}

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/JsonUtilsTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/JsonUtilsTest.java
@@ -23,8 +23,6 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import org.assertj.core.util.Maps;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -78,25 +76,6 @@ public class JsonUtilsTest {
         JsonNode jsonNode = JsonUtils.getJsonNode(json);
         Assert.assertNotNull(jsonNode);
         Assert.assertEquals("2", jsonNode.findValue("mxsm").asText());
-    }
-
-    @Test
-    public void testParseTypeReferenceObject() throws JsonProcessingException {
-        String jsonString = "{\"key\":\"value\"}";
-        TypeReference<Map<String, String>> typeReference = new TypeReference<Map<String, String>>() {};
-        Map<String, String> expected = Maps.newHashMap("key", "value");
-        Map<String, String> actual = JsonUtils.parseTypeReferenceObject(jsonString, typeReference);
-
-        Assert.assertEquals(expected, actual);
-    }
-
-    @Test
-    public void testParseTypeReferenceObjectWithEmptyText() throws JsonProcessingException {
-        String jsonString = "";
-        TypeReference<Map<String, String>> typeReference = new TypeReference<Map<String, String>>() {};
-        Map<String, String> actual = JsonUtils.parseTypeReferenceObject(jsonString, typeReference);
-
-        Assert.assertEquals(null, actual);
     }
 
     @Data

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/JsonUtilsTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/JsonUtilsTest.java
@@ -23,6 +23,8 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.assertj.core.util.Maps;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -76,6 +78,25 @@ public class JsonUtilsTest {
         JsonNode jsonNode = JsonUtils.getJsonNode(json);
         Assert.assertNotNull(jsonNode);
         Assert.assertEquals("2", jsonNode.findValue("mxsm").asText());
+    }
+
+    @Test
+    public void testParseTypeReferenceObject() throws JsonProcessingException {
+        String jsonString = "{\"key\":\"value\"}";
+        TypeReference<Map<String, String>> typeReference = new TypeReference<Map<String, String>>() {};
+        Map<String, String> expected = Maps.newHashMap("key", "value");
+        Map<String, String> actual = JsonUtils.parseTypeReferenceObject(jsonString, typeReference);
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testParseTypeReferenceObjectWithEmptyText() throws JsonProcessingException {
+        String jsonString = "";
+        TypeReference<Map<String, String>> typeReference = new TypeReference<Map<String, String>>() {};
+        Map<String, String> actual = JsonUtils.parseTypeReferenceObject(jsonString, typeReference);
+
+        Assert.assertEquals(null, actual);
     }
 
     @Data

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/NetUtilsTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/NetUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.eventmesh.common.utils;
 import org.apache.eventmesh.common.enums.HttpMethod;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -69,5 +70,13 @@ public class NetUtilsTest {
         String actual = NetUtils.parsePostBody(exchange);
         Assert.assertEquals(expected, actual);
 
+    }
+
+    @Test
+    public void testSendSuccessResponseHeaders() throws IOException {
+        HttpExchange exchange = Mockito.mock(HttpExchange.class);
+        NetUtils.sendSuccessResponseHeaders(exchange);
+        Mockito.verify(exchange, Mockito.times(1))
+                .sendResponseHeaders(Mockito.anyInt(), Mockito.anyLong());
     }
 }


### PR DESCRIPTION
Fixes #3946.

### Motivation

Import code coverage of NetUtils, TopicResponse.



### Modifications

Add test methods of `NetUtils#sendSuccessResponseHeaders()`.

Add test class for `TopicResponse`.



### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
