### PR TITLE
[ISSUE #3900] Removed Additional Null Check

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/catalog/protos/Operation.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/catalog/protos/Operation.java
@@ -86,9 +86,6 @@ public final class Operation extends
         Objects.requireNonNull(input, "CodedInputStream can not be null");
         Objects.requireNonNull(extensionRegistry, "ExtensionRegistryLite can not be null");
 
-        if (extensionRegistry == null) {
-            throw new NullPointerException();
-        }
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
                 com.google.protobuf.UnknownFieldSet.newBuilder();
         try {


### PR DESCRIPTION
ISSUE #3900
Removed additional null check as both Objects.requireNonNull and later explicit null check is doing the same thing.

<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
-->

Fixes #3900.

### Motivation

* as the issue suggest, there is an extra null check that is exhibiting the same functionality. as the Objects.requireNonNull throws NPE if the object is null. the later null check is redundant the execution won't reach the later check. 



### Modifications

* Removed the additional redundant null check. 



### Documentation

- Does this pull request introduce a new feature? (yes / no) no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why? simple code refactoring.
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
