### PR TITLE
[ISSUE #3999]Exception thrown when 'gradlew checkstyleMain' run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ allprojects {
         showViolations = true
         maxWarnings = 0
         configFile = new File("${rootDir}/style/checkStyle.xml")
+        configDirectory = file("${rootDir}/style")
     }
 
     checkstyleMain.exclude '**/org/apache/eventmesh/client/grpc/protos**'

--- a/style/checkStyle.xml
+++ b/style/checkStyle.xml
@@ -27,15 +27,15 @@
   <property name="fileExtensions" value="java, properties, xml, gradle, env, sh"/>
   <module name="SuppressWarningsFilter" />
   <module name="Header">
-    <property name="headerFile" value="/checkstyle-header1.txt"/>
+    <property name="headerFile" value="${config_loc}/checkstyle-header1.txt"/>
     <property name="fileExtensions" value="java, gradle"/>
   </module>
   <module name="Header">
-    <property name="headerFile" value="/checkstyle-header2.txt"/>
+    <property name="headerFile" value="${config_loc}/checkstyle-header2.txt"/>
     <property name="fileExtensions" value="properties, env"/>
   </module>
   <module name="Header">
-    <property name="headerFile" value="/checkstyle-header3.txt"/>
+    <property name="headerFile" value="${config_loc}/checkstyle-header3.txt"/>
     <property name="fileExtensions" value="sh"/>
   </module>
   <module name="RegexpSingleline">


### PR DESCRIPTION
Fixes #3999.

### Motivation

We need CI can output the checkstyle error report or pass successfully when `gradlew checkstyleMain` is executed.

The error report should be like this when the header's format is wrong.
```
> Task :eventmesh-common:checkstyleMain
[ant:checkstyle] [WARN] E:\IdeaProjects\eventmesh\eventmesh-common\src\main\java\org\apache\eventmesh\common\loadbalance\LoadBalanceType.java:2: 当前行与被期待的 header: ' * Licensed to the Apache Software Foundation (ASF) under o
ne or more' 不符。 [Header]

> Task :eventmesh-common:checkstyleMain FAILED

```



### Modifications

Config the project path in gradle for CheckStyle.



### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
