### PR TITLE
[ISSUE #4058]Design an abstract class for SendMessageContext of grpc and SendMessageContext of http.

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/AbstractSendMessageContext.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/AbstractSendMessageContext.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.core.protocol;
+
+public abstract class AbstractSendMessageContext extends RetryContext{
+
+    protected String bizSeqNo;
+
+    protected long createTime = System.currentTimeMillis();
+
+    public String getBizSeqNo() {
+        return bizSeqNo;
+    }
+
+    public void setBizSeqNo(String bizSeqNo) {
+        this.bizSeqNo = bizSeqNo;
+    }
+
+    public long getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(long createTime) {
+        this.createTime = createTime;
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/RetryContext.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/RetryContext.java
@@ -50,4 +50,12 @@ public abstract class RetryContext implements DelayRetryable {
     public long getDelay(TimeUnit unit) {
         return unit.convert(this.executeTime - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
     }
+
+    public CloudEvent getEvent() {
+        return event;
+    }
+
+    public void setEvent(CloudEvent event) {
+        this.event = event;
+    }
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/producer/SendMessageContext.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/producer/SendMessageContext.java
@@ -22,6 +22,7 @@ import org.apache.eventmesh.api.SendResult;
 import org.apache.eventmesh.api.exception.OnExceptionContext;
 import org.apache.eventmesh.common.Constants;
 import org.apache.eventmesh.runtime.boot.EventMeshGrpcServer;
+import org.apache.eventmesh.runtime.core.protocol.AbstractSendMessageContext;
 import org.apache.eventmesh.runtime.core.protocol.RetryContext;
 
 import org.apache.commons.lang3.time.DateFormatUtils;
@@ -31,17 +32,11 @@ import org.slf4j.LoggerFactory;
 
 import io.cloudevents.CloudEvent;
 
-public class SendMessageContext extends RetryContext {
+public class SendMessageContext extends AbstractSendMessageContext {
 
     public static final Logger logger = LoggerFactory.getLogger("retry");
 
-    private CloudEvent event;
-
-    private String bizSeqNo;
-
     private EventMeshProducer eventMeshProducer;
-
-    private long createTime = System.currentTimeMillis();
 
     public EventMeshGrpcServer eventMeshGrpcServer;
 
@@ -53,36 +48,12 @@ public class SendMessageContext extends RetryContext {
         this.eventMeshGrpcServer = eventMeshGrpcServer;
     }
 
-    public String getBizSeqNo() {
-        return bizSeqNo;
-    }
-
-    public void setBizSeqNo(String bizSeqNo) {
-        this.bizSeqNo = bizSeqNo;
-    }
-
-    public CloudEvent getEvent() {
-        return event;
-    }
-
-    public void setEvent(CloudEvent event) {
-        this.event = event;
-    }
-
     public EventMeshProducer getEventMeshProducer() {
         return eventMeshProducer;
     }
 
     public void setEventMeshProducer(EventMeshProducer eventMeshProducer) {
         this.eventMeshProducer = eventMeshProducer;
-    }
-
-    public long getCreateTime() {
-        return createTime;
-    }
-
-    public void setCreateTime(long createTime) {
-        this.createTime = createTime;
     }
 
     @Override

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/producer/SendMessageContext.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/producer/SendMessageContext.java
@@ -22,6 +22,7 @@ import org.apache.eventmesh.api.SendResult;
 import org.apache.eventmesh.api.exception.OnExceptionContext;
 import org.apache.eventmesh.common.Constants;
 import org.apache.eventmesh.runtime.boot.EventMeshHTTPServer;
+import org.apache.eventmesh.runtime.core.protocol.AbstractSendMessageContext;
 import org.apache.eventmesh.runtime.core.protocol.RetryContext;
 
 import org.apache.commons.lang3.time.DateFormatUtils;
@@ -36,15 +37,9 @@ import io.cloudevents.CloudEvent;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class SendMessageContext extends RetryContext {
-
-    private CloudEvent event;
-
-    private String bizSeqNo;
+public class SendMessageContext extends AbstractSendMessageContext {
 
     private EventMeshProducer eventMeshProducer;
-
-    private long createTime = System.currentTimeMillis();
 
     private Map<String, String> props;
 
@@ -70,36 +65,12 @@ public class SendMessageContext extends RetryContext {
         return props.get(key);
     }
 
-    public String getBizSeqNo() {
-        return bizSeqNo;
-    }
-
-    public void setBizSeqNo(String bizSeqNo) {
-        this.bizSeqNo = bizSeqNo;
-    }
-
-    public CloudEvent getEvent() {
-        return event;
-    }
-
-    public void setEvent(CloudEvent event) {
-        this.event = event;
-    }
-
     public EventMeshProducer getEventMeshProducer() {
         return eventMeshProducer;
     }
 
     public void setEventMeshProducer(EventMeshProducer eventMeshProducer) {
         this.eventMeshProducer = eventMeshProducer;
-    }
-
-    public long getCreateTime() {
-        return createTime;
-    }
-
-    public void setCreateTime(long createTime) {
-        this.createTime = createTime;
     }
 
     public List<CloudEvent> getEventList() {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/session/send/UpStreamMsgContext.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/session/send/UpStreamMsgContext.java
@@ -66,10 +66,6 @@ public class UpStreamMsgContext extends RetryContext {
         return session;
     }
 
-    public CloudEvent getEvent() {
-        return event;
-    }
-
     public long getCreateTime() {
         return createTime;
     }


### PR DESCRIPTION
Fixes #4058.

### Motivation

`org.apache.eventmesh.runtime.core.protocol.grpc.producer.SendMessageContext` and `org.apache.eventmesh.runtime.core.protocol.http.producer.SendMessageContext` can share a parent class.



### Modifications

Add an abstract class for these two class.

Do some related modifications.



### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
