### PR TITLE
[ISSUE #4065]Make registry plugin Nacos support more configuration items

### DIFF
--- a/eventmesh-registry-plugin/eventmesh-registry-nacos/src/main/java/org/apache/eventmesh/registry/nacos/config/NacosRegistryConfiguration.java
+++ b/eventmesh-registry-plugin/eventmesh-registry-nacos/src/main/java/org/apache/eventmesh/registry/nacos/config/NacosRegistryConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.registry.nacos.config;
+
+import org.apache.eventmesh.common.config.Config;
+import org.apache.eventmesh.common.config.ConfigFiled;
+
+import com.alibaba.nacos.api.PropertyKeyConst;
+import com.alibaba.nacos.client.naming.utils.UtilAndComs;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@Config(prefix = "eventMesh.registry.nacos")
+public class NacosRegistryConfiguration {
+
+    @ConfigFiled(field = PropertyKeyConst.ENDPOINT)
+    private String endpoint;
+
+    @ConfigFiled(field = PropertyKeyConst.ENDPOINT_PORT)
+    private String endpointPort;
+
+    @ConfigFiled(field = PropertyKeyConst.ACCESS_KEY)
+    private String accessKey;
+
+    @ConfigFiled(field = PropertyKeyConst.SECRET_KEY)
+    private String secretKey;
+
+    @ConfigFiled(field = PropertyKeyConst.CLUSTER_NAME)
+    private String clusterName;
+
+    @ConfigFiled(field = PropertyKeyConst.NAMING_POLLING_THREAD_COUNT)
+    private Integer pollingThreadCount;
+
+    @ConfigFiled(field = UtilAndComs.NACOS_NAMING_LOG_NAME)
+    private String logFileName;
+
+    @ConfigFiled(field = UtilAndComs.NACOS_NAMING_LOG_LEVEL)
+    private String logLevel;
+
+}

--- a/eventmesh-registry-plugin/eventmesh-registry-nacos/src/main/java/org/apache/eventmesh/registry/nacos/config/NacosRegistryConfiguration.java
+++ b/eventmesh-registry-plugin/eventmesh-registry-nacos/src/main/java/org/apache/eventmesh/registry/nacos/config/NacosRegistryConfiguration.java
@@ -47,7 +47,7 @@ public class NacosRegistryConfiguration {
     private String clusterName;
 
     @ConfigFiled(field = PropertyKeyConst.NAMING_POLLING_THREAD_COUNT)
-    private Integer pollingThreadCount;
+    private Integer pollingThreadCount = Runtime.getRuntime().availableProcessors() / 2 + 1;
 
     @ConfigFiled(field = UtilAndComs.NACOS_NAMING_LOG_NAME)
     private String logFileName;

--- a/eventmesh-registry-plugin/eventmesh-registry-nacos/src/main/java/org/apache/eventmesh/registry/nacos/service/NacosRegistryService.java
+++ b/eventmesh-registry-plugin/eventmesh-registry-nacos/src/main/java/org/apache/eventmesh/registry/nacos/service/NacosRegistryService.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -127,19 +128,27 @@ public class NacosRegistryService implements RegistryService {
             return properties;
         }
         String endpoint = nacosConfig.getEndpoint();
-        if (endpoint.contains(":")) {
+        if (Objects.nonNull(endpoint) && endpoint.contains(":")) {
             int index = endpoint.indexOf(":");
             properties.put(PropertyKeyConst.ENDPOINT, endpoint.substring(0, index));
             properties.put(PropertyKeyConst.ENDPOINT_PORT, endpoint.substring(index + 1));
         } else {
-            properties.put(PropertyKeyConst.ENDPOINT, endpoint);
+            Optional.ofNullable(endpoint).ifPresent(value -> properties.put(PropertyKeyConst.ENDPOINT, endpoint));
+            String endpointPort = nacosConfig.getEndpointPort();
+            Optional.ofNullable(endpointPort).ifPresent(value -> properties.put(PropertyKeyConst.ENDPOINT_PORT, endpointPort));
         }
-        properties.put(PropertyKeyConst.ACCESS_KEY, nacosConfig.getAccessKey());
-        properties.put(PropertyKeyConst.SECRET_KEY, nacosConfig.getSecretKey());
-        properties.put(PropertyKeyConst.CLUSTER_NAME, nacosConfig.getClusterName());
-        properties.put(UtilAndComs.NACOS_NAMING_LOG_NAME, nacosConfig.getLogFileName());
-        properties.put(UtilAndComs.NACOS_NAMING_LOG_LEVEL, nacosConfig.getLogLevel());
-        properties.put(PropertyKeyConst.NAMING_POLLING_THREAD_COUNT, nacosConfig.getPollingThreadCount());
+        String accessKey = nacosConfig.getAccessKey();
+        Optional.ofNullable(accessKey).ifPresent(value -> properties.put(PropertyKeyConst.ACCESS_KEY, accessKey));
+        String secretKey = nacosConfig.getSecretKey();
+        Optional.ofNullable(secretKey).ifPresent(value -> properties.put(PropertyKeyConst.SECRET_KEY, secretKey));
+        String clusterName = nacosConfig.getClusterName();
+        Optional.ofNullable(clusterName).ifPresent(value -> properties.put(PropertyKeyConst.CLUSTER_NAME, clusterName));
+        String logFileName = nacosConfig.getLogFileName();
+        Optional.ofNullable(logFileName).ifPresent(value -> properties.put(UtilAndComs.NACOS_NAMING_LOG_NAME, logFileName));
+        String logLevel = nacosConfig.getLogLevel();
+        Optional.ofNullable(logLevel).ifPresent(value -> properties.put(UtilAndComs.NACOS_NAMING_LOG_LEVEL, logLevel));
+        Integer pollingThreadCount = nacosConfig.getPollingThreadCount();
+        Optional.ofNullable(pollingThreadCount).ifPresent(value -> properties.put(PropertyKeyConst.NAMING_POLLING_THREAD_COUNT, pollingThreadCount));
         return properties;
     }
 

--- a/eventmesh-runtime/conf/eventmesh.properties
+++ b/eventmesh-runtime/conf/eventmesh.properties
@@ -89,6 +89,12 @@ eventMesh.registry.plugin.type=nacos
 eventMesh.registry.plugin.server-addr=127.0.0.1:8848
 eventMesh.registry.plugin.username=nacos
 eventMesh.registry.plugin.password=nacos
+#registry plugin: nacos
+eventMesh.registry.nacos.endpoint=
+eventMesh.registry.nacos.accessKey=
+eventMesh.registry.nacos.secretKey=
+eventMesh.registry.nacos.clusterName=
+eventMesh.registry.nacos.namingPollingThreadCount=
 
 # metrics plugin, if you have multiple plugin, you can use ',' to split
 eventMesh.metrics.plugin=prometheus

--- a/eventmesh-runtime/conf/eventmesh.properties
+++ b/eventmesh-runtime/conf/eventmesh.properties
@@ -89,12 +89,13 @@ eventMesh.registry.plugin.type=nacos
 eventMesh.registry.plugin.server-addr=127.0.0.1:8848
 eventMesh.registry.plugin.username=nacos
 eventMesh.registry.plugin.password=nacos
-#registry plugin: nacos
-eventMesh.registry.nacos.endpoint=
-eventMesh.registry.nacos.accessKey=
-eventMesh.registry.nacos.secretKey=
-eventMesh.registry.nacos.clusterName=
-eventMesh.registry.nacos.namingPollingThreadCount=
+# registry plugin: nacos
+#eventMesh.registry.nacos.endpoint=
+#eventMesh.registry.nacos.accessKey=
+#eventMesh.registry.nacos.secretKey=
+#eventMesh.registry.nacos.clusterName=
+# The default value is half of CPU's num
+#eventMesh.registry.nacos.namingPollingThreadCount=5
 
 # metrics plugin, if you have multiple plugin, you can use ',' to split
 eventMesh.metrics.plugin=prometheus


### PR DESCRIPTION
Fixes #4065.

### Motivation

Currently, the registry plugin Nacos only supports to config server address, userName and password.



### Modifications

Make registry plugin Nacos support more configuration items: `endpoint`,` accessKey`, `secretKey` and so on.



### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
