### PR TITLE
[ISSUE #4067] Expand the zookeeper configuration for registry plugin

### DIFF
--- a/eventmesh-registry-plugin/eventmesh-registry-zookeeper/src/main/java/org/apache/eventmesh/registry/zookeeper/config/ZKRegistryConfiguration.java
+++ b/eventmesh-registry-plugin/eventmesh-registry-zookeeper/src/main/java/org/apache/eventmesh/registry/zookeeper/config/ZKRegistryConfiguration.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.registry.zookeeper.config;
+
+import org.apache.eventmesh.common.config.Config;
+import org.apache.eventmesh.common.config.ConfigFiled;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@Config(prefix = "eventMesh.registry.zookeeper")
+public class ZKRegistryConfiguration {
+
+    @ConfigFiled(field = "scheme")
+    private String scheme;
+
+    @ConfigFiled(field = "auth")
+    private String auth;
+
+    @ConfigFiled(field = "connectionTimeoutMs")
+    private Integer connectionTimeoutMs = 5000;
+
+    @ConfigFiled(field = "sessionTimeoutMs")
+    private Integer sessionTimeoutMs = 40000;
+
+    // Fully qualified name of RetryPolicy implementation
+    @ConfigFiled(field = "retryPolicy.class")
+    private String retryPolicyClass;
+
+    @ConfigFiled(field = "retryPolicy.baseSleepTimeMs")
+    private Integer baseSleepTimeMs = 1000;
+
+    @ConfigFiled(field = "retryPolicy.maxRetries")
+    private Integer maxRetries = 5;
+
+    @ConfigFiled(field = "retryPolicy.maxSleepTimeMs")
+    private Integer maxSleepTimeMs = 5000;
+
+    @ConfigFiled(field = "retryPolicy.retryIntervalMs")
+    private Integer retryIntervalTimeMs = 1000;
+
+    @ConfigFiled(field = "retryPolicy.nTimes")
+    private Integer retryNTimes = 10;
+
+    @ConfigFiled(field = "retryPolicy.sleepMsBetweenRetries")
+    private Integer sleepMsBetweenRetries = 1000;
+
+}

--- a/eventmesh-registry-plugin/eventmesh-registry-zookeeper/src/main/java/org/apache/eventmesh/registry/zookeeper/service/ZookeeperRegistryService.java
+++ b/eventmesh-registry-plugin/eventmesh-registry-zookeeper/src/main/java/org/apache/eventmesh/registry/zookeeper/service/ZookeeperRegistryService.java
@@ -23,9 +23,12 @@ import org.apache.eventmesh.api.registry.RegistryService;
 import org.apache.eventmesh.api.registry.dto.EventMeshDataInfo;
 import org.apache.eventmesh.api.registry.dto.EventMeshRegisterInfo;
 import org.apache.eventmesh.api.registry.dto.EventMeshUnRegisterInfo;
+import org.apache.eventmesh.common.Constants;
 import org.apache.eventmesh.common.config.CommonConfiguration;
+import org.apache.eventmesh.common.config.ConfigService;
 import org.apache.eventmesh.common.utils.ConfigurationContextUtil;
 import org.apache.eventmesh.common.utils.JsonUtils;
+import org.apache.eventmesh.registry.zookeeper.config.ZKRegistryConfiguration;
 import org.apache.eventmesh.registry.zookeeper.constant.ZookeeperConstant;
 import org.apache.eventmesh.registry.zookeeper.pojo.EventMeshInstance;
 
@@ -34,7 +37,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.CuratorFrameworkFactory.Builder;
+import org.apache.curator.retry.BoundedExponentialBackoffRetry;
 import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.retry.RetryForever;
+import org.apache.curator.retry.RetryNTimes;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.data.Stat;
 
@@ -43,6 +50,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -65,6 +73,8 @@ public class ZookeeperRegistryService implements RegistryService {
 
     private ConcurrentMap<String, EventMeshRegisterInfo> eventMeshRegisterInfoMap;
 
+    private ZKRegistryConfiguration zkConfig;
+
     @Override
     public void init() throws RegistryException {
 
@@ -84,6 +94,8 @@ public class ZookeeperRegistryService implements RegistryService {
             this.serverAddr = commonConfiguration.getNamesrvAddr();
             break;
         }
+        ZKRegistryConfiguration zkConfig = ConfigService.getInstance().buildConfigInstance(ZKRegistryConfiguration.class);
+        this.zkConfig = zkConfig;
     }
 
     @Override
@@ -94,17 +106,63 @@ public class ZookeeperRegistryService implements RegistryService {
             return;
         }
         try {
-            RetryPolicy retryPolicy = new ExponentialBackoffRetry(1000, 5);
-            zkClient = CuratorFrameworkFactory.builder()
-                .connectString(serverAddr)
-                .retryPolicy(retryPolicy)
-                .namespace(ZookeeperConstant.NAMESPACE)
-                .build();
+            zkClient = buildZkClient();
             zkClient.start();
-
         } catch (Exception e) {
             throw new RegistryException("ZookeeperRegistry starting failed", e);
         }
+    }
+
+    private CuratorFramework buildZkClient() throws ClassNotFoundException {
+        Builder builder = CuratorFrameworkFactory.builder()
+            .connectString(serverAddr)
+            .namespace(ZookeeperConstant.NAMESPACE);
+        if (zkConfig == null) {
+            return builder.build();
+        }
+        builder.retryPolicy(createRetryPolicy());
+        String scheme = zkConfig.getScheme();
+        String auth = zkConfig.getAuth();
+        if (!StringUtils.isAnyBlank(scheme, auth)) {
+            builder.authorization(scheme, auth.getBytes(Constants.DEFAULT_CHARSET));
+        }
+        Optional.ofNullable(zkConfig.getConnectionTimeoutMs()).ifPresent((timeout) -> builder.connectionTimeoutMs(timeout));
+        Optional.ofNullable(zkConfig.getSessionTimeoutMs()).ifPresent((timeout) -> builder.sessionTimeoutMs(timeout));
+        return builder.build();
+    }
+
+    private RetryPolicy createRetryPolicy() throws ClassNotFoundException {
+        String retryPolicyClass = zkConfig.getRetryPolicyClass();
+        if (StringUtils.isBlank(retryPolicyClass)) {
+            return new ExponentialBackoffRetry(1000, 5);
+        }
+        Class<?> clazz = Class.forName(retryPolicyClass);
+        if (clazz == ExponentialBackoffRetry.class) {
+            return new ExponentialBackoffRetry(
+                getOrDefault(zkConfig.getBaseSleepTimeMs(), 1000, Integer.class),
+                getOrDefault(zkConfig.getMaxRetries(), 5, Integer.class));
+        } else if (clazz == BoundedExponentialBackoffRetry.class) {
+            return new BoundedExponentialBackoffRetry(
+                getOrDefault(zkConfig.getBaseSleepTimeMs(), 1000, Integer.class),
+                getOrDefault(zkConfig.getMaxSleepTimeMs(), 5000, Integer.class),
+                getOrDefault(zkConfig.getMaxRetries(), 5, Integer.class));
+        } else if (clazz == RetryForever.class) {
+            return new RetryForever(
+                getOrDefault(zkConfig.getRetryIntervalTimeMs(), 1000, Integer.class));
+        } else if (clazz == RetryNTimes.class) {
+            return new RetryNTimes(
+                getOrDefault(zkConfig.getRetryNTimes(), 10, Integer.class),
+                getOrDefault(zkConfig.getSleepMsBetweenRetries(), 1000, Integer.class));
+        } else {
+            throw new IllegalArgumentException("Unsupported retry policy: " + retryPolicyClass);
+        }
+    }
+
+    private <T> T getOrDefault(T value, T defaultValue, Class<T> clazz) {
+        if (value != null) {
+            return value;
+        }
+        return defaultValue;
     }
 
     @Override

--- a/eventmesh-runtime/conf/eventmesh.properties
+++ b/eventmesh-runtime/conf/eventmesh.properties
@@ -90,6 +90,23 @@ eventMesh.registry.plugin.server-addr=127.0.0.1:8848
 eventMesh.registry.plugin.username=nacos
 eventMesh.registry.plugin.password=nacos
 
+# registry plugin: zookeeper
+#eventMesh.registry.zookeeper.scheme=
+#eventMesh.registry.zookeeper.auth=
+#eventMesh.registry.zookeeper.connectionTimeoutMs=
+#eventMesh.registry.zookeeper.sessionTimeoutMs=
+
+# Fully qualified name of org.apache.curator.RetryPolicy implementation
+#eventMesh.registry.zookeeper.retryPolicy.class=
+
+# Constructor arguments for different org.apache.curator.RetryPolicy implementations
+#eventMesh.registry.zookeeper.retryPolicy.baseSleepTimeMs=
+#eventMesh.registry.zookeeper.retryPolicy.maxRetries=
+#eventMesh.registry.zookeeper.retryPolicy.maxSleepTimeMs=
+#eventMesh.registry.zookeeper.retryPolicy.retryIntervalMs=
+#eventMesh.registry.zookeeper.retryPolicy.nTimes=
+#eventMesh.registry.zookeeper.retryPolicy.sleepMsBetweenRetries=
+
 # metrics plugin, if you have multiple plugin, you can use ',' to split
 eventMesh.metrics.plugin=prometheus
 


### PR DESCRIPTION
Fixes #4067.

### Motivation

For now, the registry plugin zk in eventmesh supports the configuration of the zookeeper server's address.



### Modifications

Expand the zookeeper configuration configuration for registry plugin:
`scheme`, `auth`, `connectionTimeoutMs`, `sessionTimeoutMs`, the implementation name of `org.apache.curator.RetryPolicy`, and the parameters of different `org.apache.curator.RetryPolicy`'s implementations.



### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
