### PR TITLE
[ISSUE #4069]Add TLSConfig to registry plugin Consul. 

### DIFF
--- a/eventmesh-registry-plugin/eventmesh-registry-consul/src/main/java/org/apache/eventmesh/registry/consul/config/ConsulTLSConfig.java
+++ b/eventmesh-registry-plugin/eventmesh-registry-consul/src/main/java/org/apache/eventmesh/registry/consul/config/ConsulTLSConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.registry.consul.config;
+
+import org.apache.eventmesh.common.config.Config;
+import org.apache.eventmesh.common.config.ConfigFiled;
+import org.apache.eventmesh.common.config.convert.converter.EnumConverter;
+
+import com.ecwid.consul.transport.TLSConfig.KeyStoreInstanceType;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@Config(prefix = "eventMesh.registry.consul.tls")
+public class ConsulTLSConfig {
+
+    @ConfigFiled(field = "keyStoreInstanceType", converter = EnumConverter.class)
+    private KeyStoreInstanceType keyStoreInstanceType;
+
+    @ConfigFiled(field = "certificatePath")
+    private String certificatePath;
+
+    @ConfigFiled(field = "certificatePassword")
+    private String certificatePassword;
+
+    @ConfigFiled(field = "keyStorePath")
+    private String keyStorePath;
+
+    @ConfigFiled(field = "keyStorePassword")
+    private String keyStorePassword;
+
+}

--- a/eventmesh-registry-plugin/eventmesh-registry-consul/src/main/java/org/apache/eventmesh/registry/consul/service/ConsulRegistryService.java
+++ b/eventmesh-registry-plugin/eventmesh-registry-consul/src/main/java/org/apache/eventmesh/registry/consul/service/ConsulRegistryService.java
@@ -23,17 +23,21 @@ import org.apache.eventmesh.api.registry.dto.EventMeshDataInfo;
 import org.apache.eventmesh.api.registry.dto.EventMeshRegisterInfo;
 import org.apache.eventmesh.api.registry.dto.EventMeshUnRegisterInfo;
 import org.apache.eventmesh.common.config.CommonConfiguration;
+import org.apache.eventmesh.common.config.ConfigService;
 import org.apache.eventmesh.common.utils.ConfigurationContextUtil;
+import org.apache.eventmesh.registry.consul.config.ConsulTLSConfig;
 
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.ecwid.consul.transport.TLSConfig;
 import com.ecwid.consul.v1.ConsulClient;
-import com.ecwid.consul.v1.ConsulRawClient;
+import com.ecwid.consul.v1.ConsulRawClient.Builder;
 import com.ecwid.consul.v1.agent.model.NewService;
 import com.ecwid.consul.v1.agent.model.Service;
 import com.ecwid.consul.v1.health.HealthServicesRequest;
@@ -60,6 +64,8 @@ public class ConsulRegistryService implements RegistryService {
 
     private String token;
 
+    private ConsulTLSConfig tlsConfig;
+
     @Override
     public void init() throws RegistryException {
         if (initStatus.compareAndSet(false, true)) {
@@ -79,6 +85,8 @@ public class ConsulRegistryService implements RegistryService {
                     break;
                 }
             }
+            ConsulTLSConfig tlsConfig = ConfigService.getInstance().buildConfigInstance(ConsulTLSConfig.class);
+            this.tlsConfig = tlsConfig;
         }
     }
 
@@ -87,8 +95,28 @@ public class ConsulRegistryService implements RegistryService {
         if (!startStatus.compareAndSet(false, true)) {
             return;
         }
-        consulClient = new ConsulClient(new ConsulRawClient(consulHost, Integer.parseInt(consulPort)));
+        Builder builder = Builder.builder();
+        builder.setHost(consulHost);
+        builder.setPort(Integer.parseInt(consulPort));
+        if (tlsConfig != null
+            && Objects.nonNull(tlsConfig.getKeyStoreInstanceType())
+            && !StringUtils.isAnyBlank(
+                tlsConfig.getCertificatePassword(),
+                tlsConfig.getCertificatePath(),
+                tlsConfig.getKeyStorePassword(),
+                tlsConfig.getKeyStorePath())) {
+            builder.setTlsConfig(convertToTlsConfig(tlsConfig));
+        }
+        consulClient = new ConsulClient(builder.build());
+    }
 
+    private TLSConfig convertToTlsConfig(ConsulTLSConfig tlsConfig) {
+        return new TLSConfig(
+            tlsConfig.getKeyStoreInstanceType(),
+            tlsConfig.getCertificatePath(),
+            tlsConfig.getCertificatePassword(),
+            tlsConfig.getKeyStorePath(),
+            tlsConfig.getKeyStorePassword());
     }
 
     @Override

--- a/eventmesh-runtime/conf/eventmesh.properties
+++ b/eventmesh-runtime/conf/eventmesh.properties
@@ -90,6 +90,14 @@ eventMesh.registry.plugin.server-addr=127.0.0.1:8848
 eventMesh.registry.plugin.username=nacos
 eventMesh.registry.plugin.password=nacos
 
+# The TLS configuration of registry plugin consul
+# keyStoreInstanceType's value can refer to com.ecwid.consul.transport.TLSConfig.KeyStoreInstanceType
+#eventMesh.registry.consul.tls.keyStoreInstanceType=
+#eventMesh.registry.consul.tls.certificatePath=
+#eventMesh.registry.consul.tls.certificatePassword=
+#eventMesh.registry.consul.tls.keyStorePath=
+#eventMesh.registry.consul.tls.keyStorePassword=
+
 # metrics plugin, if you have multiple plugin, you can use ',' to split
 eventMesh.metrics.plugin=prometheus
 


### PR DESCRIPTION
Fixes #4069.

### Motivation

The registry plugin Consul does not support `TLSConfig` for now. 



### Modifications

Add TLSConfig to registry plugin Consul.



### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
