### PR TITLE
[ISSUE #4030] Avoid unnecessary boxing by using plain == for primitive types

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/convert/converter/BaseDataTypeConverter.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/convert/converter/BaseDataTypeConverter.java
@@ -42,8 +42,8 @@ public class BaseDataTypeConverter {
         @Override
         public Boolean convert(ConvertInfo convertInfo) {
             String value = (String) convertInfo.getValue();
-            if (Objects.equals(value.length(), 1)) {
-                return Objects.equals(convertInfo.getValue(), "1") ? Boolean.TRUE : Boolean.FALSE;
+            if (value.length() == 1) {
+                return convertInfo.getValue().equals("1") ? Boolean.TRUE : Boolean.FALSE;
             }
 
             return Boolean.valueOf((String) convertInfo.getValue());


### PR DESCRIPTION
Fixes #4030 

### Modifications

Avoided unnecessary boxing by using plain `==` for primitive types at line 45


### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
