### PR TITLE
[ISSUE #4079]The error of building metric observer: java.util.NoSuchElementException

### DIFF
--- a/eventmesh-metrics-plugin/eventmesh-metrics-prometheus/src/main/java/org/apache/eventmesh/metrics/prometheus/metrics/PrometheusGrpcExporter.java
+++ b/eventmesh-metrics-plugin/eventmesh-metrics-prometheus/src/main/java/org/apache/eventmesh/metrics/prometheus/metrics/PrometheusGrpcExporter.java
@@ -59,7 +59,7 @@ public class PrometheusGrpcExporter {
     public static void export(final String meterName, final GrpcSummaryMetrics summaryMetrics) {
         final Meter meter = GlobalMeterProvider.getMeter(meterName);
 
-        paramPairs.forEach((k, v) ->
-                observeOfValue(meter, METRICS_GRPC_PREFIX + k[0], k[1], GRPC, v.apply(summaryMetrics)));
+        paramPairs.forEach((metricInfo, getMetric) ->
+            observeOfValue(meter, METRICS_GRPC_PREFIX + metricInfo[0], metricInfo[1], GRPC, summaryMetrics, getMetric));
     }
 }

--- a/eventmesh-metrics-plugin/eventmesh-metrics-prometheus/src/main/java/org/apache/eventmesh/metrics/prometheus/metrics/PrometheusHttpExporter.java
+++ b/eventmesh-metrics-plugin/eventmesh-metrics-prometheus/src/main/java/org/apache/eventmesh/metrics/prometheus/metrics/PrometheusHttpExporter.java
@@ -177,7 +177,7 @@ public class PrometheusHttpExporter {
 
     public void export(String name, HttpSummaryMetrics summaryMetrics) {
         Meter meter = GlobalMeterProvider.getMeter(name);
-        paramPairs.forEach((k, v) -> observeOfValue(meter, k[0], k[1], HTTP, v.apply(summaryMetrics)));
+        paramPairs.forEach((metricInfo, getMetric) -> observeOfValue(meter, metricInfo[0], metricInfo[1], HTTP, summaryMetrics, getMetric));
     }
 
 }

--- a/eventmesh-metrics-plugin/eventmesh-metrics-prometheus/src/main/java/org/apache/eventmesh/metrics/prometheus/metrics/PrometheusTcpExporter.java
+++ b/eventmesh-metrics-plugin/eventmesh-metrics-prometheus/src/main/java/org/apache/eventmesh/metrics/prometheus/metrics/PrometheusTcpExporter.java
@@ -79,7 +79,7 @@ public class PrometheusTcpExporter {
 
     public void export(final String meterName, final TcpSummaryMetrics summaryMetrics) {
         final Meter meter = GlobalMeterProvider.getMeter(meterName);
-        paramPairs.forEach((k, v) ->
-                observeOfValue(meter, METRICS_TCP_PREFIX + k[0], k[1], TCP, v.apply(summaryMetrics)));
+        paramPairs.forEach((metricInfo, getMetric) ->
+                observeOfValue(meter, METRICS_TCP_PREFIX + metricInfo[0], metricInfo[1], TCP, summaryMetrics, getMetric));
     }
 }


### PR DESCRIPTION
Fixes #4079.

### Motivation

Error occurs when building metric observer. Because the metrics of EventMesh is not ready yet, they should not be obtained at that time. Eg `v.apply(summaryMetrics)` get metrics here
```
paramPairs.forEach((k, v) ->
                observeOfValue(meter, METRICS_GRPC_PREFIX + k[0], k[1], GRPC, v.apply(summaryMetrics)));
```


### Modifications

Modify the method `PrometheusExporterUtils#observeOfValue()` to make the action of getting metrics deferred execution.
Eg `getMetric` is `Function` here. It can defer the action of getting metrics.

```
paramPairs.forEach((metricInfo, getMetric) ->
            observeOfValue(meter, METRICS_GRPC_PREFIX + metricInfo[0], metricInfo[1], GRPC, summaryMetrics, getMetric));
```

### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
