### PR TITLE
[ISSUE #4110] Enhance thread handling of InterruptedException

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/retry/HttpRetryer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/retry/HttpRetryer.java
@@ -83,6 +83,9 @@ public class HttpRetryer {
                     });
                 }
             } catch (Exception e) {
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
                 retryLogger.error("http-retry-dispatcher error!", e);
             }
         }, "http-retry-dispatcher");


### PR DESCRIPTION

Fixes #4110.

### Motivation

If a thread is interrupted while in a blocked state, in order to prevent subsequent code from making erroneous judgments after handling the interruption, the `InterruptedException` is thrown and at the same time, the `Thread.interrupted()` method is called to clear the thread's interrupt status.

If the dispatcher is interrupted while executing the `take()` method, it will catch the `InterruptedException` exception and continue executing the exception handling block. At this point, the information about the thread being interrupted should not be lost. However, because `InterruptedException` is a `checked exception`, if it is not handled, it will be propagated to the method caller and may be thrown in `EventMeshHTTPServer.java`, resulting in a delayed closure of the thread. Moreover, there is no timely exit or restoration of the interrupt status at this point, so the thread may continue executing the `retry()` method, thereby losing the information about the thread being interrupted.

However, the issue states that `InterruptedExceptions` should be re-thrown, but I think this handling is inappropriate. This approach does not reset the thread's interrupt status nor does it communicate the intention and semantics of the thread being interrupted to other developers. It would be better to reset the interrupt status.

### Modifications

Catch the InterruptedException exception and re-interrupt the thread.

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
