### PR TITLE
[ISSUE #4138] Add Unit Test for UrlMappingPattern

### DIFF
--- a/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/util/UrlMappingPatternTest.java
+++ b/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/util/UrlMappingPatternTest.java
@@ -31,7 +31,6 @@ import java.util.regex.Pattern;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 public class UrlMappingPatternTest {
 
@@ -91,7 +90,7 @@ public class UrlMappingPatternTest {
     @Test
     public void testCompile() throws NoSuchFieldException, IllegalAccessException {
         // Obtain compiledUrlMappingPattern field with reflection
-        Field compiledUrlMappingPatternField = urlMappingPattern.getClass().getDeclaredField("compiledUrlMappingPattern");
+        Field compiledUrlMappingPatternField = UrlMappingPattern.class.getDeclaredField("compiledUrlMappingPattern");
         compiledUrlMappingPatternField.setAccessible(true);
 
         urlMappingPattern.compile();
@@ -101,8 +100,9 @@ public class UrlMappingPatternTest {
         assertNotNull(compiledPattern);
 
         // Verify that the mocked pattern is compiled with the expected regex
-        Mockito.verify(urlMappingPattern.compiledUrlMappingPattern)
-            .compile("/test/([%\\w-.\\~!$&'\\(\\)\\*\\+,;=:\\[\\]@]+?)/path/([%\\w-.\\~!$&'\\(\\)\\*\\+,;=:\\[\\]@]+?)(?:\\?.*?)?$");
+        String expectedRegex = "/test/([%\\w-.\\~!$&'\\(\\)\\*\\+,;=:\\[\\]@]+?)/path/([%\\w-.\\~!$&'\\(\\)\\*\\+,;=:\\[\\]@]+?)(?:\\?.*?)?$";
+        Pattern expectedPattern = Pattern.compile(expectedRegex);
+        assertEquals(expectedPattern.pattern(), compiledPattern.pattern());
     }
 
     class TestUrlMappingPattern extends UrlMappingPattern {

--- a/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/util/UrlMappingPatternTest.java
+++ b/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/util/UrlMappingPatternTest.java
@@ -96,6 +96,7 @@ public class UrlMappingPatternTest {
 
         urlMappingPattern.compile();
 
+        // Verify that the compiledUrlMappingPattern field is updated
         Pattern compiledPattern = (Pattern) compiledUrlMappingPatternField.get(urlMappingPattern);
         assertNotNull(compiledPattern);
 

--- a/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/util/UrlMappingPatternTest.java
+++ b/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/util/UrlMappingPatternTest.java
@@ -18,6 +18,7 @@
 package org.apache.eventmesh.admin.rocketmq.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -89,19 +90,18 @@ public class UrlMappingPatternTest {
 
     @Test
     public void testCompile() throws NoSuchFieldException, IllegalAccessException {
-        // Mock the compiledUrlMappingPattern field with reflection
-        Pattern mockedPattern = mock(Pattern.class);
+        // Obtain compiledUrlMappingPattern field with reflection
         Field compiledUrlMappingPatternField = urlMappingPattern.getClass().getDeclaredField("compiledUrlMappingPattern");
         compiledUrlMappingPatternField.setAccessible(true);
-        compiledUrlMappingPatternField.set(urlMappingPattern, mockedPattern);
 
         urlMappingPattern.compile();
 
         // Verify that the compiledUrlMappingPattern field is updated
-        assertEquals(mockedPattern, compiledUrlMappingPatternField.get(urlMappingPattern));
+        Pattern compiledPattern = (Pattern) compiledUrlMappingPatternField.get(urlMappingPattern);
+        assertNotNull(compiledPattern);
 
         // Verify that the mocked pattern is compiled with the expected regex
-        Mockito.verify(mockedPattern)
+        Mockito.verify(urlMappingPattern.compiledUrlMappingPattern)
             .compile("/test/([%\\w-.\\~!$&'\\(\\)\\*\\+,;=:\\[\\]@]+?)/path/([%\\w-.\\~!$&'\\(\\)\\*\\+,;=:\\[\\]@]+?)(?:\\?.*?)?$");
     }
 

--- a/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/util/UrlMappingPatternTest.java
+++ b/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/util/UrlMappingPatternTest.java
@@ -23,12 +23,14 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class UrlMappingPatternTest {
 
@@ -86,8 +88,21 @@ public class UrlMappingPatternTest {
     }
 
     @Test
-    public void testCompile() {
-        //TODO : Fix me to test the method compile(). It is better using Mockito not PowerMockito.
+    public void testCompile() throws NoSuchFieldException, IllegalAccessException {
+        // Mock the compiledUrlMappingPattern field with reflection
+        Pattern mockedPattern = mock(Pattern.class);
+        Field compiledUrlMappingPatternField = urlMappingPattern.getClass().getDeclaredField("compiledUrlMappingPattern");
+        compiledUrlMappingPatternField.setAccessible(true);
+        compiledUrlMappingPatternField.set(urlMappingPattern, mockedPattern);
+
+        urlMappingPattern.compile();
+
+        // Verify that the compiledUrlMappingPattern field is updated
+        assertEquals(mockedPattern, compiledUrlMappingPatternField.get(urlMappingPattern));
+
+        // Verify that the mocked pattern is compiled with the expected regex
+        Mockito.verify(mockedPattern)
+            .compile("/test/([%\\w-.\\~!$&'\\(\\)\\*\\+,;=:\\[\\]@]+?)/path/([%\\w-.\\~!$&'\\(\\)\\*\\+,;=:\\[\\]@]+?)(?:\\?.*?)?$");
     }
 
     class TestUrlMappingPattern extends UrlMappingPattern {

--- a/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/util/UrlMappingPatternTest.java
+++ b/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/util/UrlMappingPatternTest.java
@@ -96,7 +96,6 @@ public class UrlMappingPatternTest {
 
         urlMappingPattern.compile();
 
-        // Verify that the compiledUrlMappingPattern field is updated
         Pattern compiledPattern = (Pattern) compiledUrlMappingPatternField.get(urlMappingPattern);
         assertNotNull(compiledPattern);
 


### PR DESCRIPTION
Fixes #4138 .

### Motivation

The TO-DO mark said that "It is better using Mockito not PowerMockito", so I used Mockito. Although there are private method/field to test in the compile() method of UrlMappingPattern.

### Modifications

Use reflections to access private method and field, then write regular expressions.

The Test case passed.

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
