### PR TITLE
[ISSUE #3904] Make fields final that should be final

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/Constants.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/Constants.java
@@ -126,11 +126,11 @@ public class Constants {
 
     public static final String OPERATION_TIMEOUT = "OPERATION_TIMEOUT";
 
-    public static String CLOUD_EVENTS_PROTOCOL_NAME = "cloudevents";
+    public static final String CLOUD_EVENTS_PROTOCOL_NAME = "cloudevents";
 
-    public static String EM_MESSAGE_PROTOCOL_NAME = "eventmeshmessage";
+    public static final String EM_MESSAGE_PROTOCOL_NAME = "eventmeshmessage";
 
-    public static String OPEN_MESSAGE_PROTOCOL_NAME = "openmessage";
+    public static final String OPEN_MESSAGE_PROTOCOL_NAME = "openmessage";
 
     // delimiter define
     public static final String COMMA = ",";


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
-->

Fixes #3904

### Motivation

Bring consistency in the declaration of constant fields

### Modifications

The class **Constants** in the package **org.apache.eventmesh.common** have some fields (CLOUD_EVENTS_PROTOCOL_NAME, EM_MESSAGE_PROTOCOL_NAME, OPEN_MESSAGE_PROTOCOL_NAME) that didn't had **final** modified. In this PR these fields are made final.


### Documentation

- Does this pull request introduce a new feature? (no)
