### PR TITLE
[ISSUE #4185] Correct eventmesh.properties comment grammar mistake

### DIFF
--- a/eventmesh-connectors/README.md
+++ b/eventmesh-connectors/README.md
@@ -4,7 +4,7 @@
 A connector is a bridge that interacts with a specific external service or underlying data source (e.g., Databases) on behalf of user applications. A connector is either a Source or a Sink.
 
 ## Source
-A source connector obtains data from an underlying data producer and delivers it to targets, after original data has been transformed into CloudEvents. It doesn't limit the way how a source retrieves data. (e.g., A source may pull data from a message queue or act as an HTTP server waiting for data sent to it).
+A source connector obtains data from an underlying data producer, and delivers it to targets after original data has been transformed into CloudEvents. It doesn't limit the way how a source retrieves data. (e.g., A source may pull data from a message queue or act as an HTTP server waiting for data sent to it).
 
 ## Sink 
 A sink connector receives CloudEvents and does some specific business logics. (e.g., A MySQL Sink extracts useful data from CloudEvents and writes them to a MySQL database).

--- a/eventmesh-runtime/conf/eventmesh.properties
+++ b/eventmesh-runtime/conf/eventmesh.properties
@@ -115,5 +115,5 @@ eventMesh.webHook.fileMode.filePath= #{eventMeshHome}/webhook
 # Nacos storage mode, and the configuration naming rule is eventmesh webHook. nacosMode. {nacos native configuration key} please see the specific configuration [nacos github api](https://github.com/alibaba/nacos/blob/develop/api/src/main/java/com/alibaba/nacos/api/SystemPropertyKeyConst.java)
 ## Address of Nacos
 eventMesh.webHook.nacosMode.serverAddr=127.0.0.1:8848
-# Webhook eventcloud sending mode. And eventmesh connector. plugin. The type configuration is the same
+# Webhook CloudEvent sending mode. This property is the same as the eventMesh.storage.plugin.type configuration.
 eventMesh.webHook.producer.storage=standalone

--- a/eventmesh-webhook/eventmesh-webhook-admin/src/test/resources/eventmesh.properties
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/test/resources/eventmesh.properties
@@ -24,5 +24,5 @@ eventMesh.webHook.fileMode.filePath=.
 # Nacos storage mode, and the configuration naming rule is eventmesh webHook. nacosMode. {nacos native configuration key} please see the specific configuration [nacos github api](https://github.com/alibaba/nacos/blob/develop/api/src/main/java/com/alibaba/nacos/api/SystemPropertyKeyConst.java)
 ## Address of Nacos
 eventMesh.webHook.nacosMode.serverAddr=127.0.0.1:8848
-# Webhook eventcloud sending mode. And eventmesh storage. plugin. The type configuration is the same
+# Webhook CloudEvent sending mode. This property is the same as the eventMesh.storage.plugin.type configuration.
 eventMesh.webHook.producer.storage=standalone

--- a/eventmesh-webhook/eventmesh-webhook-receive/src/test/resources/eventmesh.properties
+++ b/eventmesh-webhook/eventmesh-webhook-receive/src/test/resources/eventmesh.properties
@@ -26,5 +26,5 @@ eventMesh.webHook.fileMode.filePath=.
 # Nacos storage mode, and the configuration naming rule is eventmesh webHook. nacosMode. {nacos native configuration key} please see the specific configuration [nacos github api](https://github.com/alibaba/nacos/blob/develop/api/src/main/java/com/alibaba/nacos/api/SystemPropertyKeyConst.java)
 ## Address of Nacos
 eventMesh.webHook.nacosMode.serverAddr=127.0.0.1:8848
-# Webhook eventcloud sending mode. And eventmesh storage. plugin. The type configuration is the same
+# Webhook CloudEvent sending mode. This property is the same as the eventMesh.storage.plugin.type configuration.
 eventMesh.webHook.producer.storage=standalone


### PR DESCRIPTION
Fixes #4185.

### Motivation

![image](https://github.com/apache/eventmesh/assets/41445332/99683171-b442-47c2-92e3-24a9f81c9709)

According to the original Chinese comments in the git commit history, the existing English comments are misleading. The English translation does not match the meaning of the original Chinese text, which affects understanding.

### Modifications

Correct eventmesh.properties comment grammar mistake.

```
    # Webhook CloudEvent sending mode. This property is the same as the eventMesh.storage.plugin.type configuration.
    producer:
      storage: standalone
```

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
