### PR TITLE
[ISSUE#4198]Do some code optimization.[GrpcRetryer]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/retry/GrpcRetryer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/retry/GrpcRetryer.java
@@ -78,8 +78,9 @@ public class GrpcRetryer {
                     });
                 }
             } catch (Exception e) {
-                if (e instanceof InterruptedException)
+                if (e instanceof InterruptedException) {
                     Thread.currentThread().interrupt();
+                }
                 log.error("grpc-retry-dispatcher error!", e);
             }
         }, "grpc-retry-dispatcher");

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/retry/GrpcRetryer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/retry/GrpcRetryer.java
@@ -78,9 +78,8 @@ public class GrpcRetryer {
                     });
                 }
             } catch (Exception e) {
-                if(e instanceof InterruptedException){
+                if (e instanceof InterruptedException)
                     Thread.currentThread().interrupt();
-                }
                 log.error("grpc-retry-dispatcher error!", e);
             }
         }, "grpc-retry-dispatcher");

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/retry/GrpcRetryer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/retry/GrpcRetryer.java
@@ -62,7 +62,7 @@ public class GrpcRetryer {
 
         dispatcher = new Thread(() -> {
             try {
-                DelayRetryable retryObj = null;
+                DelayRetryable retryObj;
                 while (!Thread.currentThread().isInterrupted()
                     && (retryObj = failed.take()) != null) {
                     final DelayRetryable delayRetryable = retryObj;
@@ -78,6 +78,9 @@ public class GrpcRetryer {
                     });
                 }
             } catch (Exception e) {
+                if(e instanceof InterruptedException){
+                    Thread.currentThread().interrupt();
+                }
                 log.error("grpc-retry-dispatcher error!", e);
             }
         }, "grpc-retry-dispatcher");


### PR DESCRIPTION
Fixes #4198 

### Modifications

- Variable `retryObj` initializer `null` is redundant at line 65, removed.

- Throwing of the `InterruptedException` at line 80.

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)