### PR TITLE
[ISSUE #4208] Add JavaDoc for org.apache.eventmesh.runtime.admin APIs of dashboard

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/controller/ClientManageController.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/controller/ClientManageController.java
@@ -83,10 +83,10 @@ public class ClientManageController {
     /**
      * Constructs a new ClientManageController with the given server instance.
      *
-     * @param eventMeshTCPServer the TCP server for EventMesh
-     * @param eventMeshHTTPServer the HTTP server for EventMesh
-     * @param eventMeshGrpcServer the gRPC server for EventMesh
-     * @param eventMeshRegistry the registry adaptor for EventMesh
+     * @param eventMeshTCPServer the TCP server instance of EventMesh
+     * @param eventMeshHTTPServer the HTTP server instance of EventMesh
+     * @param eventMeshGrpcServer the gRPC server instance of EventMesh
+     * @param eventMeshRegistry the registry adaptor of EventMesh
      */
     public ClientManageController(EventMeshTCPServer eventMeshTCPServer,
         EventMeshHTTPServer eventMeshHTTPServer,

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/controller/ClientManageController.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/controller/ClientManageController.java
@@ -58,6 +58,13 @@ import com.sun.net.httpserver.HttpServer;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * This class is responsible for managing the client connections
+ * and initializing the client handlers.
+ * <p>
+ * It starts the AdminController for managing the event store or MQ.
+ */
+
 @SuppressWarnings("restriction")
 @Slf4j
 public class ClientManageController {
@@ -73,6 +80,14 @@ public class ClientManageController {
     @Setter
     private AdminWebHookConfigOperationManager adminWebHookConfigOperationManage;
 
+    /**
+     * Constructs a new ClientManageController with the given server instance.
+     *
+     * @param eventMeshTCPServer the TCP server for EventMesh
+     * @param eventMeshHTTPServer the HTTP server for EventMesh
+     * @param eventMeshGrpcServer the gRPC server for EventMesh
+     * @param eventMeshRegistry the registry adaptor for EventMesh
+     */
     public ClientManageController(EventMeshTCPServer eventMeshTCPServer,
         EventMeshHTTPServer eventMeshHTTPServer,
         EventMeshGrpcServer eventMeshGrpcServer,
@@ -81,10 +96,13 @@ public class ClientManageController {
         this.eventMeshHTTPServer = eventMeshHTTPServer;
         this.eventMeshGrpcServer = eventMeshGrpcServer;
         this.eventMeshRegistry = eventMeshRegistry;
-
     }
 
-
+    /**
+     * Invoke this method to start this controller on the specified port.
+     *
+     * @throws IOException if an I/O error occurs while starting the server
+     */
     public void start() throws IOException {
         int port = eventMeshTCPServer.getEventMeshTCPConfiguration().getEventMeshServerAdminPort();
         HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/controller/HttpHandlerManager.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/controller/HttpHandlerManager.java
@@ -26,8 +26,9 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 
 /**
- * httpHandlerManager
+ * This class manages the registration of {@link HttpHandler} for an HttpServer.
  */
+
 public class HttpHandlerManager {
 
     private final List<HttpHandler> httpHandlers = new ArrayList<>();
@@ -36,6 +37,16 @@ public class HttpHandlerManager {
         this.httpHandlers.add(httpHandler);
     }
 
+    /**
+     * Registers multiple HTTP handlers to a given HttpServer.
+     * <p>
+     * Each HTTP handler is annotated with the @EventHttpHandler annotation,
+     * which specifies the path where the handler should be registered.
+     *
+     * @param server A HttpServer object that is bound to an IP address and port number
+     *               and listens for incoming TCP connections from clients on this address.
+     *               The registered HTTP handlers will be associated with this server.
+     */
     public void registerHttpHandler(HttpServer server) {
         httpHandlers.forEach(httpHandler -> {
             EventHttpHandler eventHttpHandler = httpHandler.getClass().getAnnotation(EventHttpHandler.class);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/controller/HttpHandlerManager.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/controller/HttpHandlerManager.java
@@ -33,6 +33,11 @@ public class HttpHandlerManager {
 
     private final List<HttpHandler> httpHandlers = new ArrayList<>();
 
+    /**
+     * Registers an HTTP handler.
+     *
+     * @param httpHandler The {@link HttpHandler} to be registered.
+     */
     public void register(HttpHandler httpHandler) {
         this.httpHandlers.add(httpHandler);
     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/controller/HttpHandlerManager.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/controller/HttpHandlerManager.java
@@ -26,7 +26,8 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 
 /**
- * This class manages the registration of {@link HttpHandler} for an {@link HttpServer}.
+ * This class manages the registration of {@linkplain com.sun.net.httpserver.HttpHandler HttpHandler}
+ * for an {@linkplain com.sun.net.httpserver.HttpServer HttpServer}.
  */
 
 public class HttpHandlerManager {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/controller/HttpHandlerManager.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/controller/HttpHandlerManager.java
@@ -26,7 +26,7 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 
 /**
- * This class manages the registration of {@link HttpHandler} for an HttpServer.
+ * This class manages the registration of {@link HttpHandler} for an {@link HttpServer}.
  */
 
 public class HttpHandlerManager {
@@ -37,6 +37,8 @@ public class HttpHandlerManager {
      * Registers an HTTP handler.
      *
      * @param httpHandler The {@link HttpHandler} to be registered.
+     *                    A handler which is invoked to process HTTP exchanges.
+     *                    Each HTTP exchange is handled by one of these handlers.
      */
     public void register(HttpHandler httpHandler) {
         this.httpHandlers.add(httpHandler);
@@ -45,7 +47,7 @@ public class HttpHandlerManager {
     /**
      * Registers multiple HTTP handlers to a given HttpServer.
      * <p>
-     * Each HTTP handler is annotated with the @EventHttpHandler annotation,
+     * Each HTTP handler is annotated with the {@link EventHttpHandler} annotation,
      * which specifies the path where the handler should be registered.
      *
      * @param server A HttpServer object that is bound to an IP address and port number

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/AbstractHttpHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/AbstractHttpHandler.java
@@ -24,8 +24,12 @@ import com.sun.net.httpserver.HttpHandler;
 import lombok.Data;
 
 /**
- * AbstractHttpHandler
+ * An abstract class that implements the {@link HttpHandler} interface
+ * and provides basic functionality for HTTP request handling.
+ * <p>
+ * Subclasses should extend this class to implement specific HTTP request handling logic.
  */
+
 @Data
 public abstract class AbstractHttpHandler implements HttpHandler {
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/ConfigurationHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/ConfigurationHandler.java
@@ -59,7 +59,7 @@ public class ConfigurationHandler extends AbstractHttpHandler {
     private final EventMeshGrpcConfiguration eventMeshGrpcConfiguration;
 
     /**
-     * Constructs a new ConfigurationHandler with the provided configurations and HTTP handler manager.
+     * Constructs a new instance with the provided configurations and HTTP handler manager.
      *
      * @param eventMeshTCPConfiguration the TCP configuration for EventMesh
      * @param eventMeshHTTPConfiguration the HTTP configuration for EventMesh

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/ConfigurationHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/ConfigurationHandler.java
@@ -41,8 +41,18 @@ import com.sun.net.httpserver.HttpExchange;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * The config handler
+ * This class handles the {@code /configuration} endpoint,
+ * corresponding to the {@code eventmesh-dashboard} path {@code /}.
+ * <p>
+ * This handler is responsible for retrieving the current configuration information of the EventMesh node,
+ * including service name, service environment, and listening ports for various protocols.
+ * <p>
+ * It is an implementation of the {@link AbstractHttpHandler} class
+ * and the {@link #handle} method is implemented by the HttpHandler.
+ *
+ * @see com.sun.net.httpserver.HttpHandler
  */
+
 @Slf4j
 @EventHttpHandler(path = "/configuration")
 public class ConfigurationHandler extends AbstractHttpHandler {
@@ -51,6 +61,15 @@ public class ConfigurationHandler extends AbstractHttpHandler {
     private final EventMeshHTTPConfiguration eventMeshHTTPConfiguration;
     private final EventMeshGrpcConfiguration eventMeshGrpcConfiguration;
 
+    /**
+     * Constructs a new ConfigurationHandler with the provided configurations and HTTP handler manager.
+     *
+     * @param eventMeshTCPConfiguration the TCP configuration for EventMesh
+     * @param eventMeshHTTPConfiguration the HTTP configuration for EventMesh
+     * @param eventMeshGrpcConfiguration the gRPC configuration for EventMesh
+     * @param httpHandlerManager Manages the registration of {@linkplain com.sun.net.httpserver.HttpHandler HttpHandler}
+     *                           for an {@link com.sun.net.httpserver.HttpServer HttpServer}.
+     */
     public ConfigurationHandler(
         EventMeshTCPConfiguration eventMeshTCPConfiguration,
         EventMeshHTTPConfiguration eventMeshHTTPConfiguration,
@@ -64,7 +83,13 @@ public class ConfigurationHandler extends AbstractHttpHandler {
     }
 
     /**
-     * OPTIONS /configuration
+     * Handles the OPTIONS request for {@code /configuration}.
+     * <p>
+     * This method adds CORS (Cross-Origin Resource Sharing) response headers to the {@link HttpExchange} object
+     * and sends a 200 status code.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void preflight(HttpExchange httpExchange) throws IOException {
         httpExchange.getResponseHeaders().add(EventMeshConstants.HANDLER_ORIGIN, "*");
@@ -77,7 +102,12 @@ public class ConfigurationHandler extends AbstractHttpHandler {
     }
 
     /**
-     * GET /config Return a response that contains the EventMesh configuration
+     * Handles the GET request for {@code /configuration}.
+     * <p>
+     * This method retrieves the EventMesh configuration information and returns it as a JSON response.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void get(HttpExchange httpExchange) throws IOException {
         httpExchange.getResponseHeaders().add(EventMeshConstants.CONTENT_TYPE, EventMeshConstants.APPLICATION_JSON);
@@ -123,6 +153,15 @@ public class ConfigurationHandler extends AbstractHttpHandler {
         }
     }
 
+    /**
+     * Handles the HTTP requests for {@code /configuration}.
+     * <p>
+     * It delegates the handling to {@code preflight()} or {@code get()} methods
+     * based on the request method type (OPTIONS or GET).
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
+     */
     @Override
     public void handle(HttpExchange httpExchange) throws IOException {
         switch (HttpMethod.valueOf(httpExchange.getRequestMethod())) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/ConfigurationHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/ConfigurationHandler.java
@@ -46,11 +46,8 @@ import lombok.extern.slf4j.Slf4j;
  * <p>
  * This handler is responsible for retrieving the current configuration information of the EventMesh node,
  * including service name, service environment, and listening ports for various protocols.
- * <p>
- * It is an implementation of the {@link AbstractHttpHandler} class
- * and the {@link #handle} method is implemented by the HttpHandler.
  *
- * @see com.sun.net.httpserver.HttpHandler
+ * @see AbstractHttpHandler
  */
 
 @Slf4j
@@ -83,10 +80,10 @@ public class ConfigurationHandler extends AbstractHttpHandler {
     }
 
     /**
-     * Handles the OPTIONS request for {@code /configuration}.
+     * Handles the OPTIONS request first for {@code /configuration}.
      * <p>
-     * This method adds CORS (Cross-Origin Resource Sharing) response headers to the {@link HttpExchange} object
-     * and sends a 200 status code.
+     * This method adds CORS (Cross-Origin Resource Sharing) response headers to
+     * the {@link HttpExchange} object and sends a 200 status code.
      *
      * @param httpExchange the exchange containing the request from the client and used to send the response
      * @throws IOException if an I/O error occurs while handling the request
@@ -158,6 +155,8 @@ public class ConfigurationHandler extends AbstractHttpHandler {
      * <p>
      * It delegates the handling to {@code preflight()} or {@code get()} methods
      * based on the request method type (OPTIONS or GET).
+     * <p>
+     * This method is an implementation of {@linkplain com.sun.net.httpserver.HttpHandler#handle(HttpExchange)  HttpHandler.handle()}
      *
      * @param httpExchange the exchange containing the request from the client and used to send the response
      * @throws IOException if an I/O error occurs while handling the request

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/EventHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/EventHandler.java
@@ -47,14 +47,34 @@ import com.sun.net.httpserver.HttpExchange;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * The event handler
+ * This class handles the {@code /event} endpoint,
+ * corresponding to the {@code eventmesh-dashboard} path {@code /event}.
+ * <p>
+ * It is responsible for managing operations on events,
+ * including retrieving the event list and creating events.
+ * <p>
+ * The GET method supports querying events by {@code topicName},
+ * and uses {@code offset} and {@code length} parameters for pagination.
+ * <p>
+ * An instance of {@link MQAdminWrapper} is used to interact with the messaging system.
+ *
+ * @see AbstractHttpHandler
+ * @see MQAdminWrapper
  */
+
 @Slf4j
 @EventHttpHandler(path = "/event")
 public class EventHandler extends AbstractHttpHandler {
 
     private final MQAdminWrapper admin;
 
+    /**
+     * Constructs a new instance with the specified connector plugin type and HTTP handler manager.
+     *
+     * @param connectorPluginType The name of event storage connector plugin.
+     * @param httpHandlerManager httpHandlerManager Manages the registration of {@linkplain com.sun.net.httpserver.HttpHandler HttpHandler}
+     *                           for an {@link com.sun.net.httpserver.HttpServer HttpServer}.
+     */
     public EventHandler(
         String connectorPluginType,
         HttpHandlerManager httpHandlerManager
@@ -69,7 +89,13 @@ public class EventHandler extends AbstractHttpHandler {
     }
 
     /**
-     * OPTIONS /event
+     * Handles the OPTIONS request first for {@code /event}.
+     * <p>
+     * This method adds CORS (Cross-Origin Resource Sharing) response headers to
+     * the {@link HttpExchange} object and sends a 200 status code.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void preflight(HttpExchange httpExchange) throws IOException {
         httpExchange.getResponseHeaders().add(EventMeshConstants.HANDLER_ORIGIN, "*");
@@ -81,6 +107,17 @@ public class EventHandler extends AbstractHttpHandler {
         out.close();
     }
 
+    /**
+     * Converts a query string to a map of key-value pairs.
+     * <p>
+     * This method takes a query string and parses it to create a map of key-value pairs,
+     * where each key and value are extracted from the query string separated by '='.
+     * <p>
+     * If the query string is null, an empty map is returned.
+     *
+     * @param query the query string to convert to a map
+     * @return a map containing the key-value pairs from the query string
+     */
     private Map<String, String> queryToMap(String query) {
         if (query == null) {
             return new HashMap<>();
@@ -98,7 +135,12 @@ public class EventHandler extends AbstractHttpHandler {
     }
 
     /**
-     * GET /event Return the list of event
+     * Handles the GET request for {@code /event}.
+     * <p>
+     * This method retrieves the list of events from the {@link MQAdminWrapper} and returns it as a JSON response.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void get(HttpExchange httpExchange) {
         httpExchange.getResponseHeaders().add(EventMeshConstants.CONTENT_TYPE, EventMeshConstants.APPLICATION_JSON);
@@ -147,7 +189,12 @@ public class EventHandler extends AbstractHttpHandler {
     }
 
     /**
-     * POST /event Create an event
+     * Handles the POST request for {@code /event}.
+     * <p>
+     * This method creates an event based on the request data, then returns {@code 200 OK}.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void post(HttpExchange httpExchange) {
         httpExchange.getResponseHeaders().add(EventMeshConstants.CONTENT_TYPE, EventMeshConstants.APPLICATION_JSON);
@@ -179,6 +226,17 @@ public class EventHandler extends AbstractHttpHandler {
         }
     }
 
+    /**
+     * Handles the HTTP requests for {@code /event}.
+     * <p>
+     * It delegates the handling to {@code preflight()}, {@code get()} or {@code post()} methods
+     * based on the request method type (OPTIONS, GET or POST).
+     * <p>
+     * This method is an implementation of {@linkplain com.sun.net.httpserver.HttpHandler#handle(HttpExchange)  HttpHandler.handle()}.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
+     */
     @Override
     public void handle(HttpExchange httpExchange) throws IOException {
         switch (HttpMethod.valueOf(httpExchange.getRequestMethod())) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/HTTPClientHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/HTTPClientHandler.java
@@ -45,14 +45,29 @@ import com.sun.net.httpserver.HttpExchange;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * The client handler
+ * This class handles the {@code /client/http} endpoint,
+ * corresponding to the {@code eventmesh-dashboard} path {@code /http}.
+ * <p>
+ * It is responsible for managing operations on HTTP clients,
+ * including retrieving the information list of connected HTTP clients
+ * and deleting HTTP clients by disconnecting their connections based on the provided host and port.
+ *
+ * @see AbstractHttpHandler
  */
+
 @Slf4j
 @EventHttpHandler(path = "/client/http")
 public class HTTPClientHandler extends AbstractHttpHandler {
 
     private final EventMeshHTTPServer eventMeshHTTPServer;
 
+    /**
+     * Constructs a new instance with the provided server instance and HTTP handler manager.
+     *
+     * @param eventMeshHTTPServer  the HTTP server instance of EventMesh
+     * @param httpHandlerManager  Manages the registration of {@linkplain com.sun.net.httpserver.HttpHandler HttpHandler}
+     *                            for an {@link com.sun.net.httpserver.HttpServer HttpServer}.
+     */
     public HTTPClientHandler(
         EventMeshHTTPServer eventMeshHTTPServer, HttpHandlerManager httpHandlerManager
     ) {
@@ -61,7 +76,13 @@ public class HTTPClientHandler extends AbstractHttpHandler {
     }
 
     /**
-     * OPTIONS /client
+     * Handles the OPTIONS request first for {@code /client/http}.
+     * <p>
+     * This method adds CORS (Cross-Origin Resource Sharing) response headers to
+     * the {@link HttpExchange} object and sends a 200 status code.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void preflight(HttpExchange httpExchange) throws IOException {
         httpExchange.getResponseHeaders().add(EventMeshConstants.HANDLER_ORIGIN, "*");
@@ -74,7 +95,13 @@ public class HTTPClientHandler extends AbstractHttpHandler {
     }
 
     /**
-     * DELETE /client/http
+     * Handles the DELETE request for {@code /client/http}.
+     * <p>
+     * This method deletes a connected HTTP client by disconnecting their connections
+     * based on the provided host and port, then returns {@code 200 OK}.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void delete(HttpExchange httpExchange) throws IOException {
         try (OutputStream out = httpExchange.getResponseBody()) {
@@ -103,10 +130,16 @@ public class HTTPClientHandler extends AbstractHttpHandler {
     }
 
     /**
-     * GET /client/http Return a response that contains the list of clients
+     * Handles the GET request for {@code /client/http}.
+     * <p>
+     * This method retrieves the list of connected HTTP clients and returns it as a JSON response.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void list(HttpExchange httpExchange) throws IOException {
         OutputStream out = httpExchange.getResponseBody();
+        // Set the response headers
         httpExchange.getResponseHeaders().add(EventMeshConstants.CONTENT_TYPE, EventMeshConstants.APPLICATION_JSON);
         httpExchange.getResponseHeaders().add(EventMeshConstants.HANDLER_ORIGIN, "*");
 
@@ -115,6 +148,7 @@ public class HTTPClientHandler extends AbstractHttpHandler {
             List<GetClientResponse> getClientResponseList = new ArrayList<>();
 
             for (List<Client> clientList : eventMeshHTTPServer.getSubscriptionManager().getLocalClientInfoMapping().values()) {
+                // Convert each Client object to GetClientResponse and add to getClientResponseList
                 for (Client client : clientList) {
                     GetClientResponse getClientResponse = new GetClientResponse(
                         Optional.ofNullable(client.getEnv()).orElse(""),
@@ -134,6 +168,7 @@ public class HTTPClientHandler extends AbstractHttpHandler {
                 }
             }
 
+            // Sort the getClientResponseList by host and port
             getClientResponseList.sort((lhs, rhs) -> {
                 if (lhs.getHost().equals(rhs.getHost())) {
                     return lhs.getHost().compareTo(rhs.getHost());
@@ -141,6 +176,7 @@ public class HTTPClientHandler extends AbstractHttpHandler {
                 return Integer.compare(rhs.getPort(), lhs.getPort());
             });
 
+            // Convert getClientResponseList to JSON and send the response
             String result = JsonUtils.toJSONString(getClientResponseList);
             httpExchange.sendResponseHeaders(200, Objects.requireNonNull(result).getBytes(Constants.DEFAULT_CHARSET).length);
             out.write(result.getBytes(Constants.DEFAULT_CHARSET));
@@ -166,6 +202,17 @@ public class HTTPClientHandler extends AbstractHttpHandler {
         }
     }
 
+    /**
+     * Handles the HTTP requests for {@code /client/http}.
+     * <p>
+     * It delegates the handling to {@code preflight()}, {@code list()} or {@code delete()} methods
+     * based on the request method type (OPTIONS, GET or DELETE).
+     * <p>
+     * This method is an implementation of {@linkplain com.sun.net.httpserver.HttpHandler#handle(HttpExchange)  HttpHandler.handle()}.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
+     */
     @Override
     public void handle(HttpExchange httpExchange) throws IOException {
         switch (HttpMethod.valueOf(httpExchange.getRequestMethod())) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/HTTPClientHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/HTTPClientHandler.java
@@ -64,9 +64,9 @@ public class HTTPClientHandler extends AbstractHttpHandler {
     /**
      * Constructs a new instance with the provided server instance and HTTP handler manager.
      *
-     * @param eventMeshHTTPServer  the HTTP server instance of EventMesh
-     * @param httpHandlerManager  Manages the registration of {@linkplain com.sun.net.httpserver.HttpHandler HttpHandler}
-     *                            for an {@link com.sun.net.httpserver.HttpServer HttpServer}.
+     * @param eventMeshHTTPServer the HTTP server instance of EventMesh
+     * @param httpHandlerManager  Manages the registration of {@linkplain com.sun.net.httpserver.HttpHandler HttpHandler} for an
+     *                            {@link com.sun.net.httpserver.HttpServer HttpServer}.
      */
     public HTTPClientHandler(
         EventMeshHTTPServer eventMeshHTTPServer, HttpHandlerManager httpHandlerManager
@@ -105,14 +105,17 @@ public class HTTPClientHandler extends AbstractHttpHandler {
      */
     void delete(HttpExchange httpExchange) throws IOException {
         try (OutputStream out = httpExchange.getResponseBody()) {
+            // Parse the request body string into a DeleteHTTPClientRequest object
             String request = HttpExchangeUtils.streamToString(httpExchange.getRequestBody());
             DeleteHTTPClientRequest deleteHTTPClientRequest = JsonUtils.parseObject(request, DeleteHTTPClientRequest.class);
             String url = Objects.requireNonNull(deleteHTTPClientRequest).getUrl();
 
             for (List<Client> clientList : eventMeshHTTPServer.getSubscriptionManager().getLocalClientInfoMapping().values()) {
+                // Find the client that matches the url to be deleted
                 clientList.removeIf(client -> Objects.equals(client.getUrl(), url));
             }
 
+            // Set the response headers and send a 200 status code empty response
             httpExchange.getResponseHeaders().add(EventMeshConstants.HANDLER_ORIGIN, "*");
             httpExchange.sendResponseHeaders(200, 0);
         } catch (Exception e) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/MetricsHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/MetricsHandler.java
@@ -58,6 +58,14 @@ public class MetricsHandler extends AbstractHttpHandler {
     private final HttpSummaryMetrics httpSummaryMetrics;
     private final TcpSummaryMetrics tcpSummaryMetrics;
 
+    /**
+     * Constructs a new instance with the provided EventMesh server instance and HTTP handler manager.
+     *
+     * @param eventMeshHTTPServer the HTTP server instance of EventMesh
+     * @param eventMeshTcpServer the TCP server instance of EventMesh
+     * @param httpHandlerManager Manages the registration of {@linkplain com.sun.net.httpserver.HttpHandler HttpHandler}
+     *                           for an {@link com.sun.net.httpserver.HttpServer HttpServer}.
+     */
     public MetricsHandler(EventMeshHTTPServer eventMeshHTTPServer,
         EventMeshTCPServer eventMeshTcpServer,
         HttpHandlerManager httpHandlerManager) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/MetricsHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/MetricsHandler.java
@@ -41,6 +41,16 @@ import com.sun.net.httpserver.HttpExchange;
 
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * This class handles the {@code /metrics} endpoint,
+ * corresponding to the {@code eventmesh-dashboard} path {@code /metrics}.
+ * <p>
+ * This handler is responsible for retrieving summary information of metrics,
+ * including HTTP and TCP metrics.
+ *
+ * @see AbstractHttpHandler
+ */
+
 @Slf4j
 @EventHttpHandler(path = "/metrics")
 public class MetricsHandler extends AbstractHttpHandler {
@@ -57,7 +67,13 @@ public class MetricsHandler extends AbstractHttpHandler {
     }
 
     /**
-     * OPTIONS /metrics
+     * Handles the OPTIONS request first for {@code /metrics}.
+     * <p>
+     * This method adds CORS (Cross-Origin Resource Sharing) response headers to
+     * the {@link HttpExchange} object and sends a 200 status code.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void preflight(HttpExchange httpExchange) throws IOException {
         httpExchange.getResponseHeaders().add(EventMeshConstants.HANDLER_ORIGIN, "*");
@@ -70,7 +86,12 @@ public class MetricsHandler extends AbstractHttpHandler {
     }
 
     /**
-     * GET /metrics Return a response that contains a summary of metrics
+     * Handles the GET request for {@code /metrics}.
+     * <p>
+     * This method retrieves the EventMesh metrics summary and returns it as a JSON response.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void get(HttpExchange httpExchange) throws IOException {
         OutputStream out = httpExchange.getResponseBody();
@@ -149,7 +170,17 @@ public class MetricsHandler extends AbstractHttpHandler {
         }
     }
 
-
+    /**
+     * Handles the HTTP requests for {@code /metrics}.
+     * <p>
+     * It delegates the handling to {@code preflight()} or {@code get()} methods
+     * based on the request method type (OPTIONS or GET).
+     * <p>
+     * This method is an implementation of {@linkplain com.sun.net.httpserver.HttpHandler#handle(HttpExchange)  HttpHandler.handle()}
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
+     */
     @Override
     public void handle(HttpExchange httpExchange) throws IOException {
         switch (HttpMethod.valueOf(httpExchange.getRequestMethod())) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/RegistryHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/RegistryHandler.java
@@ -60,7 +60,7 @@ public class RegistryHandler extends AbstractHttpHandler {
     private final Registry eventMeshRegistry;
 
     /**
-     * Constructs a new {@link RegistryHandler} instance with the specified {@link Registry} and {@link HttpHandlerManager}.
+     * Constructs a new instance with the specified {@link Registry} and {@link HttpHandlerManager}.
      *
      * @param eventMeshRegistry  The {@link Registry} instance used for retrieving EventMesh cluster information.
      * @param httpHandlerManager Manages the registration of {@linkplain com.sun.net.httpserver.HttpHandler HttpHandler}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/RegistryHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/RegistryHandler.java
@@ -42,12 +42,30 @@ import com.sun.net.httpserver.HttpExchange;
 
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * This class handles the {@code /registry} endpoint,
+ * corresponding to the {@code eventmesh-dashboard} path {@code /registry}.
+ * <p>
+ * This handler is responsible for retrieving a list of EventMesh clusters from the
+ * {@link Registry} object, encapsulate them into a list of {@link GetRegistryResponse} objects,
+ * and sort them by {@code EventMeshClusterName}.
+ *
+ * @see AbstractHttpHandler
+ */
+
 @Slf4j
 @EventHttpHandler(path = "/registry")
 public class RegistryHandler extends AbstractHttpHandler {
 
     private final Registry eventMeshRegistry;
 
+    /**
+     * Constructs a new {@link RegistryHandler} instance with the specified {@link Registry} and {@link HttpHandlerManager}.
+     *
+     * @param eventMeshRegistry  The {@link Registry} instance used for retrieving EventMesh cluster information.
+     * @param httpHandlerManager Manages the registration of {@linkplain com.sun.net.httpserver.HttpHandler HttpHandler}
+     *                           for an {@linkplain com.sun.net.httpserver.HttpServer HttpServer}.
+     */
     public RegistryHandler(Registry eventMeshRegistry,
         HttpHandlerManager httpHandlerManager) {
         super(httpHandlerManager);
@@ -55,7 +73,13 @@ public class RegistryHandler extends AbstractHttpHandler {
     }
 
     /**
-     * OPTION /registry
+     * Handles the OPTIONS request first for {@code /registry}.
+     * <p>
+     * This method adds CORS (Cross-Origin Resource Sharing) response headers to
+     * the {@link HttpExchange} object and sends a 200 status code.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void preflight(HttpExchange httpExchange) throws IOException {
         httpExchange.getResponseHeaders().add(EventMeshConstants.HANDLER_ORIGIN, "*");
@@ -67,7 +91,12 @@ public class RegistryHandler extends AbstractHttpHandler {
     }
 
     /**
-     * GET /registry Return a response that contains the list of EventMesh clusters
+     * Handles the GET request for {@code /registry}.
+     * <p>
+     * This method retrieves a list of EventMesh clusters and returns it as a JSON response.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void get(HttpExchange httpExchange) throws IOException {
         OutputStream out = httpExchange.getResponseBody();
@@ -119,6 +148,17 @@ public class RegistryHandler extends AbstractHttpHandler {
         }
     }
 
+    /**
+     * Handles the HTTP requests for {@code /registry}.
+     * <p>
+     * It delegates the handling to {@code preflight()} or {@code get()} methods
+     * based on the request method type (OPTIONS or GET).
+     * <p>
+     * This method is an implementation of {@linkplain com.sun.net.httpserver.HttpHandler#handle(HttpExchange)  HttpHandler.handle()}
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
+     */
     @Override
     public void handle(HttpExchange httpExchange) throws IOException {
         switch (HttpMethod.valueOf(httpExchange.getRequestMethod())) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/TCPClientHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/TCPClientHandler.java
@@ -51,14 +51,29 @@ import com.sun.net.httpserver.HttpExchange;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * The client handler
+ * This class handles the {@code /client/tcp} endpoint,
+ * corresponding to the {@code eventmesh-dashboard} path {@code /tcp}.
+ * <p>
+ * It is responsible for managing operations on TCP clients,
+ * including retrieving the information list of connected TCP clients
+ * and deleting TCP clients by disconnecting their connections based on the provided host and port.
+ *
+ * @see AbstractHttpHandler
  */
+
 @Slf4j
 @EventHttpHandler(path = "/client/tcp")
 public class TCPClientHandler extends AbstractHttpHandler {
 
     private final EventMeshTCPServer eventMeshTCPServer;
 
+    /**
+     * Constructs a new instance with the provided server instance and HTTP handler manager.
+     *
+     * @param eventMeshTCPServer  the TCP server instance of EventMesh
+     * @param httpHandlerManager  Manages the registration of {@linkplain com.sun.net.httpserver.HttpHandler HttpHandler}
+     *                            for an {@link com.sun.net.httpserver.HttpServer HttpServer}.
+     */
     public TCPClientHandler(
         EventMeshTCPServer eventMeshTCPServer, HttpHandlerManager httpHandlerManager
     ) {
@@ -67,7 +82,13 @@ public class TCPClientHandler extends AbstractHttpHandler {
     }
 
     /**
-     * OPTIONS /client
+     * Handles the OPTIONS request first for {@code /client/tcp}.
+     * <p>
+     * This method adds CORS (Cross-Origin Resource Sharing) response headers to
+     * the {@link HttpExchange} object and sends a 200 status code.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void preflight(HttpExchange httpExchange) throws IOException {
         httpExchange.getResponseHeaders().add(EventMeshConstants.HANDLER_ORIGIN, "*");
@@ -80,11 +101,18 @@ public class TCPClientHandler extends AbstractHttpHandler {
     }
 
     /**
-     * DELETE /client/tcp
+     * Handles the DELETE request for {@code /client/tcp}.
+     * <p>
+     * This method deletes a connected TCP client by disconnecting their connections
+     * based on the provided host and port, then returns {@code 200 OK}.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void delete(HttpExchange httpExchange) throws IOException {
         
         try (OutputStream out = httpExchange.getResponseBody()) {
+            // Parse the request body string into a DeleteTCPClientRequest object
             String request = HttpExchangeUtils.streamToString(httpExchange.getRequestBody());
             DeleteTCPClientRequest deleteTCPClientRequest = JsonUtils.parseObject(request, DeleteTCPClientRequest.class);
             String host = Objects.requireNonNull(deleteTCPClientRequest).getHost();
@@ -94,7 +122,9 @@ public class TCPClientHandler extends AbstractHttpHandler {
             ConcurrentHashMap<InetSocketAddress, Session> sessionMap = clientSessionGroupMapping.getSessionMap();
             if (!sessionMap.isEmpty()) {
                 for (Map.Entry<InetSocketAddress, Session> entry : sessionMap.entrySet()) {
+                    // Find the Session object that matches the host and port to be deleted
                     if (entry.getKey().getHostString().equals(host) && entry.getKey().getPort() == port) {
+                        // Call the serverGoodby2Client method in EventMeshTcp2Client to disconnect the client's connection
                         EventMeshTcp2Client.serverGoodby2Client(
                             eventMeshTCPServer,
                             entry.getValue(),
@@ -104,6 +134,7 @@ public class TCPClientHandler extends AbstractHttpHandler {
                 }
             }
 
+            // Set the response headers and send a 200 status code empty response
             httpExchange.getResponseHeaders().add(EventMeshConstants.HANDLER_ORIGIN, "*");
             httpExchange.sendResponseHeaders(200, 0);
         } catch (Exception e) {
@@ -121,17 +152,24 @@ public class TCPClientHandler extends AbstractHttpHandler {
     }
 
     /**
-     * GET /client/tcp Return a response that contains the list of clients
+     * Handles the GET request for {@code /client/tcp}.
+     * <p>
+     * This method retrieves the list of connected TCP clients and returns it as a JSON response.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void list(HttpExchange httpExchange) throws IOException {
 
         try (OutputStream out = httpExchange.getResponseBody()) {
+            // Set the response headers
             httpExchange.getResponseHeaders().add(EventMeshConstants.CONTENT_TYPE, EventMeshConstants.APPLICATION_JSON);
             httpExchange.getResponseHeaders().add(EventMeshConstants.HANDLER_ORIGIN, "*");
-            // Get the list of TCP clients
+            // Get the list of connected TCP clients
             ClientSessionGroupMapping clientSessionGroupMapping = eventMeshTCPServer.getClientSessionGroupMapping();
             Map<InetSocketAddress, Session> sessionMap = clientSessionGroupMapping.getSessionMap();
             List<GetClientResponse> getClientResponseList = new ArrayList<>();
+            // Convert each Session object to GetClientResponse and add to getClientResponseList
             for (Session session : sessionMap.values()) {
                 UserAgent userAgent = session.getClient();
                 GetClientResponse getClientResponse = new GetClientResponse(
@@ -150,6 +188,7 @@ public class TCPClientHandler extends AbstractHttpHandler {
                 getClientResponseList.add(getClientResponse);
             }
 
+            // Sort the getClientResponseList by host and port
             getClientResponseList.sort((lhs, rhs) -> {
                 if (lhs.getHost().equals(rhs.getHost())) {
                     return lhs.getHost().compareTo(rhs.getHost());
@@ -157,6 +196,7 @@ public class TCPClientHandler extends AbstractHttpHandler {
                 return Integer.compare(rhs.getPort(), lhs.getPort());
             });
 
+            // Convert getClientResponseList to JSON and send the response
             String result = JsonUtils.toJSONString(getClientResponseList);
             httpExchange.sendResponseHeaders(200, Objects.requireNonNull(result).getBytes(Constants.DEFAULT_CHARSET).length);
             out.write(result.getBytes(Constants.DEFAULT_CHARSET));
@@ -174,6 +214,17 @@ public class TCPClientHandler extends AbstractHttpHandler {
         } 
     }
 
+    /**
+     * Handles the HTTP requests for {@code /client/tcp}.
+     * <p>
+     * It delegates the handling to {@code preflight()}, {@code list()} or {@code delete()} methods
+     * based on the request method type (OPTIONS, GET or DELETE).
+     * <p>
+     * This method is an implementation of {@linkplain com.sun.net.httpserver.HttpHandler#handle(HttpExchange)  HttpHandler.handle()}.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
+     */
     @Override
     public void handle(HttpExchange httpExchange) throws IOException {
         switch (HttpMethod.valueOf(httpExchange.getRequestMethod())) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/TopicHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/TopicHandler.java
@@ -199,7 +199,7 @@ public class TopicHandler extends AbstractHttpHandler {
     /**
      * Handles the HTTP requests for {@code /topic}.
      * <p>
-     * It delegates the handling to {@code preflight()}, {@code get()}, {@code post()}, or {@code delete()} methods
+     * It delegates the handling to {@code preflight()}, {@code get()}, {@code post()} or {@code delete()} methods
      * based on the request method type (OPTIONS, GET, POST or DELETE).
      * <p>
      * This method is an implementation of {@linkplain com.sun.net.httpserver.HttpHandler#handle(HttpExchange)  HttpHandler.handle()}.

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/TopicHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/TopicHandler.java
@@ -43,14 +43,32 @@ import com.sun.net.httpserver.HttpExchange;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * The topic handler
+ * This class handles the {@code /topic} endpoint,
+ * corresponding to the {@code eventmesh-dashboard} path {@code /topic},
+ * including the "Create Topic" and "Remove" buttons.
+ * <p>
+ * It provides functionality for managing topics, including retrieving the list of topics (GET),
+ * creating a new topic (POST), and deleting an existing topic (DELETE).
+ * <p>
+ * An instance of {@link MQAdminWrapper} is used to interact with the messaging system.
+ *
+ * @see AbstractHttpHandler
+ * @see MQAdminWrapper
  */
+
 @Slf4j
 @EventHttpHandler(path = "/topic")
 public class TopicHandler extends AbstractHttpHandler {
 
     private final MQAdminWrapper admin;
 
+    /**
+     * Constructs a new instance with the specified connector plugin type and HTTP handler manager.
+     *
+     * @param connectorPluginType The name of event storage connector plugin.
+     * @param httpHandlerManager httpHandlerManager Manages the registration of {@linkplain com.sun.net.httpserver.HttpHandler HttpHandler}
+     *                           for an {@link com.sun.net.httpserver.HttpServer HttpServer}.
+     */
     public TopicHandler(
         String connectorPluginType,
         HttpHandlerManager httpHandlerManager
@@ -65,7 +83,13 @@ public class TopicHandler extends AbstractHttpHandler {
     }
 
     /**
-     * OPTIONS /topic
+     * Handles the OPTIONS request first for {@code /topic}.
+     * <p>
+     * This method adds CORS (Cross-Origin Resource Sharing) response headers to
+     * the {@link HttpExchange} object and sends a 200 status code.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void preflight(HttpExchange httpExchange) throws IOException {
         httpExchange.getResponseHeaders().add(EventMeshConstants.HANDLER_ORIGIN, "*");
@@ -78,7 +102,12 @@ public class TopicHandler extends AbstractHttpHandler {
     }
 
     /**
-     * GET /topic Return a response that contains the list of topics
+     * Handles the GET request for {@code /topic}.
+     * <p>
+     * This method retrieves the list of topics from the {@link MQAdminWrapper} and returns it as a JSON response.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void get(HttpExchange httpExchange) throws IOException {
 
@@ -104,7 +133,12 @@ public class TopicHandler extends AbstractHttpHandler {
     }
 
     /**
-     * POST /topic Create a topic if it doesn't exist
+     * Handles the POST request for {@code /topic}.
+     * <p>
+     * This method creates a topic if it doesn't exist based on the request data, then returns {@code 200 OK}.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void post(HttpExchange httpExchange) throws IOException {
 
@@ -131,7 +165,12 @@ public class TopicHandler extends AbstractHttpHandler {
     }
 
     /**
-     * DELETE /topic Delete a topic if it exists
+     * Handles the DELETE request for {@code /topic}.
+     * <p>
+     * This method deletes a topic if it exists based on the request data, then returns {@code 200 OK}.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
      */
     void delete(HttpExchange httpExchange) throws IOException {
 
@@ -157,6 +196,17 @@ public class TopicHandler extends AbstractHttpHandler {
         }
     }
 
+    /**
+     * Handles the HTTP requests for {@code /topic}.
+     * <p>
+     * It delegates the handling to {@code preflight()}, {@code get()}, {@code post()}, or {@code delete()} methods
+     * based on the request method type (OPTIONS, GET, POST or DELETE).
+     * <p>
+     * This method is an implementation of {@linkplain com.sun.net.httpserver.HttpHandler#handle(HttpExchange)  HttpHandler.handle()}.
+     *
+     * @param httpExchange the exchange containing the request from the client and used to send the response
+     * @throws IOException if an I/O error occurs while handling the request
+     */
     @Override
     public void handle(HttpExchange httpExchange) throws IOException {
         switch (HttpMethod.valueOf(httpExchange.getRequestMethod())) {


### PR DESCRIPTION
Fixes #4208.

### Motivation

Please see https://github.com/apache/eventmesh/issues/4208.

### Modifications

Adds JavaDoc and single-line comments for all the classes and methods included in the eventmesh-dashboard APIs.

Another doc PR for other classes of `org.apache.eventmesh.runtime.admin` package which are not included in the eventmesh-dashboard APIs will be submitted later, in order to make reviewing less difficult.

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
