### PR TITLE
[ISSUE #4215] Correct typos and Remove redundant keyword for AdminWebHookConfigOperationManager

### DIFF
--- a/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/AdminWebHookConfigOperationManager.java
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/AdminWebHookConfigOperationManager.java
@@ -36,7 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class AdminWebHookConfigOperationManager {
 
-    private static final transient Map<String, Class<? extends WebHookConfigOperation>> WEBHOOK_CONFIG_OPERATION_MAP
+    private static final Map<String, Class<? extends WebHookConfigOperation>> WEBHOOK_CONFIG_OPERATION_MAP
         = new HashMap<>();
 
     static {

--- a/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/AdminWebHookConfigOperationManager.java
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/AdminWebHookConfigOperationManager.java
@@ -67,16 +67,19 @@ public class AdminWebHookConfigOperationManager {
 
         final Constructor<? extends WebHookConfigOperation> constructor =
             WEBHOOK_CONFIG_OPERATION_MAP.get(operationMode).getDeclaredConstructor(Properties.class);
-        final boolean oldAccesssible = constructor.isAccessible();
+        // Save the original accessibility of constructor
+        final boolean oldAccessible = constructor.isAccessible();
         try {
             constructor.setAccessible(true);
             final Properties operationProperties = adminConfiguration.getOperationProperties();
             if (log.isInfoEnabled()) {
                 log.info("operationMode is {}  properties is {} ", operationMode, operationProperties);
             }
+            // Affects which implementation of the WebHookConfigOperation interface is used.
             this.webHookConfigOperation = constructor.newInstance(operationProperties);
         } finally {
-            constructor.setAccessible(oldAccesssible);
+            // Restore the original accessibility of constructor
+            constructor.setAccessible(oldAccessible);
         }
 
     }


### PR DESCRIPTION
Fixes #4215.

### Motivation

#### Typos

![image](https://github.com/apache/eventmesh/assets/41445332/1bd52756-90d9-4ba7-99a5-3a7b59e67cbf)

#### Redundant keyword

![image](https://github.com/apache/eventmesh/assets/41445332/b5c1587a-07a3-4080-b10f-a666dfbf0dfc)

The `transient` keyword won't make any sense in this context as it's a static field. `transient` is used to indicate that a field should not be serialized, but `static` fields are inherently not serialized anyway.

### Modifications

#### Correct typos

![image](https://github.com/apache/eventmesh/assets/41445332/87a38fb6-e4e0-4347-87d8-626c46ee6795)

#### Remove redundant keyword

![image](https://github.com/apache/eventmesh/assets/41445332/5fd9d7ee-dfaf-4629-95b3-155a9deff948)

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
