### PR TITLE
[ISSUE #3511] Swaped 2 arguments so they are in the correct order: expected value, actual value: Assert.assertEquals(expected, actual).[ConfigurationHolderTest]

### DIFF
--- a/eventmesh-storage-plugin/eventmesh-storage-rabbitmq/src/test/java/org/apache/eventmesh/storage/rabbitmq/config/ConfigurationHolderTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rabbitmq/src/test/java/org/apache/eventmesh/storage/rabbitmq/config/ConfigurationHolderTest.java
@@ -47,16 +47,16 @@ public class ConfigurationHolderTest {
     }
 
     private void assertConfig(ConfigurationHolder config) {
-        Assert.assertEquals(config.getHost(), "127.0.0.1");
-        Assert.assertEquals(config.getPort(), 5672);
-        Assert.assertEquals(config.getUsername(), "username-success!!!");
-        Assert.assertEquals(config.getPasswd(), "passwd-success!!!");
-        Assert.assertEquals(config.getVirtualHost(), "virtualHost-success!!!");
+        Assert.assertEquals("127.0.0.1", config.getHost());
+        Assert.assertEquals(5672, config.getPort());
+        Assert.assertEquals("username-success!!!", config.getUsername());
+        Assert.assertEquals("passwd-success!!!", config.getPasswd());
+        Assert.assertEquals("virtualHost-success!!!", config.getVirtualHost());
 
-        Assert.assertEquals(config.getExchangeType(), BuiltinExchangeType.TOPIC);
-        Assert.assertEquals(config.getExchangeName(), "exchangeName-success!!!");
-        Assert.assertEquals(config.getRoutingKey(), "routingKey-success!!!");
-        Assert.assertEquals(config.getQueueName(), "queueName-success!!!");
+        Assert.assertEquals(BuiltinExchangeType.TOPIC, config.getExchangeType());
+        Assert.assertEquals("exchangeName-success!!!", config.getExchangeName());
+        Assert.assertEquals("routingKey-success!!!", config.getRoutingKey());
+        Assert.assertEquals("queueName-success!!!", config.getQueueName());
         Assert.assertTrue(config.isAutoAck());
     }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
-->

Fixes #3511 .

### Motivation

*Changed the order of arguments for Assert.assertEquals(expected, actual).

*In the standard assertions library, including JUnit's Assert.assertEquals(), the first argument is the expected value, and the second argument is the actual value. The correct order is Assert.assertEquals(expected, actual).


### Modifications

*The first argument is the expected value, and the second argument is the actual value. So I have swapped it top correct order.


### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
