### PR TITLE
[ISSUE #4199] Catch Exception instead of Throwable

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/service/EventEmitter.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/service/EventEmitter.java
@@ -18,8 +18,6 @@
 package org.apache.eventmesh.runtime.core.protocol.grpc.service;
 
 import io.grpc.stub.StreamObserver;
-
-
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -34,24 +32,24 @@ public class EventEmitter<T> {
     public synchronized void onNext(T event) {
         try {
             emitter.onNext(event);
-        } catch (Throwable t) {
-            log.warn("StreamObserver Error onNext. {}", t.getMessage());
+        } catch (Exception e) {
+            log.warn("StreamObserver Error onNext. {}", e.getMessage());
         }
     }
 
     public synchronized void onCompleted() {
         try {
             emitter.onCompleted();
-        } catch (Throwable t) {
-            log.warn("StreamObserver Error onCompleted. {}", t.getMessage());
+        } catch (Exception e) {
+            log.warn("StreamObserver Error onCompleted. {}", e.getMessage());
         }
     }
 
     public synchronized void onError(Throwable t) {
         try {
             emitter.onError(t);
-        } catch (Throwable t1) {
-            log.warn("StreamObserver Error onError. {}", t1.getMessage());
+        } catch (Exception e) {
+            log.warn("StreamObserver Error onError. {}", e.getMessage());
         }
     }
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/service/EventEmitter.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/service/EventEmitter.java
@@ -18,6 +18,7 @@
 package org.apache.eventmesh.runtime.core.protocol.grpc.service;
 
 import io.grpc.stub.StreamObserver;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j


### PR DESCRIPTION
Fixes [#4199](https://github.com/apache/eventmesh/issues/4199).

### Motivation

eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/service/EventEmitter.java line 37,45,53

Use `Exception` instead of `Throwable`.

### Modifications

Use `Exception` instead of `Throwable`.

### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation