### PR TITLE
[ISSUE #4022]contains() is a legacy method that is equivalent to containsValue()

### DIFF
--- a/eventmesh-registry-plugin/eventmesh-registry-consul/src/main/java/org/apache/eventmesh/registry/consul/service/HeatBeatScheduler.java
+++ b/eventmesh-registry-plugin/eventmesh-registry-consul/src/main/java/org/apache/eventmesh/registry/consul/service/HeatBeatScheduler.java
@@ -91,7 +91,7 @@ public class HeatBeatScheduler {
                     consulClient.agentCheckPass(checkId, aclToken);
                     return;
                 }
-                if (heartBeatMap.contains(instance)) {
+                if (heartBeatMap.containsValue(instance)) {
                     consulClient.agentCheckPass(checkId);
                 }
             } finally {


### PR DESCRIPTION
Fixes #4022 

### Motivation

`containsValue()` method is used to check whether a particular value is being mapped by a single or more than one key in the HashMap. It is more appropriate to use `containsValue()` here, than `contains()`.

### Modifications

Changed `contains()` to `containsValue()` at line 94.

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)