### PR TITLE
[ISSUE #4263] InterruptedExceptions should never be ignored[ThreadUtils]

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/ThreadUtils.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/ThreadUtils.java
@@ -34,7 +34,7 @@ public class ThreadUtils {
             long timeout = ThreadLocalRandom.current().nextLong(min, max + 1);
             timeUnit.sleep(timeout);
         } catch (InterruptedException ignore) {
-            Thread.currentThread().interrupt;
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -51,7 +51,7 @@ public class ThreadUtils {
         try {
             sleepWithThrowException(timeout, timeUnit);
         } catch (InterruptedException ignore) {
-            Thread.currentThread().interrupt;
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/ThreadUtils.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/ThreadUtils.java
@@ -34,7 +34,7 @@ public class ThreadUtils {
             long timeout = ThreadLocalRandom.current().nextLong(min, max + 1);
             timeUnit.sleep(timeout);
         } catch (InterruptedException ignore) {
-            //ignore
+            Thread.currentThread().interrupt;
         }
     }
 
@@ -51,7 +51,7 @@ public class ThreadUtils {
         try {
             sleepWithThrowException(timeout, timeUnit);
         } catch (InterruptedException ignore) {
-            //ignore
+            Thread.currentThread().interrupt;
         }
     }
 


### PR DESCRIPTION
Fixes #4263 

### Modifications

Restored interrupted states in lines 37 & 54

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)