### PR TITLE
[ISSUE #4335] Fix Webhook connection not closing after processing

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/enums/ConnectionType.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/enums/ConnectionType.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.common.enums;
+
+public enum ConnectionType {
+    PERSISTENT,
+    SHORT_LIVED
+}

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/http/common/RequestURI.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/http/common/RequestURI.java
@@ -33,7 +33,7 @@ public enum RequestURI {
 
     UNSUBSCRIBE_REMOTE("/eventmesh/unsubscribe/remote", "UNSUBSCRIBE REMOTE"),
 
-    CRATE_TOPIC("/eventmesh/topic/create", "CRATE TOPIC"),
+    CREATE_TOPIC("/eventmesh/topic/create", "CREATE TOPIC"),
 
     DELETE_TOPIC("/eventmesh/topic/delete", "DELETE TOPIC"),
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/AsyncHttpProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/AsyncHttpProcessor.java
@@ -25,6 +25,7 @@ import io.netty.handler.codec.http.HttpResponse;
 /**
  * async http processor
  */
+
 public interface AsyncHttpProcessor extends HttpProcessor {
 
     default HttpResponse handler(HttpRequest httpRequest) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/CreateTopicProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/CreateTopicProcessor.java
@@ -153,6 +153,6 @@ public class CreateTopicProcessor implements AsyncHttpProcessor {
 
     @Override
     public String[] paths() {
-        return new String[]{RequestURI.CRATE_TOPIC.getRequestURI()};
+        return new String[]{RequestURI.CREATE_TOPIC.getRequestURI()};
     }
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/ShortHttpProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/ShortHttpProcessor.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.eventmesh.runtime.core.protocol.http.processor;
 
 /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/ShortHttpProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/ShortHttpProcessor.java
@@ -1,0 +1,7 @@
+package org.apache.eventmesh.runtime.core.protocol.http.processor;
+
+/**
+ * short-lived HTTP processor
+ */
+
+public interface ShortHttpProcessor extends HttpProcessor {}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/WebHookProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/WebHookProcessor.java
@@ -34,7 +34,7 @@ import io.netty.handler.codec.http.HttpResponse;
 import lombok.Setter;
 
 @EventMeshTrace(isEnable = true)
-public class WebHookProcessor implements HttpProcessor {
+public class WebHookProcessor implements ShortHttpProcessor {
 
     @Setter
     private WebHookController webHookController;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/HttpResponseUtils.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/HttpResponseUtils.java
@@ -45,7 +45,7 @@ public class HttpResponseUtils {
         return new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
 
-    private static ByteBuf crateByteBuf(ChannelHandlerContext ctx, String body) {
+    private static ByteBuf createByteBuf(ChannelHandlerContext ctx, String body) {
         byte[] bytes = body.getBytes(Constants.DEFAULT_CHARSET);
         ByteBuf byteBuf = ctx.alloc().buffer(bytes.length);
         byteBuf.writeBytes(bytes);
@@ -64,7 +64,7 @@ public class HttpResponseUtils {
     public static HttpResponse getHttpResponse(String body, ChannelHandlerContext ctx, AsciiString headerValue) {
         HttpHeaders responseHeaders = new DefaultHttpHeaders();
         responseHeaders.add(HttpHeaderNames.CONTENT_TYPE, headerValue);
-        return new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, crateByteBuf(ctx, body),
+        return new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, createByteBuf(ctx, body),
             responseHeaders, responseHeaders);
     }
 

--- a/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperation.java
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperation.java
@@ -76,7 +76,7 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
         final File webhookConfigFile = getWebhookConfigFile(webHookConfig);
         if (webhookConfigFile.exists()) {
             if (log.isErrorEnabled()) {
-                log.error("webhookConfig {} is existed", webHookConfig.getCallbackPath());
+                log.error("webhookConfig {} exists", webHookConfig.getCallbackPath());
             }
             return 0;
         }

--- a/eventmesh-webhook/eventmesh-webhook-receive/src/main/java/org/apache/eventmesh/webhook/receive/storage/WebhookFileListener.java
+++ b/eventmesh-webhook/eventmesh-webhook-receive/src/main/java/org/apache/eventmesh/webhook/receive/storage/WebhookFileListener.java
@@ -51,7 +51,7 @@ public class WebhookFileListener {
     private final transient Set<String> pathSet = new LinkedHashSet<>(); // monitored subdirectory
     private final transient Map<WatchKey, String> watchKeyPathMap = new ConcurrentHashMap<>(); // WatchKey's path
     private transient String filePath;
-    private final transient Map<String, WebHookConfig> cacheWebHookConfig;
+    private transient Map<String, WebHookConfig> cacheWebHookConfig;
 
     public WebhookFileListener(final String filePath, final Map<String, WebHookConfig> cacheWebHookConfig) {
         this.filePath = WebHookOperationConstant.getFilePath(filePath);
@@ -143,7 +143,6 @@ public class WebhookFileListener {
                 WatchKey key = null;
                 try {
                     assert service != null;
-                    // The code will block here until a file system event occurs
                     key = service.take();
                 } catch (InterruptedException e) {
                     log.error("Interrupted", e);

--- a/eventmesh-webhook/eventmesh-webhook-receive/src/main/java/org/apache/eventmesh/webhook/receive/storage/WebhookFileListener.java
+++ b/eventmesh-webhook/eventmesh-webhook-receive/src/main/java/org/apache/eventmesh/webhook/receive/storage/WebhookFileListener.java
@@ -51,7 +51,7 @@ public class WebhookFileListener {
     private final transient Set<String> pathSet = new LinkedHashSet<>(); // monitored subdirectory
     private final transient Map<WatchKey, String> watchKeyPathMap = new ConcurrentHashMap<>(); // WatchKey's path
     private transient String filePath;
-    private transient Map<String, WebHookConfig> cacheWebHookConfig;
+    private final transient Map<String, WebHookConfig> cacheWebHookConfig;
 
     public WebhookFileListener(final String filePath, final Map<String, WebHookConfig> cacheWebHookConfig) {
         this.filePath = WebHookOperationConstant.getFilePath(filePath);
@@ -143,6 +143,7 @@ public class WebhookFileListener {
                 WatchKey key = null;
                 try {
                     assert service != null;
+                    // The code will block here until a file system event occurs
                     key = service.take();
                 } catch (InterruptedException e) {
                     log.error("Interrupted", e);


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
-->

Fixes #4335.

### Motivation

Most of the services that use `HandlerService` are affected by this bug. When sending webhook payloads using Postman and spoofing the hash value, the CloudEvent is sent successfully. However, Postman remains in a waiting state even after receiving a 200 or 500 status code. 

Webhook Delivery Error:

![image](https://github.com/apache/eventmesh/assets/41445332/dcf095ed-b0d3-4ffd-ac8c-81d9f8bc0067)

![image](https://github.com/apache/eventmesh/assets/41445332/00be5240-ea5a-4e8b-aeb4-9bce1e314ed4)

**In the screenshots of the webhook documentation, the tasks are also failing.** I will submit a corresponding PR to correct it later.

![image](https://github.com/apache/eventmesh/assets/41445332/642e0d1b-38da-4879-af0f-7a0547af0c01)

### Modifications

I choose to asynchronously close the connection in the `sendResponse()` method rather than synchronously closing it in `postHandler()` or `run()`. This is to avoid premature closure of the connection while asynchronous tasks are still in progress. As shown, this modification may occasionally cause GitHub to report an "EOF" error.

![image](https://github.com/apache/eventmesh/assets/41445332/0e885a25-68a3-4978-ab64-e25c904e8969)

After promptly closing the connection, Postman no longer waits, and the GitHub task succeeds.

![image](https://github.com/apache/eventmesh/assets/41445332/4f6c12d6-d7c8-46c2-88ec-c3af51feee43)

![image](https://github.com/apache/eventmesh/assets/41445332/b450112b-f6df-4fe6-9e13-73f95f5256c6)

### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
