### PR TITLE
[ISSUE #4341] WebHookConfig failed to load after being inserted

### DIFF
--- a/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperation.java
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperation.java
@@ -99,14 +99,16 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
 
     @Override
     public Integer deleteWebHookConfig(final WebHookConfig webHookConfig) {
-        final File webhookConfigFile = getWebhookConfigFile(webHookConfig);
-        if (!webhookConfigFile.exists()) {
-            if (log.isErrorEnabled()) {
-                log.error("webhookConfig {} does not exist", webHookConfig.getCallbackPath());
+        synchronized (SharedLatchHolder.lock) {
+            final File webhookConfigFile = getWebhookConfigFile(webHookConfig);
+            if (!webhookConfigFile.exists()) {
+                if (log.isErrorEnabled()) {
+                    log.error("webhookConfig {} does not exist", webHookConfig.getCallbackPath());
+                }
+                return 0;
             }
-            return 0;
+            return webhookConfigFile.delete() ? 1 : 0;
         }
-        return webhookConfigFile.delete() ? 1 : 0;
     }
 
     /**

--- a/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperation.java
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperation.java
@@ -88,7 +88,7 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
         final File webhookConfigFile = getWebhookConfigFile(webHookConfig);
         if (!webhookConfigFile.exists()) {
             if (log.isErrorEnabled()) {
-                log.error("webhookConfig {} is not existed", webHookConfig.getCallbackPath());
+                log.error("webhookConfig {} does not exist", webHookConfig.getCallbackPath());
             }
             return 0;
         }
@@ -100,7 +100,7 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
         final File webhookConfigFile = getWebhookConfigFile(webHookConfig);
         if (!webhookConfigFile.exists()) {
             if (log.isErrorEnabled()) {
-                log.error("webhookConfig {} is not existed", webHookConfig.getCallbackPath());
+                log.error("webhookConfig {} does not exist", webHookConfig.getCallbackPath());
             }
             return 0;
         }
@@ -115,7 +115,7 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
         final File webhookConfigFile = getWebhookConfigFile(webHookConfig);
         if (!webhookConfigFile.exists()) {
             if (log.isErrorEnabled()) {
-                log.error("webhookConfig {} is not existed", webHookConfig.getCallbackPath());
+                log.error("webhookConfig {} does not exist", webHookConfig.getCallbackPath());
             }
             return null;
         }

--- a/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperation.java
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperation.java
@@ -38,7 +38,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperation.java
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperation.java
@@ -175,10 +175,8 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
     }
 
     public static boolean writeToFile(final File webhookConfigFile, final WebHookConfig webHookConfig) {
-        // Wait for the previous cacheInit to complete and ensure the atomicity of countDown in case of concurrency
+        // Wait for the previous cacheInit to complete in case of concurrency
         synchronized (SharedLatchHolder.lock) {
-            // Reset latch count
-            SharedLatchHolder.latch = new CountDownLatch(1);
             try (FileOutputStream fos = new FileOutputStream(webhookConfigFile);
                 BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(fos, StandardCharsets.UTF_8))) {
                 // Lock this file to prevent concurrent modification and it will be automatically unlocked when fos closes
@@ -190,8 +188,6 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
                 }
                 return false;
             }
-            // Notify that file write has been completed
-            SharedLatchHolder.latch.countDown();
             return true;
         }
     }

--- a/eventmesh-webhook/eventmesh-webhook-api/src/main/java/org/apache/eventmesh/webhook/api/common/SharedLatchHolder.java
+++ b/eventmesh-webhook/eventmesh-webhook-api/src/main/java/org/apache/eventmesh/webhook/api/common/SharedLatchHolder.java
@@ -17,12 +17,9 @@
 
 package org.apache.eventmesh.webhook.api.common;
 
-import java.util.concurrent.CountDownLatch;
-
 public class SharedLatchHolder {
-    // ensure writeToFile is executed before cacheInit
-    public static CountDownLatch latch = new CountDownLatch(1);
 
-    // ensure cacheInit is executed before the next writeToFile
+    // secure the execution sequence of writeToFile and cacheInit
     public static final Object lock = new Object();
+
 }

--- a/eventmesh-webhook/eventmesh-webhook-api/src/main/java/org/apache/eventmesh/webhook/api/common/SharedLatchHolder.java
+++ b/eventmesh-webhook/eventmesh-webhook-api/src/main/java/org/apache/eventmesh/webhook/api/common/SharedLatchHolder.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.webhook.api.common;
+
+import java.util.concurrent.CountDownLatch;
+
+public class SharedLatchHolder {
+    public static CountDownLatch latch = new CountDownLatch(1);
+}

--- a/eventmesh-webhook/eventmesh-webhook-api/src/main/java/org/apache/eventmesh/webhook/api/common/SharedLatchHolder.java
+++ b/eventmesh-webhook/eventmesh-webhook-api/src/main/java/org/apache/eventmesh/webhook/api/common/SharedLatchHolder.java
@@ -20,5 +20,9 @@ package org.apache.eventmesh.webhook.api.common;
 import java.util.concurrent.CountDownLatch;
 
 public class SharedLatchHolder {
+    // ensure writeToFile is executed before cacheInit
     public static CountDownLatch latch = new CountDownLatch(1);
+
+    // ensure cacheInit is executed before the next writeToFile
+    public static final Object lock = new Object();
 }

--- a/eventmesh-webhook/eventmesh-webhook-receive/src/main/java/org/apache/eventmesh/webhook/receive/storage/WebhookFileListener.java
+++ b/eventmesh-webhook/eventmesh-webhook-receive/src/main/java/org/apache/eventmesh/webhook/receive/storage/WebhookFileListener.java
@@ -155,17 +155,15 @@ public class WebhookFileListener {
                     // manufacturer change
                     final String path = flashPath.concat("/").concat(event.context().toString());
                     final File file = new File(path);
-                    if (ENTRY_CREATE == event.kind() || ENTRY_MODIFY == event.kind()) {
-                        if (file.isFile()) {
-                            cacheInit(file);
-                        } else {
-                            try {
-                                key = Paths.get(path).register(service, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE);
-                                watchKeyPathMap.put(key, path);
-                            } catch (IOException e) {
-                                log.error("registerWatchKey failed", e);
-                            }
+                    if (!file.isFile() && (ENTRY_CREATE == event.kind() || ENTRY_MODIFY == event.kind())) {
+                        try {
+                            key = Paths.get(path).register(service, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE);
+                            watchKeyPathMap.put(key, path);
+                        } catch (IOException e) {
+                            log.error("registerWatchKey failed", e);
                         }
+                    } else if (file.isFile() && ENTRY_MODIFY == event.kind()) {
+                        cacheInit(file);
                     } else if (ENTRY_DELETE == event.kind()) {
                         if (file.isDirectory()) {
                             watchKeyPathMap.remove(key);

--- a/eventmesh-webhook/eventmesh-webhook-receive/src/main/java/org/apache/eventmesh/webhook/receive/storage/WebhookFileListener.java
+++ b/eventmesh-webhook/eventmesh-webhook-receive/src/main/java/org/apache/eventmesh/webhook/receive/storage/WebhookFileListener.java
@@ -93,7 +93,7 @@ public class WebhookFileListener {
     /**
      * Read the file and cache it in local map for manufacturers webhook payload delivery
      * <p>
-     * A CountDownLatch is used to ensure that this method should be invoked after the {@code webhookConfigFile} is written completely
+     * A shared lock is used to ensure that this method should be invoked after the {@code webhookConfigFile} is written completely
      * by {@code org.apache.eventmesh.webhook.admin.FileWebHookConfigOperation#writeToFile} when multiple modify events are triggered.
      *
      * @param webhookConfigFile webhookConfigFile
@@ -169,8 +169,7 @@ public class WebhookFileListener {
                     } else if (file.isFile() && ENTRY_MODIFY == event.kind()) {
                         // If it is a file, cache it only when it is modified to wait for complete file writes
                         try {
-                            // Wait for the notification of file write completion before initializing the cache
-                            SharedLatchHolder.latch.await();
+                            // Wait for file write completion before initializing the cache
                             synchronized (SharedLatchHolder.lock) {
                                 cacheInit(file);
                             }

--- a/eventmesh-webhook/eventmesh-webhook-receive/src/main/java/org/apache/eventmesh/webhook/receive/storage/WebhookFileListener.java
+++ b/eventmesh-webhook/eventmesh-webhook-receive/src/main/java/org/apache/eventmesh/webhook/receive/storage/WebhookFileListener.java
@@ -51,7 +51,7 @@ public class WebhookFileListener {
     private final transient Set<String> pathSet = new LinkedHashSet<>(); // monitored subdirectory
     private final transient Map<WatchKey, String> watchKeyPathMap = new ConcurrentHashMap<>(); // WatchKey's path
     private transient String filePath;
-    private transient Map<String, WebHookConfig> cacheWebHookConfig;
+    private final transient Map<String, WebHookConfig> cacheWebHookConfig;
 
     public WebhookFileListener(final String filePath, final Map<String, WebHookConfig> cacheWebHookConfig) {
         this.filePath = WebHookOperationConstant.getFilePath(filePath);
@@ -143,6 +143,7 @@ public class WebhookFileListener {
                 WatchKey key = null;
                 try {
                     assert service != null;
+                    // The code will block here until a file system event occurs
                     key = service.take();
                 } catch (InterruptedException e) {
                     log.error("Interrupted", e);

--- a/eventmesh-webhook/eventmesh-webhook-receive/src/main/java/org/apache/eventmesh/webhook/receive/storage/WebhookFileListener.java
+++ b/eventmesh-webhook/eventmesh-webhook-receive/src/main/java/org/apache/eventmesh/webhook/receive/storage/WebhookFileListener.java
@@ -91,7 +91,10 @@ public class WebhookFileListener {
     }
 
     /**
-     * Read the file and cache it in map
+     * Read the file and cache it in local map for manufacturers webhook payload delivery
+     * <p>
+     * A CountDownLatch is used to ensure that this method should be invoked after the {@code webhookConfigFile} is written completely
+     * by {@code org.apache.eventmesh.webhook.admin.FileWebHookConfigOperation#writeToFile} when multiple modify events are triggered.
      *
      * @param webhookConfigFile webhookConfigFile
      */

--- a/eventmesh-webhook/eventmesh-webhook-receive/src/main/java/org/apache/eventmesh/webhook/receive/storage/WebhookFileListener.java
+++ b/eventmesh-webhook/eventmesh-webhook-receive/src/main/java/org/apache/eventmesh/webhook/receive/storage/WebhookFileListener.java
@@ -171,7 +171,9 @@ public class WebhookFileListener {
                         try {
                             // Wait for the notification of file write completion before initializing the cache
                             SharedLatchHolder.latch.await();
-                            cacheInit(file);
+                            synchronized (SharedLatchHolder.lock) {
+                                cacheInit(file);
+                            }
                         } catch (Exception e) {
                             log.error("cacheInit failed", e);
                         }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
-->

Fixes #4341.

### Feature Description

When creating a new WebHookConfig, the `writeToFile` method is invoked to create a file and write data. The `fileWatchRegister` can monitor file creation, modification, and deletion. It calls the `cacheInit` method during creation and modification events to store the WebHookConfig in `cacheWebHookConfig`.

### Bug Phenomenon

Under normal circumstances, when copying the `webhook.github.eventmesh.all` configuration file, both ENTRY_CREATE and ENTRY_MODIFY events are generated as expected:

![Expected Behavior](https://github.com/apache/eventmesh/assets/41445332/efdda6e1-f9b4-4ff5-a1b5-8f9c77309197)

The bug occurs when calling the `insertWebHookConfig` endpoint for the first time to create a WebHookConfig. Only the ENTRY_CREATE event is captured (abnormal; expected behavior is to have both events):

![Bug Behavior](https://github.com/apache/eventmesh/assets/41445332/55fd606c-69d5-4a25-b6e1-49c425a6b0ec)

At this point, the file is empty, and the `cacheInit` method writes null to `cacheWebHookConfig`:

![Empty Cache](https://github.com/apache/eventmesh/assets/41445332/b4a8a37a-2841-42c3-a009-af5b96788f89)

![Null Cache](https://github.com/apache/eventmesh/assets/41445332/b567799b-2a3d-4bd5-9124-2f67b76f5bb4)

However, the loop ends after one iteration, and `fileWatchRegister` does not call the `cacheInit` method again after the file has been written with WebHookConfig data. Consequently, `cacheWebHookConfig` does not have a valid value, and GitHub's webhook calls will be unable to retrieve the corresponding webhook configuration.

![Cache Issue](https://github.com/apache/eventmesh/assets/41445332/31e4dd4e-9ffb-44b9-bc18-866121655458)

### Initial Solution

I resolved this bug by adding a slight delay after capturing the file event:

```java
try {
    assert service != null;
    key = service.take();
    Thread.sleep(1000);
} catch (InterruptedException e) {
    log.error("Interrupted", e);
}
```

With this delay, both ENTRY_CREATE and ENTRY_MODIFY events are captured. The `for (final WatchEvent<?> event : key.pollEvents())` loop iterates twice, allowing complete file data reading and the correct creation of WebHookConfig. This behavior is correct and matches expectations.

### Bug Cause

The bug arises when the JVM retrieves file system events faster than file write speed. In such cases, the obtained file events and data are incomplete. When the JVM retrieves file system events slower than file write speed, the events and data are complete.

In other words, when `fileWatchRegister` captures a file creation event, without adding a delay, `key.pollEvents()` will return only an ENTRY_CREATE event, not waiting long enough for the file's content to be fully written to disk.

Ideally, file system events are asynchronous, and file locks are synchronous. After locking and completing the write operation, `fileWatchRegister` should continue to capture `ENTRY_MODIFY` events. The failure to continue monitoring is due to an uncaught exception thrown by `cacheInit`, which propagates upwards and exits the `while` loop. This prevents the `WatchKey` from being reset, causing the `service.take()` call to be blocked and preventing the retrieval of new events.

File write speed is beyond control, and a fixed delay isn't a robust solution. Interestingly, I found that this bug doesn't fully reproduce on a different machine.

### Better Solution

My code should be more robust. A better solution is to ensure the file is fully created and written before executing actions. Therefore, I listen to the "ENTRY_MODIFY" event of the file rather than performing `cacheInit(file)` in the "ENTRY_CREATE" event. This approach provides more certainty in waiting for complete file writes.

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
