### PR TITLE
[ISSUE #4349][Unit Test] eventmesh-common header unit test.

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/ConfigService.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/ConfigService.java
@@ -17,7 +17,7 @@
 
 package org.apache.eventmesh.common.config;
 
-import static org.apache.eventmesh.common.utils.ReflectUtils.lookUpField;
+import static org.apache.eventmesh.common.utils.ReflectUtils.lookUpFieldByParentClass;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -160,7 +160,7 @@ public class ConfigService {
         try {
             field = clazz.getDeclaredField(configInfo.getField());
         } catch (NoSuchFieldException e) {
-            field = lookUpField(clazz, configInfo.getField());
+            field = lookUpFieldByParentClass(clazz, configInfo.getField());
             if (field == null) {
                 throw e;
             }

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/HttpConvertsUtils.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/HttpConvertsUtils.java
@@ -154,7 +154,6 @@ public class HttpConvertsUtils {
                     final String eventMeshInstanceKeyValue = eventMeshInstanceKeyField.get(eventMeshInstanceKey).toString();
                     // Use the attribute name to compare with the key value to achieve one-to-one correspondence and ignore case.
                     if (StringUtils.equalsIgnoreCase(headerFieldName, eventMeshInstanceKeyValue)) {
-                        MapUtils.getString(headerParam, eventMeshInstanceKeyValue);
                         headerField.set(header, MapUtils.getString(headerParam, eventMeshInstanceKeyValue));
                     }
                 }

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/HttpConvertsUtils.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/HttpConvertsUtils.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Field;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -153,6 +154,7 @@ public class HttpConvertsUtils {
                     final String eventMeshInstanceKeyValue = eventMeshInstanceKeyField.get(eventMeshInstanceKey).toString();
                     // Use the attribute name to compare with the key value to achieve one-to-one correspondence and ignore case.
                     if (StringUtils.equalsIgnoreCase(headerFieldName, eventMeshInstanceKeyValue)) {
+                        MapUtils.getString(headerParam, eventMeshInstanceKeyValue);
                         headerField.set(header, MapUtils.getString(headerParam, eventMeshInstanceKeyValue));
                     }
                 }
@@ -171,7 +173,10 @@ public class HttpConvertsUtils {
             protocolKeyField.setAccessible(true);
             switch (headerFieldName) {
                 case ProtocolKey.VERSION:
-                    headerField.set(header, ProtocolVersion.get(MapUtils.getString(headerParam, ProtocolKey.VERSION)));
+                    ProtocolVersion protocolVersion = ProtocolVersion.get(MapUtils.getString(headerParam, ProtocolKey.VERSION));
+                    if (Objects.nonNull(protocolVersion)) {
+                        headerField.set(header, protocolVersion);
+                    }
                     break;
                 case ProtocolKey.LANGUAGE:
                     String language = StringUtils.isBlank(MapUtils.getString(headerParam, ProtocolKey.LANGUAGE))
@@ -183,7 +188,9 @@ public class HttpConvertsUtils {
                     // Use the attribute name to compare with the key value to achieve one-to-one correspondence and ignore case.
                     if (StringUtils.equalsIgnoreCase(headerFieldName, protocolKeyValue)) {
                         Object value = getValue(headerParam, protocolKeyValue);
-                        headerField.set(header, value);
+                        if (Objects.nonNull(value)) {
+                            headerField.set(header, value);
+                        }
                     }
                     break;
             }

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/ReflectUtils.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/ReflectUtils.java
@@ -23,7 +23,7 @@ import java.lang.reflect.Modifier;
 public class ReflectUtils {
 
     /**
-     * Look up fields inherited from the parent class.
+     * Look up not private fields inherited from the parent class.
      *
      * @param clazz
      * @param fieldName

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/body/BodyTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/body/BodyTest.java
@@ -47,13 +47,7 @@ public class BodyTest {
 
     @Test
     public void testBuildBody() throws Exception {
-        boolean errorCode = false;
-        try {
-            Body.buildBody("-1", originalMap);
-        } catch (Exception e) {
-            errorCode = true;
-        }
-        Assert.assertEquals(true, errorCode);
+        Assert.assertThrows(Exception.class, () -> Body.buildBody("-1", originalMap));
         Body sendMessageBatchRequestBody = Body.buildBody(String.valueOf(RequestCode.MSG_BATCH_SEND.getRequestCode()), originalMap);
         Assert.assertNotNull(sendMessageBatchRequestBody);
         Assert.assertEquals(sendMessageBatchRequestBody.getClass(), SendMessageBatchRequestBody.class);

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/body/BodyTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/body/BodyTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.common.protocol.http.body;
+
+import org.apache.eventmesh.common.protocol.http.body.client.HeartbeatRequestBody;
+import org.apache.eventmesh.common.protocol.http.body.client.RegRequestBody;
+import org.apache.eventmesh.common.protocol.http.body.client.SubscribeRequestBody;
+import org.apache.eventmesh.common.protocol.http.body.client.UnRegRequestBody;
+import org.apache.eventmesh.common.protocol.http.body.client.UnSubscribeRequestBody;
+import org.apache.eventmesh.common.protocol.http.body.message.PushMessageRequestBody;
+import org.apache.eventmesh.common.protocol.http.body.message.ReplyMessageRequestBody;
+import org.apache.eventmesh.common.protocol.http.body.message.SendMessageBatchRequestBody;
+import org.apache.eventmesh.common.protocol.http.body.message.SendMessageBatchV2RequestBody;
+import org.apache.eventmesh.common.protocol.http.body.message.SendMessageRequestBody;
+import org.apache.eventmesh.common.protocol.http.common.RequestCode;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BodyTest {
+
+    private Map<String, Object> originalMap;
+
+    @Before
+    public void before() {
+        originalMap = new HashMap<>();
+    }
+
+    @Test
+    public void testBuildBody() throws Exception {
+        boolean errorCode = false;
+        try {
+            Body.buildBody("-1", originalMap);
+        } catch (Exception e) {
+            errorCode = true;
+        }
+        Assert.assertEquals(true, errorCode);
+        Body sendMessageBatchRequestBody = Body.buildBody(String.valueOf(RequestCode.MSG_BATCH_SEND.getRequestCode()), originalMap);
+        Assert.assertNotNull(sendMessageBatchRequestBody);
+        Assert.assertEquals(sendMessageBatchRequestBody.getClass(), SendMessageBatchRequestBody.class);
+        Body sendMessageBatchV2RequestBody = Body.buildBody(String.valueOf(RequestCode.MSG_BATCH_SEND_V2.getRequestCode()), originalMap);
+        Assert.assertNotNull(sendMessageBatchV2RequestBody);
+        Assert.assertEquals(sendMessageBatchV2RequestBody.getClass(), SendMessageBatchV2RequestBody.class);
+        Body sendMessageRequestBodySync = Body.buildBody(String.valueOf(RequestCode.MSG_SEND_SYNC.getRequestCode()), originalMap);
+        Assert.assertNotNull(sendMessageRequestBodySync);
+        Assert.assertEquals(sendMessageRequestBodySync.getClass(), SendMessageRequestBody.class);
+        Body sendMessageRequestBodyAsync = Body.buildBody(String.valueOf(RequestCode.MSG_SEND_ASYNC.getRequestCode()), originalMap);
+        Assert.assertNotNull(sendMessageRequestBodyAsync);
+        Assert.assertEquals(sendMessageRequestBodyAsync.getClass(), SendMessageRequestBody.class);
+        Body pushMessageRequestBodySync = Body.buildBody(String.valueOf(RequestCode.HTTP_PUSH_CLIENT_SYNC.getRequestCode()), originalMap);
+        Assert.assertNotNull(pushMessageRequestBodySync);
+        Assert.assertEquals(pushMessageRequestBodySync.getClass(), PushMessageRequestBody.class);
+        Body pushMessageRequestBodyAsync = Body.buildBody(String.valueOf(RequestCode.HTTP_PUSH_CLIENT_ASYNC.getRequestCode()), originalMap);
+        Assert.assertNotNull(pushMessageRequestBodyAsync);
+        Assert.assertEquals(pushMessageRequestBodyAsync.getClass(), PushMessageRequestBody.class);
+        Body regRequestBody = Body.buildBody(String.valueOf(RequestCode.REGISTER.getRequestCode()), originalMap);
+        Assert.assertNotNull(regRequestBody);
+        Assert.assertEquals(regRequestBody.getClass(), RegRequestBody.class);
+        Body unRegRequestBody = Body.buildBody(String.valueOf(RequestCode.UNREGISTER.getRequestCode()), originalMap);
+        Assert.assertNotNull(unRegRequestBody);
+        Assert.assertEquals(unRegRequestBody.getClass(), UnRegRequestBody.class);
+        Body subscribeRequestBody = Body.buildBody(String.valueOf(RequestCode.SUBSCRIBE.getRequestCode()), originalMap);
+        Assert.assertNotNull(subscribeRequestBody);
+        Assert.assertEquals(subscribeRequestBody.getClass(), SubscribeRequestBody.class);
+        Body unSubscribeRequestBody = Body.buildBody(String.valueOf(RequestCode.UNSUBSCRIBE.getRequestCode()), originalMap);
+        Assert.assertNotNull(unSubscribeRequestBody);
+        Assert.assertEquals(unSubscribeRequestBody.getClass(), UnSubscribeRequestBody.class);
+        Body heartbeatRequestBody = Body.buildBody(String.valueOf(RequestCode.HEARTBEAT.getRequestCode()), originalMap);
+        Assert.assertNotNull(heartbeatRequestBody);
+        Assert.assertEquals(heartbeatRequestBody.getClass(), HeartbeatRequestBody.class);
+        Body replyMessageRequestBody = Body.buildBody(String.valueOf(RequestCode.REPLY_MESSAGE.getRequestCode()), originalMap);
+        Assert.assertNotNull(replyMessageRequestBody);
+        Assert.assertEquals(replyMessageRequestBody.getClass(), ReplyMessageRequestBody.class);
+        Body baseRequestBody = Body.buildBody(String.valueOf(RequestCode.ADMIN_SHUTDOWN.getRequestCode()), originalMap);
+        Assert.assertNotNull(baseRequestBody);
+        Assert.assertEquals(baseRequestBody.getClass(), BaseRequestBody.class);
+    }
+}

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/HeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/HeaderTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.common.protocol.http.header;
+
+import org.apache.eventmesh.common.protocol.http.common.RequestCode;
+import org.apache.eventmesh.common.protocol.http.header.client.HeartbeatRequestHeader;
+import org.apache.eventmesh.common.protocol.http.header.client.RegRequestHeader;
+import org.apache.eventmesh.common.protocol.http.header.client.SubscribeRequestHeader;
+import org.apache.eventmesh.common.protocol.http.header.client.UnRegRequestHeader;
+import org.apache.eventmesh.common.protocol.http.header.client.UnSubscribeRequestHeader;
+import org.apache.eventmesh.common.protocol.http.header.message.PushMessageRequestHeader;
+import org.apache.eventmesh.common.protocol.http.header.message.ReplyMessageRequestHeader;
+import org.apache.eventmesh.common.protocol.http.header.message.SendMessageBatchRequestHeader;
+import org.apache.eventmesh.common.protocol.http.header.message.SendMessageBatchV2RequestHeader;
+import org.apache.eventmesh.common.protocol.http.header.message.SendMessageRequestHeader;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HeaderTest {
+
+    private Map<String, Object> originalMap;
+
+    @Before
+    public void before() {
+        originalMap = new HashMap<>();
+    }
+
+    @Test
+    public void testBuildHeader() throws Exception {
+        boolean errorCode = false;
+        try {
+            Header.buildHeader("-1", originalMap);
+        } catch (Exception e) {
+            errorCode = true;
+        }
+        Assert.assertEquals(true, errorCode);
+        Header messageBatchRequestHeader = Header.buildHeader(String.valueOf(RequestCode.MSG_BATCH_SEND.getRequestCode()), originalMap);
+        Assert.assertNotNull(messageBatchRequestHeader);
+        Assert.assertEquals(messageBatchRequestHeader.getClass(), SendMessageBatchRequestHeader.class);
+        Header sendMessageBatchV2RequestHeader = Header.buildHeader(String.valueOf(RequestCode.MSG_BATCH_SEND_V2.getRequestCode()), originalMap);
+        Assert.assertNotNull(sendMessageBatchV2RequestHeader);
+        Assert.assertEquals(sendMessageBatchV2RequestHeader.getClass(), SendMessageBatchV2RequestHeader.class);
+        Header sendMessageRequestHeaderSync = Header.buildHeader(String.valueOf(RequestCode.MSG_SEND_SYNC.getRequestCode()), originalMap);
+        Assert.assertNotNull(sendMessageRequestHeaderSync);
+        Assert.assertEquals(sendMessageRequestHeaderSync.getClass(), SendMessageRequestHeader.class);
+        Header sendMessageRequestHeaderAsync = Header.buildHeader(String.valueOf(RequestCode.MSG_SEND_ASYNC.getRequestCode()), originalMap);
+        Assert.assertNotNull(sendMessageRequestHeaderAsync);
+        Assert.assertEquals(sendMessageRequestHeaderAsync.getClass(), SendMessageRequestHeader.class);
+        Header pushMessageRequestHeaderSync = Header.buildHeader(String.valueOf(RequestCode.HTTP_PUSH_CLIENT_SYNC.getRequestCode()), originalMap);
+        Assert.assertNotNull(pushMessageRequestHeaderSync);
+        Assert.assertEquals(pushMessageRequestHeaderSync.getClass(), PushMessageRequestHeader.class);
+        Header pushMessageRequestHeaderAsync = Header.buildHeader(String.valueOf(RequestCode.HTTP_PUSH_CLIENT_ASYNC.getRequestCode()), originalMap);
+        Assert.assertNotNull(pushMessageRequestHeaderAsync);
+        Assert.assertEquals(pushMessageRequestHeaderAsync.getClass(), PushMessageRequestHeader.class);
+        Header regRequestHeader = Header.buildHeader(String.valueOf(RequestCode.REGISTER.getRequestCode()), originalMap);
+        Assert.assertNotNull(regRequestHeader);
+        Assert.assertEquals(regRequestHeader.getClass(), RegRequestHeader.class);
+        Header unRegRequestHeader = Header.buildHeader(String.valueOf(RequestCode.UNREGISTER.getRequestCode()), originalMap);
+        Assert.assertNotNull(unRegRequestHeader);
+        Assert.assertEquals(unRegRequestHeader.getClass(), UnRegRequestHeader.class);
+        Header subscribeRequestHeader = Header.buildHeader(String.valueOf(RequestCode.SUBSCRIBE.getRequestCode()), originalMap);
+        Assert.assertNotNull(subscribeRequestHeader);
+        Assert.assertEquals(subscribeRequestHeader.getClass(), SubscribeRequestHeader.class);
+        Header unSubscribeRequestHeader = Header.buildHeader(String.valueOf(RequestCode.UNSUBSCRIBE.getRequestCode()), originalMap);
+        Assert.assertNotNull(unSubscribeRequestHeader);
+        Assert.assertEquals(unSubscribeRequestHeader.getClass(), UnSubscribeRequestHeader.class);
+        Header heartbeatRequestHeader = Header.buildHeader(String.valueOf(RequestCode.HEARTBEAT.getRequestCode()), originalMap);
+        Assert.assertNotNull(heartbeatRequestHeader);
+        Assert.assertEquals(heartbeatRequestHeader.getClass(), HeartbeatRequestHeader.class);
+        Header replyMessageRequestHeader = Header.buildHeader(String.valueOf(RequestCode.REPLY_MESSAGE.getRequestCode()), originalMap);
+        Assert.assertNotNull(replyMessageRequestHeader);
+        Assert.assertEquals(replyMessageRequestHeader.getClass(), ReplyMessageRequestHeader.class);
+        Header baseRequestHeader = Header.buildHeader(String.valueOf(RequestCode.ADMIN_SHUTDOWN.getRequestCode()), originalMap);
+        Assert.assertNotNull(baseRequestHeader);
+        Assert.assertEquals(baseRequestHeader.getClass(), BaseRequestHeader.class);
+    }
+}

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/HeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/HeaderTest.java
@@ -47,13 +47,7 @@ public class HeaderTest {
 
     @Test
     public void testBuildHeader() throws Exception {
-        boolean errorCode = false;
-        try {
-            Header.buildHeader("-1", originalMap);
-        } catch (Exception e) {
-            errorCode = true;
-        }
-        Assert.assertEquals(true, errorCode);
+        Assert.assertThrows(Exception.class, () -> Header.buildHeader("-1", originalMap));
         Header messageBatchRequestHeader = Header.buildHeader(String.valueOf(RequestCode.MSG_BATCH_SEND.getRequestCode()), originalMap);
         Assert.assertNotNull(messageBatchRequestHeader);
         Assert.assertEquals(messageBatchRequestHeader.getClass(), SendMessageBatchRequestHeader.class);

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/RandomStringUtilsTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/RandomStringUtilsTest.java
@@ -17,29 +17,24 @@
 
 package org.apache.eventmesh.common.utils;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
+import org.apache.commons.lang3.math.NumberUtils;
 
-public class ReflectUtils {
+import org.junit.Assert;
+import org.junit.Test;
 
-    /**
-     * Look up fields inherited from the parent class.
-     *
-     * @param clazz
-     * @param fieldName
-     * @return
-     */
-    public static Field lookUpFieldByParentClass(Class<?> clazz, String fieldName) {
-        Class<?> superClass = clazz.getSuperclass();
-        while (superClass != null) {
-            Field[] superFields = superClass.getDeclaredFields();
-            for (Field superField : superFields) {
-                if (!Modifier.isPrivate(superField.getModifiers()) && superField.getName().equals(fieldName)) {
-                    return superField;
-                }
-            }
-            superClass = superClass.getSuperclass();
-        }
-        return null;
+public class RandomStringUtilsTest {
+
+    @Test
+    public void testGenerateNum() {
+        String result = RandomStringUtils.generateNum(2);
+        Assert.assertTrue(NumberUtils.isDigits(result));
+        Assert.assertEquals(2, result.length());
     }
+
+    @Test
+    public void testGenerateUUID() {
+        String result = RandomStringUtils.generateUUID();
+        Assert.assertTrue(result.matches("^\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}$"));
+    }
+
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/ReflectUtilsTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/ReflectUtilsTest.java
@@ -18,28 +18,36 @@
 package org.apache.eventmesh.common.utils;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 
-public class ReflectUtils {
+import org.junit.Assert;
+import org.junit.Test;
 
-    /**
-     * Look up fields inherited from the parent class.
-     *
-     * @param clazz
-     * @param fieldName
-     * @return
-     */
-    public static Field lookUpFieldByParentClass(Class<?> clazz, String fieldName) {
-        Class<?> superClass = clazz.getSuperclass();
-        while (superClass != null) {
-            Field[] superFields = superClass.getDeclaredFields();
-            for (Field superField : superFields) {
-                if (!Modifier.isPrivate(superField.getModifiers()) && superField.getName().equals(fieldName)) {
-                    return superField;
-                }
-            }
-            superClass = superClass.getSuperclass();
-        }
-        return null;
+public class ReflectUtilsTest {
+
+    public static class TestParent {
+
+        private String age;
+
+        public String tel;
+
     }
+
+    public static class TestObj extends TestParent {
+
+        private String name;
+
+        private String password;
+    }
+
+    @Test
+    public void testLookUpFieldByParentClass() {
+        Field fieldName = ReflectUtils.lookUpFieldByParentClass(TestObj.class, "name");
+        Field fieldAge = ReflectUtils.lookUpFieldByParentClass(TestObj.class, "age");
+        Field fieldTel = ReflectUtils.lookUpFieldByParentClass(TestObj.class, "tel");
+        Assert.assertNull(fieldName);
+        Assert.assertNull(fieldAge);
+        Assert.assertNotNull(fieldTel);
+        Assert.assertEquals("tel", fieldTel.getName());
+    }
+
 }

--- a/eventmesh-trace-plugin/eventmesh-trace-jaeger/src/test/java/org/apache/eventmesh/trace/jaeger/JaegerTraceServiceTest.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-jaeger/src/test/java/org/apache/eventmesh/trace/jaeger/JaegerTraceServiceTest.java
@@ -57,7 +57,7 @@ public class JaegerTraceServiceTest {
         try {
             sdkTracerProviderField = JaegerTraceService.class.getDeclaredField("sdkTracerProvider");
         } catch (NoSuchFieldException e) {
-            sdkTracerProviderField = ReflectUtils.lookUpField(JaegerTraceService.class, "sdkTracerProvider");
+            sdkTracerProviderField = ReflectUtils.lookUpFieldByParentClass(JaegerTraceService.class, "sdkTracerProvider");
             if (sdkTracerProviderField == null) {
                 throw e;
             }

--- a/eventmesh-trace-plugin/eventmesh-trace-pinpoint/src/test/java/org/apache/eventmesh/trace/pinpoint/PinpointTraceServiceTest.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-pinpoint/src/test/java/org/apache/eventmesh/trace/pinpoint/PinpointTraceServiceTest.java
@@ -53,7 +53,7 @@ public class PinpointTraceServiceTest {
         try {
             sdkTracerProviderField = PinpointTraceService.class.getDeclaredField("sdkTracerProvider");
         } catch (NoSuchFieldException e) {
-            sdkTracerProviderField = ReflectUtils.lookUpField(PinpointTraceService.class, "sdkTracerProvider");
+            sdkTracerProviderField = ReflectUtils.lookUpFieldByParentClass(PinpointTraceService.class, "sdkTracerProvider");
             if (sdkTracerProviderField == null) {
                 throw e;
             }

--- a/eventmesh-trace-plugin/eventmesh-trace-zipkin/src/test/java/org/apache/eventmesh/trace/zipkin/ZipkinTraceServiceTest.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-zipkin/src/test/java/org/apache/eventmesh/trace/zipkin/ZipkinTraceServiceTest.java
@@ -56,7 +56,7 @@ public class ZipkinTraceServiceTest {
         try {
             sdkTracerProviderField = ZipkinTraceService.class.getDeclaredField("sdkTracerProvider");
         } catch (NoSuchFieldException e) {
-            sdkTracerProviderField = ReflectUtils.lookUpField(ZipkinTraceService.class, "sdkTracerProvider");
+            sdkTracerProviderField = ReflectUtils.lookUpFieldByParentClass(ZipkinTraceService.class, "sdkTracerProvider");
             if (sdkTracerProviderField == null) {
                 throw e;
             }


### PR DESCRIPTION
Fixes #4349.

```java
Header pushMessageRequestHeaderAsync = Header.buildHeader(String.valueOf(RequestCode.HTTP_PUSH_CLIENT_ASYNC.getRequestCode()), originalMap);
Assert.assertNotNull(pushMessageRequestHeaderAsync);
Assert.assertEquals(pushMessageRequestHeaderAsync.getClass(), PushMessageRequestHeader.class);
```
this test case code will IllegalArgumentException. I also fixed this issue

when headerParam param is Empty value object instance will cause
`java.lang.IllegalArgumentException: Can not set int field org.apache.eventmesh.common.protocol.http.header.message.PushMessageRequestHeader.code to null value`.


```java
private void setFiledValue(Header header, Map<String, Object> headerParam, ProtocolKey protocolKey,
                               Field[] protocolKeyFields, Field headerField,
                               String headerFieldName) throws IllegalAccessException {
        for (Field protocolKeyField : protocolKeyFields) {
            protocolKeyField.setAccessible(true);
            switch (headerFieldName) {
                case ProtocolKey.VERSION:
                    headerField.set(header, ProtocolVersion.get(MapUtils.getString(headerParam, ProtocolKey.VERSION)));
                    break;
                case ProtocolKey.LANGUAGE:
                    String language = StringUtils.isBlank(MapUtils.getString(headerParam, ProtocolKey.LANGUAGE))
                        ? Constants.LANGUAGE_JAVA : MapUtils.getString(headerParam, ProtocolKey.LANGUAGE);
                    headerField.set(header, language);
                    break;
                default:
                    String protocolKeyValue = protocolKeyField.get(protocolKey).toString();
                    // Use the attribute name to compare with the key value to achieve one-to-one correspondence and ignore case.
                    if (StringUtils.equalsIgnoreCase(headerFieldName, protocolKeyValue)) {
                        Object value = getValue(headerParam, protocolKeyValue);
                        headerField.set(header, value);
                    }
                    break;
            }
        }
    }


```


@pandaapo My question is whether to obtain private attributes?  

```java
if (!Modifier.isPrivate(superField.getModifiers()) && superField.getName().equals(fieldName)) {
                    return superField;
}

```




### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
