### PR TITLE
[ISSUE #4195] Do some code optimization.[SubscribeProcessor]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/SubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/SubscribeProcessor.java
@@ -46,9 +46,9 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class SubscribeProcessor {
 
-    private final static EventMeshGrpcServer eventMeshGrpcServer;
+    private final EventMeshGrpcServer eventMeshGrpcServer;
 
-    private final static GrpcType grpcType = GrpcType.WEBHOOK;
+    private final GrpcType grpcType = GrpcType.WEBHOOK;
 
     private final Acl acl;
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/SubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/SubscribeProcessor.java
@@ -48,7 +48,7 @@ public class SubscribeProcessor {
 
     private final EventMeshGrpcServer eventMeshGrpcServer;
 
-    private final GrpcType grpcType = GrpcType.WEBHOOK;
+    private static final GrpcType grpcType = GrpcType.WEBHOOK;
 
     private final Acl acl;
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/SubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/SubscribeProcessor.java
@@ -85,9 +85,11 @@ public class SubscribeProcessor {
 
         final String consumerGroup = EventMeshCloudEventUtils.getConsumerGroup(subscription);
         // Collect new clients in the subscription
-        List<SubscriptionItem> subscriptionItems =  Objects.requireNonNull(JsonUtils.parseTypeReferenceObject(subscription.getTextData(),
+        List<SubscriptionItem> subscriptionItems = JsonUtils.parseTypeReferenceObject(subscription.getTextData(),
             new TypeReference<List<SubscriptionItem>>() {
-            }), "subscriptionItems must not be null");;
+            });
+        
+        Objects.requireNonNull(subscriptionItems, "subscriptionItems must not be null");
         final String env = EventMeshCloudEventUtils.getEnv(subscription);
         final String idc = EventMeshCloudEventUtils.getIdc(subscription);
         final String sys = EventMeshCloudEventUtils.getSys(subscription);
@@ -140,9 +142,10 @@ public class SubscribeProcessor {
     }
 
     private void doAclCheck(final CloudEvent subscription) throws AclException {
-        List<SubscriptionItem> subscriptionItems = Objects.requireNonNull(JsonUtils.parseTypeReferenceObject(subscription.getTextData(),
+        List<SubscriptionItem> subscriptionItems = JsonUtils.parseTypeReferenceObject(subscription.getTextData(),
             new TypeReference<List<SubscriptionItem>>() {
-            }), "subscriptionItems must not be null");
+            })
+        Objects.requireNonNull(subscriptionItems, "subscriptionItems must not be null");
         if (eventMeshGrpcServer.getEventMeshGrpcConfiguration().isEventMeshServerSecurityEnable()) {
             for (final SubscriptionItem item : subscriptionItems) {
                 this.acl.doAclCheckInHttpReceive(EventMeshCloudEventUtils.getConsumerGroup(subscription),

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/SubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/SubscribeProcessor.java
@@ -46,9 +46,9 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class SubscribeProcessor {
 
-    private final transient EventMeshGrpcServer eventMeshGrpcServer;
+    private final static EventMeshGrpcServer eventMeshGrpcServer;
 
-    private final transient GrpcType grpcType = GrpcType.WEBHOOK;
+    private final static GrpcType grpcType = GrpcType.WEBHOOK;
 
     private final Acl acl;
 
@@ -85,9 +85,9 @@ public class SubscribeProcessor {
 
         final String consumerGroup = EventMeshCloudEventUtils.getConsumerGroup(subscription);
         // Collect new clients in the subscription
-        List<SubscriptionItem> subscriptionItems = JsonUtils.parseTypeReferenceObject(subscription.getTextData(),
+        List<SubscriptionItem> subscriptionItems =  Objects.requireNonNull(JsonUtils.parseTypeReferenceObject(subscription.getTextData(),
             new TypeReference<List<SubscriptionItem>>() {
-            });
+            }), "subscriptionItems must not be null");;
         final String env = EventMeshCloudEventUtils.getEnv(subscription);
         final String idc = EventMeshCloudEventUtils.getIdc(subscription);
         final String sys = EventMeshCloudEventUtils.getSys(subscription);
@@ -140,9 +140,9 @@ public class SubscribeProcessor {
     }
 
     private void doAclCheck(final CloudEvent subscription) throws AclException {
-        List<SubscriptionItem> subscriptionItems = JsonUtils.parseTypeReferenceObject(subscription.getTextData(),
+        List<SubscriptionItem> subscriptionItems = Objects.requireNonNull(JsonUtils.parseTypeReferenceObject(subscription.getTextData(),
             new TypeReference<List<SubscriptionItem>>() {
-            });
+            }), "subscriptionItems must not be null");
         if (eventMeshGrpcServer.getEventMeshGrpcConfiguration().isEventMeshServerSecurityEnable()) {
             for (final SubscriptionItem item : subscriptionItems) {
                 this.acl.doAclCheckInHttpReceive(EventMeshCloudEventUtils.getConsumerGroup(subscription),

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/SubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/SubscribeProcessor.java
@@ -70,7 +70,6 @@ public class SubscribeProcessor {
             ServiceUtils.sendResponseCompleted(StatusCode.EVENTMESH_PROTOCOL_BODY_ERR, emitter);
             return;
         }
-
         try {
             doAclCheck(subscription);
         } catch (AclException e) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/SubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/SubscribeProcessor.java
@@ -144,7 +144,7 @@ public class SubscribeProcessor {
     private void doAclCheck(final CloudEvent subscription) throws AclException {
         List<SubscriptionItem> subscriptionItems = JsonUtils.parseTypeReferenceObject(subscription.getTextData(),
             new TypeReference<List<SubscriptionItem>>() {
-            })
+            });
         Objects.requireNonNull(subscriptionItems, "subscriptionItems must not be null");
         if (eventMeshGrpcServer.getEventMeshGrpcConfiguration().isEventMeshServerSecurityEnable()) {
             for (final SubscriptionItem item : subscriptionItems) {


### PR DESCRIPTION


Fixes #4195 

### Motivation

To solve below two issues:

1. transient is used to mark fields in a Serializable class which will not be written out to file (or stream). In a class that does not implement Serializable, this modifier is simply wasted keystrokes, and should be removed.
2. Dereference of 'subscriptionItems' may produce 'NullPointerException'

### Modifications

1. I have added a static keyword.
2. I have added Objects.requireNonNull() for the subscriptionItems list. 


### Documentation

- Does this pull request introduce a new feature?  (no)
- If yes, how is the feature documented? (not applicable)
- If a feature is not applicable for documentation, explain why? (Fixed small issue)
