### PR TITLE
[ISSUE #4027] Comparison using reference equality instead of value equality.[RegistryResponse]

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/catalog/protos/RegistryResponse.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/catalog/protos/RegistryResponse.java
@@ -262,7 +262,7 @@ public final class RegistryResponse extends
 
     @Override
     public Builder toBuilder() {
-        return this == DEFAULT_INSTANCE
+        return this.equals(DEFAULT_INSTANCE)
                 ? new Builder() : new Builder().mergeFrom(this);
     }
 
@@ -390,7 +390,7 @@ public final class RegistryResponse extends
         }
 
         public Builder mergeFrom(RegistryResponse other) {
-            if (other == RegistryResponse.getDefaultInstance()) {
+            if (other.equals(RegistryResponse.getDefaultInstance())) {
                 return this;
             }
             this.mergeUnknownFields(other.unknownFields);


### PR DESCRIPTION
Fixes #4027 

### Modifications

Changed `==` to `equals()` in lines 265 & 393

### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
