### PR TITLE
[ISSUE #4091]Anonymous new can be replaced with lambda.[SyncSubClient]

### DIFF
--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/demo/SyncSubClient.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/demo/SyncSubClient.java
@@ -20,13 +20,9 @@ package org.apache.eventmesh.runtime.demo;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
 import org.apache.eventmesh.common.protocol.tcp.Command;
-import org.apache.eventmesh.common.protocol.tcp.Package;
 import org.apache.eventmesh.runtime.client.common.ClientConstants;
 import org.apache.eventmesh.runtime.client.common.MessageUtils;
-import org.apache.eventmesh.runtime.client.hook.ReceiveMsgHook;
 import org.apache.eventmesh.runtime.client.impl.SubClientImpl;
-
-import io.netty.channel.ChannelHandlerContext;
 
 
 import lombok.extern.slf4j.Slf4j;
@@ -34,19 +30,17 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class SyncSubClient {
 
+
     public static void main(String[] args) throws Exception {
         try (SubClientImpl client =
-                     new SubClientImpl("localhost", 10000, MessageUtils.generateSubServer())) {
+            new SubClientImpl("localhost", 10000, MessageUtils.generateSubServer())) {
             client.init();
             client.heartbeat();
             client.justSubscribe(ClientConstants.SYNC_TOPIC, SubscriptionMode.CLUSTERING, SubscriptionType.SYNC);
-            client.registerBusiHandler(new ReceiveMsgHook() {
-                @Override
-                public void handle(Package msg, ChannelHandlerContext ctx) {
-                    if (msg.getHeader().getCommand() == Command.REQUEST_TO_CLIENT) {
-                        if ((log.isInfoEnabled())) {
-                            log.info("receive message -------------------------------" + msg);
-                        }
+            client.registerBusiHandler((msg, ctx) -> {
+                if (msg.getHeader().getCommand() == Command.REQUEST_TO_CLIENT) {
+                    if ((log.isInfoEnabled())) {
+                        log.info("receive message:{}", msg);
                     }
                 }
             });


### PR DESCRIPTION
Fixes #4091 .

### Motivation
* replace class [org.apache.eventmesh.runtime.demo.SyncSubClient] with lambda. use the correct log format.

### Modifications
* replace with lambda. 
* use the correct log format.

