### PR TITLE
Update EventMeshTcp2Client.java

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/EventMeshTcp2Client.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/EventMeshTcp2Client.java
@@ -55,10 +55,8 @@ public class EventMeshTcp2Client {
             msg.setHeader(new Header(SERVER_GOODBYE_REQUEST, OPStatus.SUCCESS.getCode(),
                 "graceful normal quit from eventmesh", null));
               tcpThreadPoolGroup.getScheduler().submit(() -> {
-                  
                     long taskExecuteTime = System.currentTimeMillis();
                     Utils.writeAndFlush(msg, startTime, taskExecuteTime, session.getContext(), session);
-                  
             });
             InetSocketAddress address = (InetSocketAddress) session.getContext().channel().remoteAddress();
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/EventMeshTcp2Client.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/EventMeshTcp2Client.java
@@ -54,13 +54,9 @@ public class EventMeshTcp2Client {
             Package msg = new Package();
             msg.setHeader(new Header(SERVER_GOODBYE_REQUEST, OPStatus.SUCCESS.getCode(),
                 "graceful normal quit from eventmesh", null));
-
-            tcpThreadPoolGroup.getScheduler().submit(new Runnable() {
-                @Override
-                public void run() {
+              tcpThreadPoolGroup.getScheduler().submit(() -> {
                     long taskExecuteTime = System.currentTimeMillis();
                     Utils.writeAndFlush(msg, startTime, taskExecuteTime, session.getContext(), session);
-                }
             });
             InetSocketAddress address = (InetSocketAddress) session.getContext().channel().remoteAddress();
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/EventMeshTcp2Client.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/EventMeshTcp2Client.java
@@ -55,8 +55,10 @@ public class EventMeshTcp2Client {
             msg.setHeader(new Header(SERVER_GOODBYE_REQUEST, OPStatus.SUCCESS.getCode(),
                 "graceful normal quit from eventmesh", null));
               tcpThreadPoolGroup.getScheduler().submit(() -> {
+                  
                     long taskExecuteTime = System.currentTimeMillis();
                     Utils.writeAndFlush(msg, startTime, taskExecuteTime, session.getContext(), session);
+                  
             });
             InetSocketAddress address = (InetSocketAddress) session.getContext().channel().remoteAddress();
 


### PR DESCRIPTION
Make anonymous inner class a lambda[EventMeshTcp2Client]

Fixes #3399 .

### Motivation

*Make anonymous inner class a lambda[EventMeshTcp2Client]*



### Modifications

*Make anonymous inner class a lambda*



### Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable 

