### PR TITLE
[ISSUE #4478] Upgrade JUnit to JUnit Jupiter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ allprojects {
                 url "https://maven.aliyun.com/repository/public"
             }
         }
-        testImplementation "junit:junit:4.13.2"
+        testImplementation "org.junit.jupiter:junit-jupiter:5.6.0"
     }
 
     spotless {
@@ -126,6 +126,10 @@ allprojects {
         }
     }
     spotlessJava.dependsOn(compileJava, javadoc, compileTestJava, test, processResources, processTestResources)
+
+    test {
+        useJUnitPlatform()
+    }
 }
 
 task tar(type: Tar) {
@@ -516,12 +520,13 @@ subprojects {
             dependency "org.springframework.boot:spring-boot-starter-web:2.7.10"
             dependency "io.openmessaging:registry-server:0.0.1"
 
-            dependency "junit:junit:4.13.2"
-            dependency "com.github.stefanbirkner:system-rules:1.16.1"
+            dependency "org.junit.jupiter:junit-jupiter:5.6.0"
+            dependency "org.junit-pioneer:junit-pioneer:1.9.1"
             dependency "org.assertj:assertj-core:2.6.0"
 
             dependency "org.mockito:mockito-core:3.8.0"
             dependency "org.mockito:mockito-inline:3.8.0"
+            dependency "org.mockito:mockito-junit-jupiter:3.8.0"
 
             dependency "io.cloudevents:cloudevents-core:2.4.2"
             dependency "io.cloudevents:cloudevents-json-jackson:2.4.2"

--- a/build.gradle
+++ b/build.gradle
@@ -522,8 +522,6 @@ subprojects {
 
             dependency "org.mockito:mockito-core:3.8.0"
             dependency "org.mockito:mockito-inline:3.8.0"
-            dependency "org.powermock:powermock-module-junit4:2.0.2"
-            dependency "org.powermock:powermock-api-mockito2:2.0.9"
 
             dependency "io.cloudevents:cloudevents-core:2.4.2"
             dependency "io.cloudevents:cloudevents-json-jackson:2.4.2"

--- a/eventmesh-admin/eventmesh-admin-rocketmq/build.gradle
+++ b/eventmesh-admin/eventmesh-admin-rocketmq/build.gradle
@@ -29,6 +29,5 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.mockito:mockito-inline'
 }

--- a/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/request/TopicCreateRequestTest.java
+++ b/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/request/TopicCreateRequestTest.java
@@ -17,11 +17,11 @@
 
 package org.apache.eventmesh.admin.rocketmq.request;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/response/TopicResponseTest.java
+++ b/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/response/TopicResponseTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.eventmesh.admin.rocketmq.response;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/util/RequestMappingTest.java
+++ b/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/util/RequestMappingTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.eventmesh.admin.rocketmq.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -26,7 +26,7 @@ import org.apache.eventmesh.common.enums.HttpMethod;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.sun.net.httpserver.HttpExchange;
 

--- a/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/util/UrlMappingPatternTest.java
+++ b/eventmesh-admin/eventmesh-admin-rocketmq/src/test/java/org/apache/eventmesh/admin/rocketmq/util/UrlMappingPatternTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.eventmesh.admin.rocketmq.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -29,8 +29,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class UrlMappingPatternTest {
 
@@ -38,7 +38,7 @@ public class UrlMappingPatternTest {
 
     private TestUrlMappingPattern urlMappingPattern;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         urlMappingPattern = new TestUrlMappingPattern(TEST_URL_MAPPING_PATTERN);
     }

--- a/eventmesh-common/build.gradle
+++ b/eventmesh-common/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "javax.annotation:javax.annotation-api:1.3.2"
 
-    implementation "com.github.stefanbirkner:system-rules"
+    testImplementation "org.junit-pioneer:junit-pioneer"
     implementation "org.yaml:snakeyaml"
 
     compileOnly 'org.projectlombok:lombok'
@@ -77,4 +77,5 @@ dependencies {
     testImplementation "org.assertj:assertj-core"
 
     testImplementation "org.mockito:mockito-core"
+    testImplementation "org.mockito:mockito-junit-jupiter"
 }

--- a/eventmesh-common/build.gradle
+++ b/eventmesh-common/build.gradle
@@ -77,6 +77,4 @@ dependencies {
     testImplementation "org.assertj:assertj-core"
 
     testImplementation "org.mockito:mockito-core"
-    testImplementation "org.powermock:powermock-module-junit4"
-    testImplementation "org.powermock:powermock-api-mockito2"
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/EventMeshMessageTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/EventMeshMessageTest.java
@@ -20,15 +20,15 @@ package org.apache.eventmesh.common;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class EventMeshMessageTest {
 
     @Test
     public void testGetProp() {
         EventMeshMessage message = createLiteMessage();
-        Assert.assertEquals(2L, message.getProp().size());
+        Assertions.assertEquals(2L, message.getProp().size());
     }
 
     @Test
@@ -37,30 +37,30 @@ public class EventMeshMessageTest {
         Map<String, String> prop = new HashMap<>();
         prop.put("key3", "value3");
         message.setProp(prop);
-        Assert.assertEquals(1L, message.getProp().size());
-        Assert.assertEquals("value3", message.getProp("key3"));
+        Assertions.assertEquals(1L, message.getProp().size());
+        Assertions.assertEquals("value3", message.getProp("key3"));
     }
 
     @Test
     public void testAddProp() {
         EventMeshMessage message = createLiteMessage();
         message.addProp("key3", "value3");
-        Assert.assertEquals(3L, message.getProp().size());
-        Assert.assertEquals("value1", message.getProp("key1"));
+        Assertions.assertEquals(3L, message.getProp().size());
+        Assertions.assertEquals("value1", message.getProp("key1"));
     }
 
     @Test
     public void testGetPropKey() {
         EventMeshMessage message = createLiteMessage();
-        Assert.assertEquals("value1", message.getProp("key1"));
+        Assertions.assertEquals("value1", message.getProp("key1"));
     }
 
     @Test
     public void testRemoveProp() {
         EventMeshMessage message = createLiteMessage();
         message.removePropIfPresent("key1");
-        Assert.assertEquals(1L, message.getProp().size());
-        Assert.assertNull(message.getProp("key1"));
+        Assertions.assertEquals(1L, message.getProp().size());
+        Assertions.assertNull(message.getProp("key1"));
     }
 
     private EventMeshMessage createLiteMessage() {

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/EventMeshThreadFactoryTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/EventMeshThreadFactoryTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.eventmesh.common;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class EventMeshThreadFactoryTest {
 
@@ -26,7 +26,7 @@ public class EventMeshThreadFactoryTest {
     public void testGetThreadNamePrefix() {
         final String threadNamePrefix = "threadNamePrefix";
         EventMeshThreadFactory factory = new EventMeshThreadFactory(threadNamePrefix, false);
-        Assert.assertEquals(threadNamePrefix, factory.getThreadNamePrefix());
+        Assertions.assertEquals(threadNamePrefix, factory.getThreadNamePrefix());
     }
 
     @Test
@@ -36,8 +36,8 @@ public class EventMeshThreadFactoryTest {
         Thread t = factory.newThread(() -> {
 
         });
-        Assert.assertNotNull(t);
-        Assert.assertEquals(threadNamePrefix + "-1", t.getName());
-        Assert.assertTrue(t.isDaemon());
+        Assertions.assertNotNull(t);
+        Assertions.assertEquals(threadNamePrefix + "-1", t.getName());
+        Assertions.assertTrue(t.isDaemon());
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/ResetCountDownLatchTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/ResetCountDownLatchTest.java
@@ -19,8 +19,9 @@ package org.apache.eventmesh.common;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class ResetCountDownLatchTest {
 
@@ -29,32 +30,33 @@ public class ResetCountDownLatchTest {
         try {
             new ResetCountDownLatch(-1);
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals(e.getMessage(), "count must be greater than or equal to 0");
+            Assertions.assertEquals(e.getMessage(), "count must be greater than or equal to 0");
         }
         ResetCountDownLatch resetCountDownLatch = new ResetCountDownLatch(1);
-        Assert.assertEquals(1, resetCountDownLatch.getCount());
+        Assertions.assertEquals(1, resetCountDownLatch.getCount());
     }
 
     @Test
     public void testAwaitTimeout() throws InterruptedException {
         ResetCountDownLatch latch = new ResetCountDownLatch(1);
         boolean await = latch.await(5, TimeUnit.MILLISECONDS);
-        Assert.assertFalse(await);
+        Assertions.assertFalse(await);
         latch.countDown();
         await = latch.await(5, TimeUnit.MILLISECONDS);
-        Assert.assertTrue(await);
+        Assertions.assertTrue(await);
     }
 
-    @Test(timeout = 1000)
+    @Test
+    @Timeout(1000)
     public void testCountDownAndGetCount() throws InterruptedException {
         int count = 2;
         ResetCountDownLatch resetCountDownLatch = new ResetCountDownLatch(count);
-        Assert.assertEquals(count, resetCountDownLatch.getCount());
+        Assertions.assertEquals(count, resetCountDownLatch.getCount());
         resetCountDownLatch.countDown();
-        Assert.assertEquals(count - 1, resetCountDownLatch.getCount());
+        Assertions.assertEquals(count - 1, resetCountDownLatch.getCount());
         resetCountDownLatch.countDown();
         resetCountDownLatch.await();
-        Assert.assertEquals(0, resetCountDownLatch.getCount());
+        Assertions.assertEquals(0, resetCountDownLatch.getCount());
     }
 
     @Test
@@ -62,18 +64,18 @@ public class ResetCountDownLatchTest {
         int count = 2;
         ResetCountDownLatch resetCountDownLatch = new ResetCountDownLatch(count);
         resetCountDownLatch.countDown();
-        Assert.assertEquals(count - 1, resetCountDownLatch.getCount());
+        Assertions.assertEquals(count - 1, resetCountDownLatch.getCount());
         resetCountDownLatch.reset();
-        Assert.assertEquals(count, resetCountDownLatch.getCount());
+        Assertions.assertEquals(count, resetCountDownLatch.getCount());
         resetCountDownLatch.countDown();
         resetCountDownLatch.countDown();
         resetCountDownLatch.await();
-        Assert.assertEquals(0, resetCountDownLatch.getCount());
+        Assertions.assertEquals(0, resetCountDownLatch.getCount());
         resetCountDownLatch.countDown();
-        Assert.assertEquals(0, resetCountDownLatch.getCount());
+        Assertions.assertEquals(0, resetCountDownLatch.getCount());
         resetCountDownLatch.reset();
         resetCountDownLatch.countDown();
-        Assert.assertEquals(1, resetCountDownLatch.getCount());
+        Assertions.assertEquals(1, resetCountDownLatch.getCount());
 
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/ThreadWrapperTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/ThreadWrapperTest.java
@@ -20,8 +20,9 @@ package org.apache.eventmesh.common;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class ThreadWrapperTest {
 
@@ -29,26 +30,27 @@ public class ThreadWrapperTest {
     public void getThreadName() {
         ThreadWrapper wrapper = createThreadWrapper(false);
         wrapper.start();
-        Assert.assertEquals("EventMesh-Wrapper-mxsm", wrapper.thread.getName());
+        Assertions.assertEquals("EventMesh-Wrapper-mxsm", wrapper.thread.getName());
     }
 
     @Test
     public void start() {
         ThreadWrapper wrapper = createThreadWrapper(false);
         wrapper.start();
-        Assert.assertTrue(wrapper.isStated());
+        Assertions.assertTrue(wrapper.isStated());
     }
 
-    @Test(timeout = 1000)
+    @Test
+    @Timeout(1000)
     public void await() {
         ThreadWrapper wrapper = createThreadWrapper(false);
         wrapper.start();
         wrapper.await(1, TimeUnit.MILLISECONDS);
-        Assert.assertFalse(wrapper.hasWakeup.get());
+        Assertions.assertFalse(wrapper.hasWakeup.get());
         wrapper.wakeup();
-        Assert.assertTrue(wrapper.hasWakeup.get());
+        Assertions.assertTrue(wrapper.hasWakeup.get());
         wrapper.await();
-        Assert.assertFalse(wrapper.hasWakeup.get());
+        Assertions.assertFalse(wrapper.hasWakeup.get());
         wrapper.await(2, TimeUnit.MILLISECONDS);
 
     }
@@ -79,7 +81,7 @@ public class ThreadWrapperTest {
         };
         wrapper.start();
         wrapper.shutdown();
-        Assert.assertEquals(100, counter.get());
+        Assertions.assertEquals(100, counter.get());
     }
 
     @Test
@@ -104,18 +106,18 @@ public class ThreadWrapperTest {
         };
         wrapper.start();
         wrapper.shutdownImmediately();
-        Assert.assertEquals(0, counter.get());
+        Assertions.assertEquals(0, counter.get());
     }
 
     @Test
     public void setDaemon() {
         ThreadWrapper threadWrapper = createThreadWrapper(true);
         threadWrapper.start();
-        Assert.assertTrue(threadWrapper.thread.isDaemon());
+        Assertions.assertTrue(threadWrapper.thread.isDaemon());
 
         ThreadWrapper threadWrapper1 = createThreadWrapper(false);
         threadWrapper1.start();
-        Assert.assertFalse(threadWrapper1.thread.isDaemon());
+        Assertions.assertFalse(threadWrapper1.thread.isDaemon());
     }
 
     private ThreadWrapper createThreadWrapper(boolean daemon) {

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/config/CommonConfigurationTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/config/CommonConfigurationTest.java
@@ -20,15 +20,15 @@ package org.apache.eventmesh.common.config;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CommonConfigurationTest {
 
     public CommonConfiguration config;
 
-    @Before
+    @BeforeEach
     public void beforeCommonConfigurationTest() throws Exception {
         ConfigService configService = ConfigService.getInstance();
         configService.setRootConfig("classPath://configuration.properties");
@@ -40,40 +40,40 @@ public class CommonConfigurationTest {
 
     @Test
     public void testGetCommonConfiguration() {
-        Assert.assertEquals("env-succeed!!!", config.getEventMeshEnv());
-        Assert.assertEquals("idc-succeed!!!", config.getEventMeshIDC());
-        Assert.assertEquals("cluster-succeed!!!", config.getEventMeshCluster());
-        Assert.assertEquals("name-succeed!!!", config.getEventMeshName());
-        Assert.assertEquals("816", config.getSysID());
-        // Assert.assertEquals("connector-succeed!!!", config.getEventMeshConnectorPluginType());
-        Assert.assertEquals("storage-succeed!!!", config.getEventMeshStoragePluginType());
-        Assert.assertEquals("storage-succeed!!!", config.getEventMeshStoragePluginType());
-        Assert.assertEquals("security-succeed!!!", config.getEventMeshSecurityPluginType());
-        Assert.assertEquals("metaStorage-succeed!!!", config.getEventMeshMetaStoragePluginType());
-        Assert.assertEquals("trace-succeed!!!", config.getEventMeshTracePluginType());
-        Assert.assertEquals("hostIp-succeed!!!", config.getEventMeshServerIp());
-        Assert.assertEquals("username-succeed!!!", config.getEventMeshMetaStoragePluginUsername());
-        Assert.assertEquals("password-succeed!!!", config.getEventMeshMetaStoragePluginPassword());
+        Assertions.assertEquals("env-succeed!!!", config.getEventMeshEnv());
+        Assertions.assertEquals("idc-succeed!!!", config.getEventMeshIDC());
+        Assertions.assertEquals("cluster-succeed!!!", config.getEventMeshCluster());
+        Assertions.assertEquals("name-succeed!!!", config.getEventMeshName());
+        Assertions.assertEquals("816", config.getSysID());
+        // Assertions.assertEquals("connector-succeed!!!", config.getEventMeshConnectorPluginType());
+        Assertions.assertEquals("storage-succeed!!!", config.getEventMeshStoragePluginType());
+        Assertions.assertEquals("storage-succeed!!!", config.getEventMeshStoragePluginType());
+        Assertions.assertEquals("security-succeed!!!", config.getEventMeshSecurityPluginType());
+        Assertions.assertEquals("metaStorage-succeed!!!", config.getEventMeshMetaStoragePluginType());
+        Assertions.assertEquals("trace-succeed!!!", config.getEventMeshTracePluginType());
+        Assertions.assertEquals("hostIp-succeed!!!", config.getEventMeshServerIp());
+        Assertions.assertEquals("username-succeed!!!", config.getEventMeshMetaStoragePluginUsername());
+        Assertions.assertEquals("password-succeed!!!", config.getEventMeshMetaStoragePluginPassword());
 
-        Assert.assertEquals(Integer.valueOf(816), config.getEventMeshMetaStorageIntervalInMills());
-        Assert.assertEquals(Integer.valueOf(1816), config.getEventMeshFetchMetaStorageAddrInterval());
+        Assertions.assertEquals(Integer.valueOf(816), config.getEventMeshMetaStorageIntervalInMills());
+        Assertions.assertEquals(Integer.valueOf(1816), config.getEventMeshFetchMetaStorageAddrInterval());
 
         List<String> list = new ArrayList<>();
         list.add("metrics-succeed1!!!");
         list.add("metrics-succeed2!!!");
         list.add("metrics-succeed3!!!");
-        Assert.assertEquals(list, config.getEventMeshMetricsPluginType());
+        Assertions.assertEquals(list, config.getEventMeshMetricsPluginType());
 
         List<String> list1 = new ArrayList<>();
         list1.add("TCP");
         list1.add("HTTP");
         list1.add("GRPC");
-        Assert.assertEquals(list1, config.getEventMeshProvideServerProtocols());
+        Assertions.assertEquals(list1, config.getEventMeshProvideServerProtocols());
 
-        Assert.assertTrue(config.isEventMeshServerSecurityEnable());
-        Assert.assertTrue(config.isEventMeshServerMetaStorageEnable());
-        Assert.assertTrue(config.isEventMeshServerTraceEnable());
+        Assertions.assertTrue(config.isEventMeshServerSecurityEnable());
+        Assertions.assertTrue(config.isEventMeshServerMetaStorageEnable());
+        Assertions.assertTrue(config.isEventMeshServerTraceEnable());
 
-        Assert.assertEquals("eventmesh.idc-succeed!!!", config.getEventMeshWebhookOrigin());
+        Assertions.assertEquals("eventmesh.idc-succeed!!!", config.getEventMeshWebhookOrigin());
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/config/ConfigServiceTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/config/ConfigServiceTest.java
@@ -22,8 +22,8 @@ import static org.apache.eventmesh.common.config.ConfigService.FILE_PATH_PREFIX;
 
 import java.io.File;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ConfigServiceTest {
 
@@ -86,6 +86,6 @@ public class ConfigServiceTest {
     }
 
     public void assertCommonConfiguration(CommonConfiguration config) {
-        Assert.assertEquals("env-succeed!!!", config.getEventMeshEnv());
+        Assertions.assertEquals("env-succeed!!!", config.getEventMeshEnv());
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
@@ -27,8 +27,8 @@ import java.io.IOException;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class WatchFileManagerTest {
 
@@ -40,8 +40,8 @@ public class WatchFileManagerTest {
 
             @Override
             public void onChanged(FileChangeContext changeContext) {
-                Assert.assertEquals(f.getName(), changeContext.getFileName());
-                Assert.assertEquals(f.getParent(), changeContext.getDirectoryPath());
+                Assertions.assertEquals(f.getName(), changeContext.getFileName());
+                Assertions.assertEquals(f.getParent(), changeContext.getDirectoryPath());
             }
 
             @Override

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/loadbalance/RandomLoadBalanceSelectorTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/loadbalance/RandomLoadBalanceSelectorTest.java
@@ -22,9 +22,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,7 +33,7 @@ public class RandomLoadBalanceSelectorTest {
 
     private RandomLoadBalanceSelector<String> randomLoadBalanceSelector;
 
-    @Before
+    @BeforeEach
     public void befor() {
         List<String> address = new ArrayList<>();
         address.add("A");
@@ -51,11 +51,11 @@ public class RandomLoadBalanceSelectorTest {
         }
         addressToNum.forEach((key, value) -> log.info("{} : {}", key, value));
         // just assert success if no exception
-        Assert.assertTrue(true);
+        Assertions.assertTrue(true);
     }
 
     @Test
     public void testGetType() {
-        Assert.assertEquals(LoadBalanceType.RANDOM, randomLoadBalanceSelector.getType());
+        Assertions.assertEquals(LoadBalanceType.RANDOM, randomLoadBalanceSelector.getType());
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/loadbalance/WeightRandomLoadBalanceSelectorTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/loadbalance/WeightRandomLoadBalanceSelectorTest.java
@@ -27,8 +27,8 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -42,7 +42,7 @@ public class WeightRandomLoadBalanceSelectorTest {
         weightList.add(new Weight<>("192.168.0.2", 20));
         weightList.add(new Weight<>("192.168.0.3", 40));
         WeightRandomLoadBalanceSelector<String> weightRandomLoadBalanceSelector = new WeightRandomLoadBalanceSelector<>(weightList);
-        Assert.assertEquals(LoadBalanceType.WEIGHT_RANDOM, weightRandomLoadBalanceSelector.getType());
+        Assertions.assertEquals(LoadBalanceType.WEIGHT_RANDOM, weightRandomLoadBalanceSelector.getType());
         int testRange = 100_000;
         Map<String, Integer> addressToNum = IntStream.range(0, testRange)
             .mapToObj(i -> weightRandomLoadBalanceSelector.select())
@@ -53,8 +53,8 @@ public class WeightRandomLoadBalanceSelectorTest {
         });
         log.info("addressToNum: {}", addressToNum);
         // the error less than 5%
-        Assert.assertTrue(Math.abs(addressToNum.get("192.168.0.3") - addressToNum.get("192.168.0.2") * 2) < testRange / 20);
-        Assert.assertTrue(Math.abs(addressToNum.get("192.168.0.3") - addressToNum.get("192.168.0.1") * 4) < testRange / 20);
+        Assertions.assertTrue(Math.abs(addressToNum.get("192.168.0.3") - addressToNum.get("192.168.0.2") * 2) < testRange / 20);
+        Assertions.assertTrue(Math.abs(addressToNum.get("192.168.0.3") - addressToNum.get("192.168.0.1") * 4) < testRange / 20);
     }
 
     @Test
@@ -64,7 +64,7 @@ public class WeightRandomLoadBalanceSelectorTest {
         weightList.add(new Weight<>("192.168.0.2", 10));
         weightList.add(new Weight<>("192.168.0.3", 10));
         WeightRandomLoadBalanceSelector<String> weightRandomLoadBalanceSelector = new WeightRandomLoadBalanceSelector<>(weightList);
-        Assert.assertEquals(LoadBalanceType.WEIGHT_RANDOM, weightRandomLoadBalanceSelector.getType());
+        Assertions.assertEquals(LoadBalanceType.WEIGHT_RANDOM, weightRandomLoadBalanceSelector.getType());
 
         int testRange = 100_000;
         Map<String, Integer> addressToNum = IntStream.range(0, testRange)
@@ -74,12 +74,12 @@ public class WeightRandomLoadBalanceSelectorTest {
         Field field = WeightRandomLoadBalanceSelector.class.getDeclaredField("sameWeightGroup");
         field.setAccessible(true);
         boolean sameWeightGroup = (boolean) field.get(weightRandomLoadBalanceSelector);
-        Assert.assertTrue(sameWeightGroup);
+        Assertions.assertTrue(sameWeightGroup);
 
         addressToNum.forEach((key, value) -> {
             log.info("{}: {}", key, value);
         });
         // the error less than 5%
-        Assert.assertTrue(Math.abs(addressToNum.get("192.168.0.3") - addressToNum.get("192.168.0.2")) < testRange / 20);
+        Assertions.assertTrue(Math.abs(addressToNum.get("192.168.0.3") - addressToNum.get("192.168.0.2")) < testRange / 20);
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/loadbalance/WeightRoundRobinLoadBalanceSelectorTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/loadbalance/WeightRoundRobinLoadBalanceSelectorTest.java
@@ -22,9 +22,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,7 +33,7 @@ public class WeightRoundRobinLoadBalanceSelectorTest {
 
     private WeightRoundRobinLoadBalanceSelector<String> weightRoundRobinLoadBalanceSelector;
 
-    @Before
+    @BeforeEach
     public void before() {
         List<Weight<String>> weightList = new ArrayList<>();
         weightList.add(new Weight<>("A", 10));
@@ -52,12 +52,12 @@ public class WeightRoundRobinLoadBalanceSelectorTest {
         addressToNum.forEach((key, value) -> {
             log.info("{}: {}", key, value);
         });
-        Assert.assertTrue(addressToNum.get("B") > addressToNum.get("A"));
-        Assert.assertTrue(addressToNum.get("C") > addressToNum.get("B"));
+        Assertions.assertTrue(addressToNum.get("B") > addressToNum.get("A"));
+        Assertions.assertTrue(addressToNum.get("C") > addressToNum.get("B"));
     }
 
     @Test
     public void testGetType() {
-        Assert.assertEquals(LoadBalanceType.WEIGHT_ROUND_ROBIN, weightRoundRobinLoadBalanceSelector.getType());
+        Assertions.assertEquals(LoadBalanceType.WEIGHT_ROUND_ROBIN, weightRoundRobinLoadBalanceSelector.getType());
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/loadbalance/WeightTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/loadbalance/WeightTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.eventmesh.common.loadbalance;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class WeightTest {
 
@@ -26,19 +26,19 @@ public class WeightTest {
     public void testDecreaseTotal() {
         Weight weight = new Weight(null, 0);
         weight.decreaseTotal(1);
-        Assert.assertEquals(-1, weight.getCurrentWeight().get());
+        Assertions.assertEquals(-1, weight.getCurrentWeight().get());
     }
 
     @Test
     public void testIncreaseCurrentWeight() {
         Weight weight = new Weight(null, 10);
         weight.increaseCurrentWeight();
-        Assert.assertEquals(10, weight.getCurrentWeight().get());
+        Assertions.assertEquals(10, weight.getCurrentWeight().get());
     }
 
     @Test
     public void testGetCurrentWeight() {
         Weight weight = new Weight(null, 0);
-        Assert.assertEquals(0, weight.getCurrentWeight().get());
+        Assertions.assertEquals(0, weight.getCurrentWeight().get());
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/grpc/common/EventMeshCloudEventUtilsTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/grpc/common/EventMeshCloudEventUtilsTest.java
@@ -28,9 +28,9 @@ import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.protobuf.Timestamp;
 
@@ -39,7 +39,7 @@ public class EventMeshCloudEventUtilsTest {
 
     private CloudEvent cloudEvent;
 
-    @Before
+    @BeforeEach
     public void init() {
 
         final Map<String, CloudEventAttributeValue> attributeValueMap = new HashMap<>(64);
@@ -79,192 +79,192 @@ public class EventMeshCloudEventUtilsTest {
 
     @Test
     public void testGetEnv() {
-        Assert.assertEquals("dev", EventMeshCloudEventUtils.getEnv(cloudEvent));
-        Assert.assertEquals("dev", EventMeshCloudEventUtils.getEnv(cloudEvent, "test"));
-        Assert.assertEquals("test", EventMeshCloudEventUtils.getEnv(CloudEvent.newBuilder().build(), "test"));
+        Assertions.assertEquals("dev", EventMeshCloudEventUtils.getEnv(cloudEvent));
+        Assertions.assertEquals("dev", EventMeshCloudEventUtils.getEnv(cloudEvent, "test"));
+        Assertions.assertEquals("test", EventMeshCloudEventUtils.getEnv(CloudEvent.newBuilder().build(), "test"));
     }
 
     @Test
     public void testGetIdc() {
-        Assert.assertEquals("eventmesh", EventMeshCloudEventUtils.getIdc(cloudEvent));
-        Assert.assertEquals("eventmesh", EventMeshCloudEventUtils.getIdc(cloudEvent, "test"));
-        Assert.assertEquals("test", EventMeshCloudEventUtils.getIdc(CloudEvent.newBuilder().build(), "test"));
+        Assertions.assertEquals("eventmesh", EventMeshCloudEventUtils.getIdc(cloudEvent));
+        Assertions.assertEquals("eventmesh", EventMeshCloudEventUtils.getIdc(cloudEvent, "test"));
+        Assertions.assertEquals("test", EventMeshCloudEventUtils.getIdc(CloudEvent.newBuilder().build(), "test"));
     }
 
     @Test
     public void testGetSys() {
-        Assert.assertEquals("eventmesh", EventMeshCloudEventUtils.getSys(cloudEvent));
-        Assert.assertEquals("eventmesh", EventMeshCloudEventUtils.getSys(cloudEvent, "test"));
-        Assert.assertEquals("Linux", EventMeshCloudEventUtils.getSys(CloudEvent.newBuilder().build(), "Linux"));
+        Assertions.assertEquals("eventmesh", EventMeshCloudEventUtils.getSys(cloudEvent));
+        Assertions.assertEquals("eventmesh", EventMeshCloudEventUtils.getSys(cloudEvent, "test"));
+        Assertions.assertEquals("Linux", EventMeshCloudEventUtils.getSys(CloudEvent.newBuilder().build(), "Linux"));
     }
 
     @Test
     public void testGetPid() {
-        Assert.assertEquals("1243", EventMeshCloudEventUtils.getPid(cloudEvent));
-        Assert.assertEquals("1243", EventMeshCloudEventUtils.getPid(cloudEvent, "test"));
-        Assert.assertEquals("987", EventMeshCloudEventUtils.getPid(CloudEvent.newBuilder().build(), "987"));
+        Assertions.assertEquals("1243", EventMeshCloudEventUtils.getPid(cloudEvent));
+        Assertions.assertEquals("1243", EventMeshCloudEventUtils.getPid(cloudEvent, "test"));
+        Assertions.assertEquals("987", EventMeshCloudEventUtils.getPid(CloudEvent.newBuilder().build(), "987"));
     }
 
     @Test
     public void testGetIp() {
-        Assert.assertEquals("127.0.0.1", EventMeshCloudEventUtils.getIp(cloudEvent));
-        Assert.assertEquals("127.0.0.1", EventMeshCloudEventUtils.getIp(cloudEvent, "127.0.0.2"));
-        Assert.assertEquals("192.168.1.1", EventMeshCloudEventUtils.getIp(CloudEvent.newBuilder().build(), "192.168.1.1"));
+        Assertions.assertEquals("127.0.0.1", EventMeshCloudEventUtils.getIp(cloudEvent));
+        Assertions.assertEquals("127.0.0.1", EventMeshCloudEventUtils.getIp(cloudEvent, "127.0.0.2"));
+        Assertions.assertEquals("192.168.1.1", EventMeshCloudEventUtils.getIp(CloudEvent.newBuilder().build(), "192.168.1.1"));
     }
 
     @Test
     public void testGetUserName() {
-        Assert.assertEquals("mxsm", EventMeshCloudEventUtils.getUserName(cloudEvent));
-        Assert.assertEquals("mxsm", EventMeshCloudEventUtils.getUserName(cloudEvent, "mxsm1"));
-        Assert.assertEquals("root", EventMeshCloudEventUtils.getUserName(CloudEvent.newBuilder().build(), "root"));
+        Assertions.assertEquals("mxsm", EventMeshCloudEventUtils.getUserName(cloudEvent));
+        Assertions.assertEquals("mxsm", EventMeshCloudEventUtils.getUserName(cloudEvent, "mxsm1"));
+        Assertions.assertEquals("root", EventMeshCloudEventUtils.getUserName(CloudEvent.newBuilder().build(), "root"));
     }
 
     @Test
     public void testGetPassword() {
-        Assert.assertEquals("mxsm", EventMeshCloudEventUtils.getPassword(cloudEvent));
-        Assert.assertEquals("mxsm", EventMeshCloudEventUtils.getPassword(cloudEvent, "mxsm1"));
-        Assert.assertEquals("root", EventMeshCloudEventUtils.getPassword(CloudEvent.newBuilder().build(), "root"));
+        Assertions.assertEquals("mxsm", EventMeshCloudEventUtils.getPassword(cloudEvent));
+        Assertions.assertEquals("mxsm", EventMeshCloudEventUtils.getPassword(cloudEvent, "mxsm1"));
+        Assertions.assertEquals("root", EventMeshCloudEventUtils.getPassword(CloudEvent.newBuilder().build(), "root"));
     }
 
     @Test
     public void testGetLanguage() {
-        Assert.assertEquals("java", EventMeshCloudEventUtils.getLanguage(cloudEvent));
-        Assert.assertEquals("java", EventMeshCloudEventUtils.getLanguage(cloudEvent, "Go"));
-        Assert.assertEquals("Go", EventMeshCloudEventUtils.getLanguage(CloudEvent.newBuilder().build(), "Go"));
+        Assertions.assertEquals("java", EventMeshCloudEventUtils.getLanguage(cloudEvent));
+        Assertions.assertEquals("java", EventMeshCloudEventUtils.getLanguage(cloudEvent, "Go"));
+        Assertions.assertEquals("Go", EventMeshCloudEventUtils.getLanguage(CloudEvent.newBuilder().build(), "Go"));
     }
 
     @Test
     public void testGetProtocolType() {
-        Assert.assertEquals(EventMeshProtocolType.CLOUD_EVENTS.protocolTypeName(), EventMeshCloudEventUtils.getProtocolType(cloudEvent));
-        Assert.assertEquals(EventMeshProtocolType.CLOUD_EVENTS.protocolTypeName(), EventMeshCloudEventUtils.getProtocolType(cloudEvent, "Go"));
-        Assert.assertEquals("eventmeshMessage", EventMeshCloudEventUtils.getProtocolType(CloudEvent.newBuilder().build(), "eventmeshMessage"));
+        Assertions.assertEquals(EventMeshProtocolType.CLOUD_EVENTS.protocolTypeName(), EventMeshCloudEventUtils.getProtocolType(cloudEvent));
+        Assertions.assertEquals(EventMeshProtocolType.CLOUD_EVENTS.protocolTypeName(), EventMeshCloudEventUtils.getProtocolType(cloudEvent, "Go"));
+        Assertions.assertEquals("eventmeshMessage", EventMeshCloudEventUtils.getProtocolType(CloudEvent.newBuilder().build(), "eventmeshMessage"));
     }
 
     @Test
     public void testGetProtocolVersion() {
-        Assert.assertEquals("1.0", EventMeshCloudEventUtils.getProtocolVersion(cloudEvent));
-        Assert.assertEquals("1.0", EventMeshCloudEventUtils.getProtocolVersion(cloudEvent, "1.1"));
-        Assert.assertEquals("1.2", EventMeshCloudEventUtils.getProtocolVersion(CloudEvent.newBuilder().build(), "1.2"));
+        Assertions.assertEquals("1.0", EventMeshCloudEventUtils.getProtocolVersion(cloudEvent));
+        Assertions.assertEquals("1.0", EventMeshCloudEventUtils.getProtocolVersion(cloudEvent, "1.1"));
+        Assertions.assertEquals("1.2", EventMeshCloudEventUtils.getProtocolVersion(CloudEvent.newBuilder().build(), "1.2"));
     }
 
     @Test
     public void testGetProtocolDesc() {
-        Assert.assertEquals("version 1.0", EventMeshCloudEventUtils.getProtocolDesc(cloudEvent));
-        Assert.assertEquals("version 1.0", EventMeshCloudEventUtils.getProtocolDesc(cloudEvent, "version 1.1"));
-        Assert.assertEquals("version 1.2", EventMeshCloudEventUtils.getProtocolDesc(CloudEvent.newBuilder().build(), "version 1.2"));
+        Assertions.assertEquals("version 1.0", EventMeshCloudEventUtils.getProtocolDesc(cloudEvent));
+        Assertions.assertEquals("version 1.0", EventMeshCloudEventUtils.getProtocolDesc(cloudEvent, "version 1.1"));
+        Assertions.assertEquals("version 1.2", EventMeshCloudEventUtils.getProtocolDesc(CloudEvent.newBuilder().build(), "version 1.2"));
     }
 
     @Test
     public void testGetSeqNum() {
-        Assert.assertEquals("100", EventMeshCloudEventUtils.getSeqNum(cloudEvent));
-        Assert.assertEquals("100", EventMeshCloudEventUtils.getSeqNum(cloudEvent, "200"));
-        Assert.assertEquals("200", EventMeshCloudEventUtils.getSeqNum(CloudEvent.newBuilder().build(), "200"));
+        Assertions.assertEquals("100", EventMeshCloudEventUtils.getSeqNum(cloudEvent));
+        Assertions.assertEquals("100", EventMeshCloudEventUtils.getSeqNum(cloudEvent, "200"));
+        Assertions.assertEquals("200", EventMeshCloudEventUtils.getSeqNum(CloudEvent.newBuilder().build(), "200"));
     }
 
     @Test
     public void testGetUniqueId() {
-        Assert.assertEquals("100", EventMeshCloudEventUtils.getUniqueId(cloudEvent));
-        Assert.assertEquals("100", EventMeshCloudEventUtils.getUniqueId(cloudEvent, "200"));
-        Assert.assertEquals("200", EventMeshCloudEventUtils.getUniqueId(CloudEvent.newBuilder().build(), "200"));
+        Assertions.assertEquals("100", EventMeshCloudEventUtils.getUniqueId(cloudEvent));
+        Assertions.assertEquals("100", EventMeshCloudEventUtils.getUniqueId(cloudEvent, "200"));
+        Assertions.assertEquals("200", EventMeshCloudEventUtils.getUniqueId(CloudEvent.newBuilder().build(), "200"));
     }
 
     @Test
     public void testGetTtl() {
-        Assert.assertEquals("100", EventMeshCloudEventUtils.getTtl(cloudEvent));
-        Assert.assertEquals("100", EventMeshCloudEventUtils.getTtl(cloudEvent, "200"));
-        Assert.assertEquals("200", EventMeshCloudEventUtils.getTtl(CloudEvent.newBuilder().build(), "200"));
+        Assertions.assertEquals("100", EventMeshCloudEventUtils.getTtl(cloudEvent));
+        Assertions.assertEquals("100", EventMeshCloudEventUtils.getTtl(cloudEvent, "200"));
+        Assertions.assertEquals("200", EventMeshCloudEventUtils.getTtl(CloudEvent.newBuilder().build(), "200"));
     }
 
     @Test
     public void testGetProducerGroup() {
-        Assert.assertEquals("mxsm_producer_group", EventMeshCloudEventUtils.getProducerGroup(cloudEvent));
-        Assert.assertEquals("mxsm_producer_group", EventMeshCloudEventUtils.getProducerGroup(cloudEvent, "mxsm_producer_group"));
-        Assert.assertEquals("mxsm_producer_group1",
+        Assertions.assertEquals("mxsm_producer_group", EventMeshCloudEventUtils.getProducerGroup(cloudEvent));
+        Assertions.assertEquals("mxsm_producer_group", EventMeshCloudEventUtils.getProducerGroup(cloudEvent, "mxsm_producer_group"));
+        Assertions.assertEquals("mxsm_producer_group1",
             EventMeshCloudEventUtils.getProducerGroup(CloudEvent.newBuilder().build(), "mxsm_producer_group1"));
     }
 
     @Test
     public void testGetTag() {
-        Assert.assertEquals("tag", EventMeshCloudEventUtils.getTag(cloudEvent));
-        Assert.assertEquals("tag", EventMeshCloudEventUtils.getTag(cloudEvent, "tag1"));
-        Assert.assertEquals("tag1", EventMeshCloudEventUtils.getTag(CloudEvent.newBuilder().build(), "tag1"));
+        Assertions.assertEquals("tag", EventMeshCloudEventUtils.getTag(cloudEvent));
+        Assertions.assertEquals("tag", EventMeshCloudEventUtils.getTag(cloudEvent, "tag1"));
+        Assertions.assertEquals("tag1", EventMeshCloudEventUtils.getTag(CloudEvent.newBuilder().build(), "tag1"));
     }
 
     @Test
     public void testGetContentType() {
-        Assert.assertEquals("text/plain", EventMeshCloudEventUtils.getContentType(cloudEvent));
-        Assert.assertEquals("text/plain", EventMeshCloudEventUtils.getContentType(cloudEvent, "application/json"));
-        Assert.assertEquals("application/json", EventMeshCloudEventUtils.getContentType(CloudEvent.newBuilder().build(), "application/json"));
+        Assertions.assertEquals("text/plain", EventMeshCloudEventUtils.getContentType(cloudEvent));
+        Assertions.assertEquals("text/plain", EventMeshCloudEventUtils.getContentType(cloudEvent, "application/json"));
+        Assertions.assertEquals("application/json", EventMeshCloudEventUtils.getContentType(CloudEvent.newBuilder().build(), "application/json"));
     }
 
     @Test
     public void testGetSubject() {
-        Assert.assertEquals("topic", EventMeshCloudEventUtils.getSubject(cloudEvent));
-        Assert.assertEquals("topic", EventMeshCloudEventUtils.getSubject(cloudEvent, "topic12"));
-        Assert.assertEquals("mxsm-topic", EventMeshCloudEventUtils.getSubject(CloudEvent.newBuilder().build(), "mxsm-topic"));
+        Assertions.assertEquals("topic", EventMeshCloudEventUtils.getSubject(cloudEvent));
+        Assertions.assertEquals("topic", EventMeshCloudEventUtils.getSubject(cloudEvent, "topic12"));
+        Assertions.assertEquals("mxsm-topic", EventMeshCloudEventUtils.getSubject(CloudEvent.newBuilder().build(), "mxsm-topic"));
     }
 
     @Test
     public void testGetDataContentType() {
-        Assert.assertEquals("text/plain", EventMeshCloudEventUtils.getDataContentType(cloudEvent));
-        Assert.assertEquals("text/plain", EventMeshCloudEventUtils.getDataContentType(cloudEvent, "application/json"));
-        Assert.assertEquals("application/json", EventMeshCloudEventUtils.getDataContentType(CloudEvent.newBuilder().build(), "application/json"));
+        Assertions.assertEquals("text/plain", EventMeshCloudEventUtils.getDataContentType(cloudEvent));
+        Assertions.assertEquals("text/plain", EventMeshCloudEventUtils.getDataContentType(cloudEvent, "application/json"));
+        Assertions.assertEquals("application/json", EventMeshCloudEventUtils.getDataContentType(CloudEvent.newBuilder().build(), "application/json"));
     }
 
     @Test
     public void testGetResponseCode() {
-        Assert.assertEquals("0", EventMeshCloudEventUtils.getResponseCode(cloudEvent));
-        Assert.assertEquals("0", EventMeshCloudEventUtils.getResponseCode(cloudEvent, "1"));
-        Assert.assertEquals("1", EventMeshCloudEventUtils.getResponseCode(CloudEvent.newBuilder().build(), "1"));
+        Assertions.assertEquals("0", EventMeshCloudEventUtils.getResponseCode(cloudEvent));
+        Assertions.assertEquals("0", EventMeshCloudEventUtils.getResponseCode(cloudEvent, "1"));
+        Assertions.assertEquals("1", EventMeshCloudEventUtils.getResponseCode(CloudEvent.newBuilder().build(), "1"));
     }
 
     @Test
     public void testGetResponseMessage() {
-        Assert.assertEquals("0", EventMeshCloudEventUtils.getResponseMessage(cloudEvent));
-        Assert.assertEquals("0", EventMeshCloudEventUtils.getResponseMessage(cloudEvent, "1"));
-        Assert.assertEquals("1", EventMeshCloudEventUtils.getResponseMessage(CloudEvent.newBuilder().build(), "1"));
+        Assertions.assertEquals("0", EventMeshCloudEventUtils.getResponseMessage(cloudEvent));
+        Assertions.assertEquals("0", EventMeshCloudEventUtils.getResponseMessage(cloudEvent, "1"));
+        Assertions.assertEquals("1", EventMeshCloudEventUtils.getResponseMessage(CloudEvent.newBuilder().build(), "1"));
     }
 
     @Test
     public void testGetResponseTime() {
-        Assert.assertEquals("2023-04-11T19:07Z", EventMeshCloudEventUtils.getResponseTime(cloudEvent));
-        Assert.assertEquals("2023-04-11T19:07Z", EventMeshCloudEventUtils.getResponseTime(cloudEvent, "2023-04-11 17:45:10"));
-        Assert.assertEquals("1970-01-01T00:00Z", EventMeshCloudEventUtils.getResponseTime(CloudEvent.newBuilder().build(), "1970-01-01T00:00Z"));
+        Assertions.assertEquals("2023-04-11T19:07Z", EventMeshCloudEventUtils.getResponseTime(cloudEvent));
+        Assertions.assertEquals("2023-04-11T19:07Z", EventMeshCloudEventUtils.getResponseTime(cloudEvent, "2023-04-11 17:45:10"));
+        Assertions.assertEquals("1970-01-01T00:00Z", EventMeshCloudEventUtils.getResponseTime(CloudEvent.newBuilder().build(), "1970-01-01T00:00Z"));
     }
 
     @Test
     public void testGetCluster() {
-        Assert.assertEquals("DefaultCluster", EventMeshCloudEventUtils.getCluster(cloudEvent));
-        Assert.assertEquals("DefaultCluster", EventMeshCloudEventUtils.getCluster(cloudEvent, "DefaultCluster1"));
-        Assert.assertEquals("DefaultCluster1", EventMeshCloudEventUtils.getCluster(CloudEvent.newBuilder().build(), "DefaultCluster1"));
+        Assertions.assertEquals("DefaultCluster", EventMeshCloudEventUtils.getCluster(cloudEvent));
+        Assertions.assertEquals("DefaultCluster", EventMeshCloudEventUtils.getCluster(cloudEvent, "DefaultCluster1"));
+        Assertions.assertEquals("DefaultCluster1", EventMeshCloudEventUtils.getCluster(CloudEvent.newBuilder().build(), "DefaultCluster1"));
     }
 
     @Test
     public void testGetConsumerGroup() {
-        Assert.assertEquals("ConsumerGroup", EventMeshCloudEventUtils.getConsumerGroup(cloudEvent));
-        Assert.assertEquals("ConsumerGroup", EventMeshCloudEventUtils.getConsumerGroup(cloudEvent, "ConsumerGroup111"));
-        Assert.assertEquals("ConsumerGroup111", EventMeshCloudEventUtils.getConsumerGroup(CloudEvent.newBuilder().build(), "ConsumerGroup111"));
+        Assertions.assertEquals("ConsumerGroup", EventMeshCloudEventUtils.getConsumerGroup(cloudEvent));
+        Assertions.assertEquals("ConsumerGroup", EventMeshCloudEventUtils.getConsumerGroup(cloudEvent, "ConsumerGroup111"));
+        Assertions.assertEquals("ConsumerGroup111", EventMeshCloudEventUtils.getConsumerGroup(CloudEvent.newBuilder().build(), "ConsumerGroup111"));
     }
 
     @Test
     public void testGetClientType() {
-        Assert.assertEquals(ClientType.SUB, EventMeshCloudEventUtils.getClientType(cloudEvent));
-        Assert.assertEquals(ClientType.SUB, EventMeshCloudEventUtils.getClientType(cloudEvent, ClientType.PUB));
-        Assert.assertEquals(ClientType.PUB, EventMeshCloudEventUtils.getClientType(CloudEvent.newBuilder().build(), ClientType.PUB));
+        Assertions.assertEquals(ClientType.SUB, EventMeshCloudEventUtils.getClientType(cloudEvent));
+        Assertions.assertEquals(ClientType.SUB, EventMeshCloudEventUtils.getClientType(cloudEvent, ClientType.PUB));
+        Assertions.assertEquals(ClientType.PUB, EventMeshCloudEventUtils.getClientType(CloudEvent.newBuilder().build(), ClientType.PUB));
     }
 
     @Test
     public void testGetURL() {
-        Assert.assertEquals("http://127.0.0.1", EventMeshCloudEventUtils.getURL(cloudEvent));
-        Assert.assertEquals("http://127.0.0.1", EventMeshCloudEventUtils.getURL(cloudEvent, "http://127.0.0.2"));
-        Assert.assertEquals("http://127.0.0.2", EventMeshCloudEventUtils.getURL(CloudEvent.newBuilder().build(), "http://127.0.0.2"));
+        Assertions.assertEquals("http://127.0.0.1", EventMeshCloudEventUtils.getURL(cloudEvent));
+        Assertions.assertEquals("http://127.0.0.1", EventMeshCloudEventUtils.getURL(cloudEvent, "http://127.0.0.2"));
+        Assertions.assertEquals("http://127.0.0.2", EventMeshCloudEventUtils.getURL(CloudEvent.newBuilder().build(), "http://127.0.0.2"));
     }
 
     @Test
     public void testGetDataContent() {
-        Assert.assertEquals("mxsm", EventMeshCloudEventUtils.getDataContent(cloudEvent));
-        Assert.assertEquals("mxsm", EventMeshCloudEventUtils.getDataContent(cloudEvent, "http://127.0.0.2"));
-        Assert.assertEquals("http://127.0.0.2", EventMeshCloudEventUtils.getDataContent(CloudEvent.newBuilder().build(), "http://127.0.0.2"));
+        Assertions.assertEquals("mxsm", EventMeshCloudEventUtils.getDataContent(cloudEvent));
+        Assertions.assertEquals("mxsm", EventMeshCloudEventUtils.getDataContent(cloudEvent, "http://127.0.0.2"));
+        Assertions.assertEquals("http://127.0.0.2", EventMeshCloudEventUtils.getDataContent(CloudEvent.newBuilder().build(), "http://127.0.0.2"));
     }
 
 

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/HttpCommandTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/HttpCommandTest.java
@@ -26,17 +26,17 @@ import org.apache.eventmesh.common.protocol.http.header.Header;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class HttpCommandTest {
 
     @Mock
@@ -47,7 +47,7 @@ public class HttpCommandTest {
 
     private HttpCommand httpCommand;
 
-    @Before
+    @BeforeEach
     public void before() {
         httpCommand = new HttpCommand("POST", "1.1", "200");
     }
@@ -58,45 +58,45 @@ public class HttpCommandTest {
         Map<String, Object> headerMap = new HashMap<>();
         headerMap.put("key1", "value1");
         when(header.toMap()).thenReturn(headerMap);
-        Assert.assertEquals("1.1", command.getHttpVersion());
-        Assert.assertEquals("POST", command.getHttpMethod());
-        Assert.assertEquals("200", command.getRequestCode());
-        Assert.assertEquals("value1", command.getHeader().toMap().get("key1"));
+        Assertions.assertEquals("1.1", command.getHttpVersion());
+        Assertions.assertEquals("POST", command.getHttpMethod());
+        Assertions.assertEquals("200", command.getRequestCode());
+        Assertions.assertEquals("value1", command.getHeader().toMap().get("key1"));
     }
 
     @Test
     public void testAbstractDesc() {
         HttpCommand command = httpCommand.createHttpCommandResponse(header, body);
         String desc = command.abstractDesc();
-        Assert.assertTrue(desc.startsWith("httpCommand"));
+        Assertions.assertTrue(desc.startsWith("httpCommand"));
     }
 
     @Test
     public void testSimpleDesc() {
         HttpCommand command = httpCommand.createHttpCommandResponse(header, body);
         String desc = command.simpleDesc();
-        Assert.assertTrue(desc.startsWith("httpCommand"));
+        Assertions.assertTrue(desc.startsWith("httpCommand"));
     }
 
     @Test
     public void testHttpResponse() throws Exception {
         HttpCommand command = httpCommand.createHttpCommandResponse(header, body);
         DefaultFullHttpResponse response = command.httpResponse();
-        Assert.assertEquals("keep-alive", response.headers().get(HttpHeaderNames.CONNECTION));
+        Assertions.assertEquals("keep-alive", response.headers().get(HttpHeaderNames.CONNECTION));
     }
 
     @Test
     public void testHttpResponseWithREQCmdType() throws Exception {
         DefaultFullHttpResponse response = httpCommand.httpResponse();
-        Assert.assertNull(response);
+        Assertions.assertNull(response);
     }
 
     @Test
     public void testCreateHttpCommandResponse() {
         HttpCommand command = new HttpCommand();
         HttpCommand response = command.createHttpCommandResponse(EventMeshRetCode.SUCCESS);
-        Assert.assertNotNull(response);
-        Assert.assertEquals("0", response.getRequestCode());
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals("0", response.getRequestCode());
 
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/HttpEventWrapperTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/HttpEventWrapperTest.java
@@ -23,20 +23,20 @@ import org.apache.eventmesh.common.utils.JsonUtils;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class HttpEventWrapperTest {
 
     private HttpEventWrapper httpEventWrapper;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         httpEventWrapper = new HttpEventWrapper("POST", "1.1", "hello");
     }
@@ -48,20 +48,20 @@ public class HttpEventWrapperTest {
         HashMap<String, Object> responseBodyMap = new HashMap<>();
         responseBodyMap.put("String", "responseBodyMap");
         HttpEventWrapper result = httpEventWrapper.createHttpResponse(headMap, responseBodyMap);
-        Assert.assertEquals("1.1", result.getHttpVersion());
-        Assert.assertEquals("POST", result.getHttpMethod());
-        Assert.assertEquals("hello", result.getRequestURI());
-        Assert.assertEquals("responseHeaderMap", result.getHeaderMap().get("String"));
+        Assertions.assertEquals("1.1", result.getHttpVersion());
+        Assertions.assertEquals("POST", result.getHttpMethod());
+        Assertions.assertEquals("hello", result.getRequestURI());
+        Assertions.assertEquals("responseHeaderMap", result.getHeaderMap().get("String"));
         Map responseMap = JsonUtils.parseObject(new String(result.getBody()), Map.class);
-        Assert.assertEquals("responseBodyMap", responseMap.get("String"));
+        Assertions.assertEquals("responseBodyMap", responseMap.get("String"));
     }
 
     @Test
     public void testCreateHttpResponse2() {
         HttpEventWrapper result = httpEventWrapper.createHttpResponse(EventMeshRetCode.SUCCESS);
         Map responseMap = JsonUtils.parseObject(new String(result.getBody()), Map.class);
-        Assert.assertEquals(EventMeshRetCode.SUCCESS.getRetCode(), responseMap.get("retCode"));
-        Assert.assertEquals(EventMeshRetCode.SUCCESS.getErrMsg(), responseMap.get("retMessage"));
+        Assertions.assertEquals(EventMeshRetCode.SUCCESS.getRetCode(), responseMap.get("retCode"));
+        Assertions.assertEquals(EventMeshRetCode.SUCCESS.getErrMsg(), responseMap.get("retMessage"));
     }
 
     @Test
@@ -69,8 +69,8 @@ public class HttpEventWrapperTest {
         byte[] bodyArray = new byte[]{'0'};
         httpEventWrapper.setBody(bodyArray);
         byte[] result = httpEventWrapper.getBody();
-        Assert.assertNotNull(result);
-        Assert.assertEquals(result[0], '0');
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(result[0], '0');
     }
 
     @Test
@@ -82,7 +82,7 @@ public class HttpEventWrapperTest {
     public void testHttpResponse() throws Exception {
         httpEventWrapper.setBody(new byte[]{(byte) 0});
         DefaultFullHttpResponse result = httpEventWrapper.httpResponse();
-        Assert.assertNotNull(result);
+        Assertions.assertNotNull(result);
     }
 
     @Test

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/body/BaseResponseBodyTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/body/BaseResponseBodyTest.java
@@ -17,12 +17,10 @@
 
 package org.apache.eventmesh.common.protocol.http.body;
 
-import static org.hamcrest.CoreMatchers.is;
-
 import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BaseResponseBodyTest {
 
@@ -31,10 +29,10 @@ public class BaseResponseBodyTest {
         BaseResponseBody body = new BaseResponseBody();
         body.setRetCode(200);
         body.setRetMsg("SUCCESS");
-        Assert.assertTrue(body.toMap().containsKey(ProtocolKey.RETCODE));
-        Assert.assertTrue(body.toMap().containsKey(ProtocolKey.RETMSG));
-        Assert.assertTrue(body.toMap().containsKey(ProtocolKey.RESTIME));
-        Assert.assertThat(body.toMap().get(ProtocolKey.RETCODE), is(200));
-        Assert.assertThat(body.toMap().get(ProtocolKey.RETMSG), is("SUCCESS"));
+        Assertions.assertTrue(body.toMap().containsKey(ProtocolKey.RETCODE));
+        Assertions.assertTrue(body.toMap().containsKey(ProtocolKey.RETMSG));
+        Assertions.assertTrue(body.toMap().containsKey(ProtocolKey.RESTIME));
+        Assertions.assertEquals(200, body.toMap().get(ProtocolKey.RETCODE));
+        Assertions.assertEquals("SUCCESS", body.toMap().get(ProtocolKey.RETMSG));
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/body/BodyTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/body/BodyTest.java
@@ -32,60 +32,60 @@ import org.apache.eventmesh.common.protocol.http.common.RequestCode;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BodyTest {
 
     private Map<String, Object> originalMap;
 
-    @Before
+    @BeforeEach
     public void before() {
         originalMap = new HashMap<>();
     }
 
     @Test
     public void testBuildBody() throws Exception {
-        Assert.assertThrows(Exception.class, () -> Body.buildBody("-1", originalMap));
+        Assertions.assertThrows(Exception.class, () -> Body.buildBody("-1", originalMap));
         Body sendMessageBatchRequestBody = Body.buildBody(String.valueOf(RequestCode.MSG_BATCH_SEND.getRequestCode()), originalMap);
-        Assert.assertNotNull(sendMessageBatchRequestBody);
-        Assert.assertEquals(sendMessageBatchRequestBody.getClass(), SendMessageBatchRequestBody.class);
+        Assertions.assertNotNull(sendMessageBatchRequestBody);
+        Assertions.assertEquals(sendMessageBatchRequestBody.getClass(), SendMessageBatchRequestBody.class);
         Body sendMessageBatchV2RequestBody = Body.buildBody(String.valueOf(RequestCode.MSG_BATCH_SEND_V2.getRequestCode()), originalMap);
-        Assert.assertNotNull(sendMessageBatchV2RequestBody);
-        Assert.assertEquals(sendMessageBatchV2RequestBody.getClass(), SendMessageBatchV2RequestBody.class);
+        Assertions.assertNotNull(sendMessageBatchV2RequestBody);
+        Assertions.assertEquals(sendMessageBatchV2RequestBody.getClass(), SendMessageBatchV2RequestBody.class);
         Body sendMessageRequestBodySync = Body.buildBody(String.valueOf(RequestCode.MSG_SEND_SYNC.getRequestCode()), originalMap);
-        Assert.assertNotNull(sendMessageRequestBodySync);
-        Assert.assertEquals(sendMessageRequestBodySync.getClass(), SendMessageRequestBody.class);
+        Assertions.assertNotNull(sendMessageRequestBodySync);
+        Assertions.assertEquals(sendMessageRequestBodySync.getClass(), SendMessageRequestBody.class);
         Body sendMessageRequestBodyAsync = Body.buildBody(String.valueOf(RequestCode.MSG_SEND_ASYNC.getRequestCode()), originalMap);
-        Assert.assertNotNull(sendMessageRequestBodyAsync);
-        Assert.assertEquals(sendMessageRequestBodyAsync.getClass(), SendMessageRequestBody.class);
+        Assertions.assertNotNull(sendMessageRequestBodyAsync);
+        Assertions.assertEquals(sendMessageRequestBodyAsync.getClass(), SendMessageRequestBody.class);
         Body pushMessageRequestBodySync = Body.buildBody(String.valueOf(RequestCode.HTTP_PUSH_CLIENT_SYNC.getRequestCode()), originalMap);
-        Assert.assertNotNull(pushMessageRequestBodySync);
-        Assert.assertEquals(pushMessageRequestBodySync.getClass(), PushMessageRequestBody.class);
+        Assertions.assertNotNull(pushMessageRequestBodySync);
+        Assertions.assertEquals(pushMessageRequestBodySync.getClass(), PushMessageRequestBody.class);
         Body pushMessageRequestBodyAsync = Body.buildBody(String.valueOf(RequestCode.HTTP_PUSH_CLIENT_ASYNC.getRequestCode()), originalMap);
-        Assert.assertNotNull(pushMessageRequestBodyAsync);
-        Assert.assertEquals(pushMessageRequestBodyAsync.getClass(), PushMessageRequestBody.class);
+        Assertions.assertNotNull(pushMessageRequestBodyAsync);
+        Assertions.assertEquals(pushMessageRequestBodyAsync.getClass(), PushMessageRequestBody.class);
         Body regRequestBody = Body.buildBody(String.valueOf(RequestCode.REGISTER.getRequestCode()), originalMap);
-        Assert.assertNotNull(regRequestBody);
-        Assert.assertEquals(regRequestBody.getClass(), RegRequestBody.class);
+        Assertions.assertNotNull(regRequestBody);
+        Assertions.assertEquals(regRequestBody.getClass(), RegRequestBody.class);
         Body unRegRequestBody = Body.buildBody(String.valueOf(RequestCode.UNREGISTER.getRequestCode()), originalMap);
-        Assert.assertNotNull(unRegRequestBody);
-        Assert.assertEquals(unRegRequestBody.getClass(), UnRegRequestBody.class);
+        Assertions.assertNotNull(unRegRequestBody);
+        Assertions.assertEquals(unRegRequestBody.getClass(), UnRegRequestBody.class);
         Body subscribeRequestBody = Body.buildBody(String.valueOf(RequestCode.SUBSCRIBE.getRequestCode()), originalMap);
-        Assert.assertNotNull(subscribeRequestBody);
-        Assert.assertEquals(subscribeRequestBody.getClass(), SubscribeRequestBody.class);
+        Assertions.assertNotNull(subscribeRequestBody);
+        Assertions.assertEquals(subscribeRequestBody.getClass(), SubscribeRequestBody.class);
         Body unSubscribeRequestBody = Body.buildBody(String.valueOf(RequestCode.UNSUBSCRIBE.getRequestCode()), originalMap);
-        Assert.assertNotNull(unSubscribeRequestBody);
-        Assert.assertEquals(unSubscribeRequestBody.getClass(), UnSubscribeRequestBody.class);
+        Assertions.assertNotNull(unSubscribeRequestBody);
+        Assertions.assertEquals(unSubscribeRequestBody.getClass(), UnSubscribeRequestBody.class);
         Body heartbeatRequestBody = Body.buildBody(String.valueOf(RequestCode.HEARTBEAT.getRequestCode()), originalMap);
-        Assert.assertNotNull(heartbeatRequestBody);
-        Assert.assertEquals(heartbeatRequestBody.getClass(), HeartbeatRequestBody.class);
+        Assertions.assertNotNull(heartbeatRequestBody);
+        Assertions.assertEquals(heartbeatRequestBody.getClass(), HeartbeatRequestBody.class);
         Body replyMessageRequestBody = Body.buildBody(String.valueOf(RequestCode.REPLY_MESSAGE.getRequestCode()), originalMap);
-        Assert.assertNotNull(replyMessageRequestBody);
-        Assert.assertEquals(replyMessageRequestBody.getClass(), ReplyMessageRequestBody.class);
+        Assertions.assertNotNull(replyMessageRequestBody);
+        Assertions.assertEquals(replyMessageRequestBody.getClass(), ReplyMessageRequestBody.class);
         Body baseRequestBody = Body.buildBody(String.valueOf(RequestCode.ADMIN_SHUTDOWN.getRequestCode()), originalMap);
-        Assert.assertNotNull(baseRequestBody);
-        Assert.assertEquals(baseRequestBody.getClass(), BaseRequestBody.class);
+        Assertions.assertNotNull(baseRequestBody);
+        Assertions.assertEquals(baseRequestBody.getClass(), BaseRequestBody.class);
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/BaseRequestHeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/BaseRequestHeaderTest.java
@@ -17,15 +17,13 @@
 
 package org.apache.eventmesh.common.protocol.http.header;
 
-import static org.hamcrest.CoreMatchers.is;
-
 import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BaseRequestHeaderTest {
 
@@ -34,7 +32,7 @@ public class BaseRequestHeaderTest {
         Map<String, Object> headerParam = new HashMap<>();
         headerParam.put(ProtocolKey.REQUEST_CODE, "200");
         BaseRequestHeader header = BaseRequestHeader.buildHeader(headerParam);
-        Assert.assertTrue(header.toMap().containsKey(ProtocolKey.REQUEST_CODE));
-        Assert.assertThat(header.toMap().get(ProtocolKey.REQUEST_CODE), is("200"));
+        Assertions.assertTrue(header.toMap().containsKey(ProtocolKey.REQUEST_CODE));
+        Assertions.assertEquals("200", header.toMap().get(ProtocolKey.REQUEST_CODE));
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/BaseResponseHeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/BaseResponseHeaderTest.java
@@ -17,19 +17,17 @@
 
 package org.apache.eventmesh.common.protocol.http.header;
 
-import static org.hamcrest.CoreMatchers.is;
-
 import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BaseResponseHeaderTest {
 
     @Test
     public void testToMap() {
         BaseResponseHeader header = BaseResponseHeader.buildHeader("200");
-        Assert.assertTrue(header.toMap().containsKey(ProtocolKey.REQUEST_CODE));
-        Assert.assertThat(header.toMap().get(ProtocolKey.REQUEST_CODE), is("200"));
+        Assertions.assertTrue(header.toMap().containsKey(ProtocolKey.REQUEST_CODE));
+        Assertions.assertEquals("200", header.toMap().get(ProtocolKey.REQUEST_CODE));
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/HeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/HeaderTest.java
@@ -32,60 +32,60 @@ import org.apache.eventmesh.common.protocol.http.header.message.SendMessageReque
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class HeaderTest {
 
     private Map<String, Object> originalMap;
 
-    @Before
+    @BeforeEach
     public void before() {
         originalMap = new HashMap<>();
     }
 
     @Test
     public void testBuildHeader() throws Exception {
-        Assert.assertThrows(Exception.class, () -> Header.buildHeader("-1", originalMap));
+        Assertions.assertThrows(Exception.class, () -> Header.buildHeader("-1", originalMap));
         Header messageBatchRequestHeader = Header.buildHeader(String.valueOf(RequestCode.MSG_BATCH_SEND.getRequestCode()), originalMap);
-        Assert.assertNotNull(messageBatchRequestHeader);
-        Assert.assertEquals(messageBatchRequestHeader.getClass(), SendMessageBatchRequestHeader.class);
+        Assertions.assertNotNull(messageBatchRequestHeader);
+        Assertions.assertEquals(messageBatchRequestHeader.getClass(), SendMessageBatchRequestHeader.class);
         Header sendMessageBatchV2RequestHeader = Header.buildHeader(String.valueOf(RequestCode.MSG_BATCH_SEND_V2.getRequestCode()), originalMap);
-        Assert.assertNotNull(sendMessageBatchV2RequestHeader);
-        Assert.assertEquals(sendMessageBatchV2RequestHeader.getClass(), SendMessageBatchV2RequestHeader.class);
+        Assertions.assertNotNull(sendMessageBatchV2RequestHeader);
+        Assertions.assertEquals(sendMessageBatchV2RequestHeader.getClass(), SendMessageBatchV2RequestHeader.class);
         Header sendMessageRequestHeaderSync = Header.buildHeader(String.valueOf(RequestCode.MSG_SEND_SYNC.getRequestCode()), originalMap);
-        Assert.assertNotNull(sendMessageRequestHeaderSync);
-        Assert.assertEquals(sendMessageRequestHeaderSync.getClass(), SendMessageRequestHeader.class);
+        Assertions.assertNotNull(sendMessageRequestHeaderSync);
+        Assertions.assertEquals(sendMessageRequestHeaderSync.getClass(), SendMessageRequestHeader.class);
         Header sendMessageRequestHeaderAsync = Header.buildHeader(String.valueOf(RequestCode.MSG_SEND_ASYNC.getRequestCode()), originalMap);
-        Assert.assertNotNull(sendMessageRequestHeaderAsync);
-        Assert.assertEquals(sendMessageRequestHeaderAsync.getClass(), SendMessageRequestHeader.class);
+        Assertions.assertNotNull(sendMessageRequestHeaderAsync);
+        Assertions.assertEquals(sendMessageRequestHeaderAsync.getClass(), SendMessageRequestHeader.class);
         Header pushMessageRequestHeaderSync = Header.buildHeader(String.valueOf(RequestCode.HTTP_PUSH_CLIENT_SYNC.getRequestCode()), originalMap);
-        Assert.assertNotNull(pushMessageRequestHeaderSync);
-        Assert.assertEquals(pushMessageRequestHeaderSync.getClass(), PushMessageRequestHeader.class);
+        Assertions.assertNotNull(pushMessageRequestHeaderSync);
+        Assertions.assertEquals(pushMessageRequestHeaderSync.getClass(), PushMessageRequestHeader.class);
         Header pushMessageRequestHeaderAsync = Header.buildHeader(String.valueOf(RequestCode.HTTP_PUSH_CLIENT_ASYNC.getRequestCode()), originalMap);
-        Assert.assertNotNull(pushMessageRequestHeaderAsync);
-        Assert.assertEquals(pushMessageRequestHeaderAsync.getClass(), PushMessageRequestHeader.class);
+        Assertions.assertNotNull(pushMessageRequestHeaderAsync);
+        Assertions.assertEquals(pushMessageRequestHeaderAsync.getClass(), PushMessageRequestHeader.class);
         Header regRequestHeader = Header.buildHeader(String.valueOf(RequestCode.REGISTER.getRequestCode()), originalMap);
-        Assert.assertNotNull(regRequestHeader);
-        Assert.assertEquals(regRequestHeader.getClass(), RegRequestHeader.class);
+        Assertions.assertNotNull(regRequestHeader);
+        Assertions.assertEquals(regRequestHeader.getClass(), RegRequestHeader.class);
         Header unRegRequestHeader = Header.buildHeader(String.valueOf(RequestCode.UNREGISTER.getRequestCode()), originalMap);
-        Assert.assertNotNull(unRegRequestHeader);
-        Assert.assertEquals(unRegRequestHeader.getClass(), UnRegRequestHeader.class);
+        Assertions.assertNotNull(unRegRequestHeader);
+        Assertions.assertEquals(unRegRequestHeader.getClass(), UnRegRequestHeader.class);
         Header subscribeRequestHeader = Header.buildHeader(String.valueOf(RequestCode.SUBSCRIBE.getRequestCode()), originalMap);
-        Assert.assertNotNull(subscribeRequestHeader);
-        Assert.assertEquals(subscribeRequestHeader.getClass(), SubscribeRequestHeader.class);
+        Assertions.assertNotNull(subscribeRequestHeader);
+        Assertions.assertEquals(subscribeRequestHeader.getClass(), SubscribeRequestHeader.class);
         Header unSubscribeRequestHeader = Header.buildHeader(String.valueOf(RequestCode.UNSUBSCRIBE.getRequestCode()), originalMap);
-        Assert.assertNotNull(unSubscribeRequestHeader);
-        Assert.assertEquals(unSubscribeRequestHeader.getClass(), UnSubscribeRequestHeader.class);
+        Assertions.assertNotNull(unSubscribeRequestHeader);
+        Assertions.assertEquals(unSubscribeRequestHeader.getClass(), UnSubscribeRequestHeader.class);
         Header heartbeatRequestHeader = Header.buildHeader(String.valueOf(RequestCode.HEARTBEAT.getRequestCode()), originalMap);
-        Assert.assertNotNull(heartbeatRequestHeader);
-        Assert.assertEquals(heartbeatRequestHeader.getClass(), HeartbeatRequestHeader.class);
+        Assertions.assertNotNull(heartbeatRequestHeader);
+        Assertions.assertEquals(heartbeatRequestHeader.getClass(), HeartbeatRequestHeader.class);
         Header replyMessageRequestHeader = Header.buildHeader(String.valueOf(RequestCode.REPLY_MESSAGE.getRequestCode()), originalMap);
-        Assert.assertNotNull(replyMessageRequestHeader);
-        Assert.assertEquals(replyMessageRequestHeader.getClass(), ReplyMessageRequestHeader.class);
+        Assertions.assertNotNull(replyMessageRequestHeader);
+        Assertions.assertEquals(replyMessageRequestHeader.getClass(), ReplyMessageRequestHeader.class);
         Header baseRequestHeader = Header.buildHeader(String.valueOf(RequestCode.ADMIN_SHUTDOWN.getRequestCode()), originalMap);
-        Assert.assertNotNull(baseRequestHeader);
-        Assert.assertEquals(baseRequestHeader.getClass(), BaseRequestHeader.class);
+        Assertions.assertNotNull(baseRequestHeader);
+        Assertions.assertEquals(baseRequestHeader.getClass(), BaseRequestHeader.class);
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/AbstractRequestHeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/AbstractRequestHeaderTest.java
@@ -20,20 +20,20 @@ package org.apache.eventmesh.common.protocol.http.header.client;
 import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.http.header.Header;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class AbstractRequestHeaderTest {
 
     public void assertMapContent(Header header) {
-        Assert.assertTrue(header.toMap().containsKey(ProtocolKey.REQUEST_CODE));
-        Assert.assertTrue(header.toMap().containsKey(ProtocolKey.LANGUAGE));
-        Assert.assertTrue(header.toMap().containsKey(ProtocolKey.VERSION));
-        Assert.assertTrue(header.toMap().containsKey(ProtocolKey.ClientInstanceKey.ENV.getKey()));
-        Assert.assertTrue(header.toMap().containsKey(ProtocolKey.ClientInstanceKey.IDC.getKey()));
-        Assert.assertTrue(header.toMap().containsKey(ProtocolKey.ClientInstanceKey.SYS.getKey()));
-        Assert.assertTrue(header.toMap().containsKey(ProtocolKey.ClientInstanceKey.PID.getKey()));
-        Assert.assertTrue(header.toMap().containsKey(ProtocolKey.ClientInstanceKey.IP.getKey()));
-        Assert.assertTrue(header.toMap().containsKey(ProtocolKey.ClientInstanceKey.USERNAME.getKey()));
-        Assert.assertTrue(header.toMap().containsKey(ProtocolKey.ClientInstanceKey.PASSWD.getKey()));
+        Assertions.assertTrue(header.toMap().containsKey(ProtocolKey.REQUEST_CODE));
+        Assertions.assertTrue(header.toMap().containsKey(ProtocolKey.LANGUAGE));
+        Assertions.assertTrue(header.toMap().containsKey(ProtocolKey.VERSION));
+        Assertions.assertTrue(header.toMap().containsKey(ProtocolKey.ClientInstanceKey.ENV.getKey()));
+        Assertions.assertTrue(header.toMap().containsKey(ProtocolKey.ClientInstanceKey.IDC.getKey()));
+        Assertions.assertTrue(header.toMap().containsKey(ProtocolKey.ClientInstanceKey.SYS.getKey()));
+        Assertions.assertTrue(header.toMap().containsKey(ProtocolKey.ClientInstanceKey.PID.getKey()));
+        Assertions.assertTrue(header.toMap().containsKey(ProtocolKey.ClientInstanceKey.IP.getKey()));
+        Assertions.assertTrue(header.toMap().containsKey(ProtocolKey.ClientInstanceKey.USERNAME.getKey()));
+        Assertions.assertTrue(header.toMap().containsKey(ProtocolKey.ClientInstanceKey.PASSWD.getKey()));
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/AbstractResponseHeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/AbstractResponseHeaderTest.java
@@ -17,25 +17,23 @@
 
 package org.apache.eventmesh.common.protocol.http.header.client;
 
-import static org.hamcrest.CoreMatchers.is;
-
 import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.http.header.Header;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class AbstractResponseHeaderTest {
 
     public void assertMapContent(Header header) {
-        Assert.assertTrue(header.toMap().containsKey(ProtocolKey.REQUEST_CODE));
-        Assert.assertTrue(header.toMap().containsKey(ProtocolKey.EventMeshInstanceKey.EVENTMESHCLUSTER));
-        Assert.assertTrue(header.toMap().containsKey(ProtocolKey.EventMeshInstanceKey.EVENTMESHIP));
-        Assert.assertTrue(header.toMap().containsKey(ProtocolKey.EventMeshInstanceKey.EVENTMESHENV));
-        Assert.assertTrue(header.toMap().containsKey(ProtocolKey.EventMeshInstanceKey.EVENTMESHIDC));
-        Assert.assertThat(header.toMap().get(ProtocolKey.REQUEST_CODE), is(200));
-        Assert.assertThat(header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHCLUSTER), is("CLUSTER"));
-        Assert.assertThat(header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHIP), is("127.0.0.1"));
-        Assert.assertThat(header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHENV), is("DEV"));
-        Assert.assertThat(header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHIDC), is("IDC"));
+        Assertions.assertTrue(header.toMap().containsKey(ProtocolKey.REQUEST_CODE));
+        Assertions.assertTrue(header.toMap().containsKey(ProtocolKey.EventMeshInstanceKey.EVENTMESHCLUSTER));
+        Assertions.assertTrue(header.toMap().containsKey(ProtocolKey.EventMeshInstanceKey.EVENTMESHIP));
+        Assertions.assertTrue(header.toMap().containsKey(ProtocolKey.EventMeshInstanceKey.EVENTMESHENV));
+        Assertions.assertTrue(header.toMap().containsKey(ProtocolKey.EventMeshInstanceKey.EVENTMESHIDC));
+        Assertions.assertEquals(200, header.toMap().get(ProtocolKey.REQUEST_CODE));
+        Assertions.assertEquals("CLUSTER", header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHCLUSTER));
+        Assertions.assertEquals("127.0.0.1", header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHIP));
+        Assertions.assertEquals("DEV", header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHENV));
+        Assertions.assertEquals("IDC", header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHIDC));
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/HeartbeatRequestHeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/HeartbeatRequestHeaderTest.java
@@ -19,7 +19,7 @@ package org.apache.eventmesh.common.protocol.http.header.client;
 
 import java.util.HashMap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class HeartbeatRequestHeaderTest extends AbstractRequestHeaderTest {
 

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/HeartbeatResponseHeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/HeartbeatResponseHeaderTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.eventmesh.common.protocol.http.header.client;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class HeartbeatResponseHeaderTest extends AbstractResponseHeaderTest {
 

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/RegRequestHeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/RegRequestHeaderTest.java
@@ -19,7 +19,7 @@ package org.apache.eventmesh.common.protocol.http.header.client;
 
 import java.util.HashMap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RegRequestHeaderTest extends AbstractRequestHeaderTest {
 

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/RegResponseHeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/RegResponseHeaderTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.eventmesh.common.protocol.http.header.client;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RegResponseHeaderTest extends AbstractResponseHeaderTest {
 

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/SubscribeRequestHeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/SubscribeRequestHeaderTest.java
@@ -19,7 +19,7 @@ package org.apache.eventmesh.common.protocol.http.header.client;
 
 import java.util.HashMap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SubscribeRequestHeaderTest extends AbstractRequestHeaderTest {
 

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/SubscribeResponseHeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/SubscribeResponseHeaderTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.eventmesh.common.protocol.http.header.client;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SubscribeResponseHeaderTest extends AbstractResponseHeaderTest {
 

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/UnRegRequestHeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/UnRegRequestHeaderTest.java
@@ -19,7 +19,7 @@ package org.apache.eventmesh.common.protocol.http.header.client;
 
 import java.util.HashMap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UnRegRequestHeaderTest extends AbstractRequestHeaderTest {
 

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/UnRegResponseHeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/UnRegResponseHeaderTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.eventmesh.common.protocol.http.header.client;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UnRegResponseHeaderTest extends AbstractResponseHeaderTest {
 

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/UnSubscribeRequestHeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/UnSubscribeRequestHeaderTest.java
@@ -19,7 +19,7 @@ package org.apache.eventmesh.common.protocol.http.header.client;
 
 import java.util.HashMap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UnSubscribeRequestHeaderTest extends AbstractRequestHeaderTest {
 

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/UnSubscribeResponseHeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/client/UnSubscribeResponseHeaderTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.eventmesh.common.protocol.http.header.client;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UnSubscribeResponseHeaderTest extends AbstractResponseHeaderTest {
 

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/message/PushMessageRequestHeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/message/PushMessageRequestHeaderTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.eventmesh.common.protocol.http.header.message;
 
-import static org.hamcrest.CoreMatchers.is;
-
 import org.apache.eventmesh.common.Constants;
 import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.http.common.ProtocolVersion;
@@ -26,15 +24,15 @@ import org.apache.eventmesh.common.protocol.http.common.ProtocolVersion;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class PushMessageRequestHeaderTest {
 
     private PushMessageRequestHeader header;
 
-    @Before
+    @BeforeEach
     public void before() {
         Map<String, Object> headerParam = new HashMap<>();
         headerParam.put(ProtocolKey.REQUEST_CODE, 200);
@@ -49,12 +47,12 @@ public class PushMessageRequestHeaderTest {
 
     @Test
     public void testToMap() {
-        Assert.assertThat(header.toMap().get(ProtocolKey.REQUEST_CODE), is(200));
-        Assert.assertThat(header.toMap().get(ProtocolKey.LANGUAGE), is(Constants.LANGUAGE_JAVA));
-        Assert.assertThat(header.toMap().get(ProtocolKey.VERSION), is(ProtocolVersion.V1));
-        Assert.assertThat(header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHCLUSTER), is("default cluster"));
-        Assert.assertThat(header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHIP), is("127.0.0.1"));
-        Assert.assertThat(header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHENV), is("DEV"));
-        Assert.assertThat(header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHIDC), is("IDC"));
+        Assertions.assertEquals(200, header.toMap().get(ProtocolKey.REQUEST_CODE));
+        Assertions.assertEquals(Constants.LANGUAGE_JAVA, header.toMap().get(ProtocolKey.LANGUAGE));
+        Assertions.assertEquals(ProtocolVersion.V1, header.toMap().get(ProtocolKey.VERSION));
+        Assertions.assertEquals("default cluster", header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHCLUSTER));
+        Assertions.assertEquals("127.0.0.1", header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHIP));
+        Assertions.assertEquals("DEV", header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHENV));
+        Assertions.assertEquals("IDC", header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHIDC));
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/message/PushMessageResponseHeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/message/PushMessageResponseHeaderTest.java
@@ -17,14 +17,12 @@
 
 package org.apache.eventmesh.common.protocol.http.header.message;
 
-import static org.hamcrest.CoreMatchers.is;
-
 import org.apache.eventmesh.common.Constants;
 import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.http.common.ProtocolVersion;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PushMessageResponseHeaderTest {
 
@@ -32,13 +30,13 @@ public class PushMessageResponseHeaderTest {
     public void testToMap() {
         PushMessageResponseHeader header = PushMessageResponseHeader.buildHeader(100, "DEV",
             "IDC", "SYSID", "PID", "127.0.0.1");
-        Assert.assertThat(header.toMap().get(ProtocolKey.REQUEST_CODE), is(100));
-        Assert.assertThat(header.toMap().get(ProtocolKey.LANGUAGE), is(Constants.LANGUAGE_JAVA));
-        Assert.assertThat(header.toMap().get(ProtocolKey.VERSION), is(ProtocolVersion.V1));
-        Assert.assertThat(header.toMap().get(ProtocolKey.ClientInstanceKey.ENV.getKey()), is("DEV"));
-        Assert.assertThat(header.toMap().get(ProtocolKey.ClientInstanceKey.IDC.getKey()), is("IDC"));
-        Assert.assertThat(header.toMap().get(ProtocolKey.ClientInstanceKey.SYS.getKey()), is("SYSID"));
-        Assert.assertThat(header.toMap().get(ProtocolKey.ClientInstanceKey.PID.getKey()), is("PID"));
-        Assert.assertThat(header.toMap().get(ProtocolKey.ClientInstanceKey.IP.getKey()), is("127.0.0.1"));
+        Assertions.assertEquals(100, header.toMap().get(ProtocolKey.REQUEST_CODE));
+        Assertions.assertEquals(Constants.LANGUAGE_JAVA, header.toMap().get(ProtocolKey.LANGUAGE));
+        Assertions.assertEquals(ProtocolVersion.V1, header.toMap().get(ProtocolKey.VERSION));
+        Assertions.assertEquals("DEV", header.toMap().get(ProtocolKey.ClientInstanceKey.ENV.getKey()));
+        Assertions.assertEquals("IDC", header.toMap().get(ProtocolKey.ClientInstanceKey.IDC.getKey()));
+        Assertions.assertEquals("SYSID", header.toMap().get(ProtocolKey.ClientInstanceKey.SYS.getKey()));
+        Assertions.assertEquals("PID", header.toMap().get(ProtocolKey.ClientInstanceKey.PID.getKey()));
+        Assertions.assertEquals("127.0.0.1", header.toMap().get(ProtocolKey.ClientInstanceKey.IP.getKey()));
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/message/ReplyMessageRequestHeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/message/ReplyMessageRequestHeaderTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.eventmesh.common.protocol.http.header.message;
 
-import static org.hamcrest.CoreMatchers.is;
-
 import org.apache.eventmesh.common.Constants;
 import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.http.common.ProtocolVersion;
@@ -26,15 +24,15 @@ import org.apache.eventmesh.common.protocol.http.common.ProtocolVersion;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ReplyMessageRequestHeaderTest {
 
     private ReplyMessageRequestHeader header;
 
-    @Before
+    @BeforeEach
     public void before() {
         Map<String, Object> headerParam = new HashMap<>();
         headerParam.put(ProtocolKey.REQUEST_CODE, "200");
@@ -50,13 +48,13 @@ public class ReplyMessageRequestHeaderTest {
 
     @Test
     public void testToMap() {
-        Assert.assertThat(header.toMap().get(ProtocolKey.REQUEST_CODE), is("200"));
-        Assert.assertThat(header.toMap().get(ProtocolKey.LANGUAGE), is(Constants.LANGUAGE_JAVA));
-        Assert.assertThat(header.toMap().get(ProtocolKey.VERSION), is(ProtocolVersion.V1));
-        Assert.assertThat(header.toMap().get(ProtocolKey.ClientInstanceKey.ENV.getKey()), is("DEV"));
-        Assert.assertThat(header.toMap().get(ProtocolKey.ClientInstanceKey.IDC.getKey()), is("IDC"));
-        Assert.assertThat(header.toMap().get(ProtocolKey.ClientInstanceKey.SYS.getKey()), is("SYS"));
-        Assert.assertThat(header.toMap().get(ProtocolKey.ClientInstanceKey.PID.getKey()), is("PID"));
-        Assert.assertThat(header.toMap().get(ProtocolKey.ClientInstanceKey.IP.getKey()), is("127.0.0.1"));
+        Assertions.assertEquals("200", header.toMap().get(ProtocolKey.REQUEST_CODE));
+        Assertions.assertEquals(Constants.LANGUAGE_JAVA, header.toMap().get(ProtocolKey.LANGUAGE));
+        Assertions.assertEquals(ProtocolVersion.V1, header.toMap().get(ProtocolKey.VERSION));
+        Assertions.assertEquals("DEV", header.toMap().get(ProtocolKey.ClientInstanceKey.ENV.getKey()));
+        Assertions.assertEquals("IDC", header.toMap().get(ProtocolKey.ClientInstanceKey.IDC.getKey()));
+        Assertions.assertEquals("SYS", header.toMap().get(ProtocolKey.ClientInstanceKey.SYS.getKey()));
+        Assertions.assertEquals("PID", header.toMap().get(ProtocolKey.ClientInstanceKey.PID.getKey()));
+        Assertions.assertEquals("127.0.0.1", header.toMap().get(ProtocolKey.ClientInstanceKey.IP.getKey()));
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/message/ReplyMessageResponseHeaderTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/http/header/message/ReplyMessageResponseHeaderTest.java
@@ -17,12 +17,10 @@
 
 package org.apache.eventmesh.common.protocol.http.header.message;
 
-import static org.hamcrest.CoreMatchers.is;
-
 import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ReplyMessageResponseHeaderTest {
 
@@ -30,10 +28,10 @@ public class ReplyMessageResponseHeaderTest {
     public void testToMap() {
         ReplyMessageResponseHeader header = ReplyMessageResponseHeader.buildHeader(100,
             "Cluster", "127.0.0.1", "DEV", "IDC");
-        Assert.assertThat(header.toMap().get(ProtocolKey.REQUEST_CODE), is(100));
-        Assert.assertThat(header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHCLUSTER), is("Cluster"));
-        Assert.assertThat(header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHIP), is("127.0.0.1"));
-        Assert.assertThat(header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHENV), is("DEV"));
-        Assert.assertThat(header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHIDC), is("IDC"));
+        Assertions.assertEquals(100, header.toMap().get(ProtocolKey.REQUEST_CODE));
+        Assertions.assertEquals("Cluster", header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHCLUSTER));
+        Assertions.assertEquals("127.0.0.1", header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHIP));
+        Assertions.assertEquals("DEV", header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHENV));
+        Assertions.assertEquals("IDC", header.toMap().get(ProtocolKey.EventMeshInstanceKey.EVENTMESHIDC));
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/tcp/codec/CodecTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/tcp/codec/CodecTest.java
@@ -23,8 +23,8 @@ import org.apache.eventmesh.common.protocol.tcp.Package;
 
 import java.util.ArrayList;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -43,8 +43,8 @@ public class CodecTest {
         Codec.Decoder cd = new Codec.Decoder();
         ArrayList<Object> result = new ArrayList<>();
         cd.decode(null, buf, result);
-        Assert.assertNotNull(result.get(0));
-        Assert.assertEquals(testP.getHeader(), ((Package) result.get(0)).getHeader());
+        Assertions.assertNotNull(result.get(0));
+        Assertions.assertEquals(testP.getHeader(), ((Package) result.get(0)).getHeader());
     }
 
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/AssertUtilsTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/AssertUtilsTest.java
@@ -17,20 +17,21 @@
 
 package org.apache.eventmesh.common.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * test {@link AssertUtils}
  */
 public class AssertUtilsTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotNull() {
-        AssertUtils.notNull(null, "error message");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> AssertUtils.notNull(null, "error message"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testIsTrue() {
-        AssertUtils.isTrue(false, "error message");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> AssertUtils.isTrue(false, "error message"));
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/ConfigurationContextUtilTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/ConfigurationContextUtilTest.java
@@ -19,15 +19,15 @@ package org.apache.eventmesh.common.utils;
 
 import org.apache.eventmesh.common.config.CommonConfiguration;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ConfigurationContextUtilTest {
 
     private CommonConfiguration grpcConfig;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         grpcConfig = new CommonConfiguration();
         grpcConfig.setEventMeshName("grpc");
@@ -40,30 +40,30 @@ public class ConfigurationContextUtilTest {
         tcpConfig.setEventMeshName("tpc");
         ConfigurationContextUtil.putIfAbsent(ConfigurationContextUtil.TCP, tcpConfig);
         CommonConfiguration get = ConfigurationContextUtil.get(ConfigurationContextUtil.TCP);
-        Assert.assertNotNull(get);
-        Assert.assertEquals(tcpConfig, get);
+        Assertions.assertNotNull(get);
+        Assertions.assertEquals(tcpConfig, get);
         CommonConfiguration newGrpc = new CommonConfiguration();
         newGrpc.setEventMeshName("newGrpc");
         ConfigurationContextUtil.putIfAbsent(ConfigurationContextUtil.GRPC, newGrpc);
         CommonConfiguration getGrpc = ConfigurationContextUtil.get(ConfigurationContextUtil.GRPC);
-        Assert.assertNotNull(getGrpc);
-        Assert.assertEquals(grpcConfig, getGrpc);
-        Assert.assertNotEquals(newGrpc, getGrpc);
+        Assertions.assertNotNull(getGrpc);
+        Assertions.assertEquals(grpcConfig, getGrpc);
+        Assertions.assertNotEquals(newGrpc, getGrpc);
     }
 
     @Test
     public void testGet() {
         CommonConfiguration result = ConfigurationContextUtil.get(ConfigurationContextUtil.GRPC);
-        Assert.assertNotNull(result);
-        Assert.assertEquals(grpcConfig, result);
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(grpcConfig, result);
     }
 
     @Test
     public void testClear() {
         CommonConfiguration result0 = ConfigurationContextUtil.get(ConfigurationContextUtil.GRPC);
-        Assert.assertNotNull(result0);
+        Assertions.assertNotNull(result0);
         ConfigurationContextUtil.clear();
         CommonConfiguration result = ConfigurationContextUtil.get(ConfigurationContextUtil.GRPC);
-        Assert.assertNull(result);
+        Assertions.assertNull(result);
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/IPUtilsTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/IPUtilsTest.java
@@ -17,22 +17,21 @@
 
 package org.apache.eventmesh.common.utils;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
 public class IPUtilsTest {
 
     @Test
+    @SetEnvironmentVariable(key = "docker_host_ip", value = "dockHostIP")
     public void testDockerIP() {
-        EnvironmentVariables environmentVariables = new EnvironmentVariables();
-        environmentVariables.set("docker_host_ip", "dockHostIP");
-        Assert.assertEquals("dockHostIP", IPUtils.getLocalAddress());
+        Assertions.assertEquals("dockHostIP", IPUtils.getLocalAddress());
     }
 
     @Test
     public void testLocalhostIP() {
-        Assert.assertNotNull(IPUtils.getLocalAddress());
+        Assertions.assertNotNull(IPUtils.getLocalAddress());
     }
 
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/JsonUtilsTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/JsonUtilsTest.java
@@ -24,8 +24,8 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -38,22 +38,22 @@ public class JsonUtilsTest {
     public void toJSONString() {
         Map<String, String> map = new HashMap<>();
         String jsonString = JsonUtils.toJSONString(map);
-        Assert.assertEquals("{}", jsonString);
+        Assertions.assertEquals("{}", jsonString);
         map.put("mxsm", "2");
         jsonString = JsonUtils.toJSONString(map);
-        Assert.assertEquals("{\"mxsm\":\"2\"}", jsonString);
+        Assertions.assertEquals("{\"mxsm\":\"2\"}", jsonString);
 
         Map<String, Object> maps = new HashMap<>();
         maps.put("mxsm", LocalDate.of(2013, 6, 28));
         jsonString = JsonUtils.toJSONString(maps);
-        Assert.assertEquals("{\"mxsm\":\"2013-06-28\"}", jsonString);
+        Assertions.assertEquals("{\"mxsm\":\"2013-06-28\"}", jsonString);
     }
 
     @Test
     public void testToBytes() {
         Map<String, String> map = new HashMap<>();
         map.put("mxsm", "2");
-        Assert.assertArrayEquals("{\"mxsm\":\"2\"}".getBytes(StandardCharsets.UTF_8), JsonUtils.toJSONBytes(map));
+        Assertions.assertArrayEquals("{\"mxsm\":\"2\"}".getBytes(StandardCharsets.UTF_8), JsonUtils.toJSONBytes(map));
     }
 
     @Test
@@ -63,23 +63,23 @@ public class JsonUtilsTest {
         Map<String, String> map = JsonUtils.parseTypeReferenceObject(json, new TypeReference<Map<String, String>>() {
 
         });
-        Assert.assertNotNull(map);
-        Assert.assertEquals("2", map.get("mxsm"));
+        Assertions.assertNotNull(map);
+        Assertions.assertEquals("2", map.get("mxsm"));
         EventMesh mxsm = JsonUtils.parseObject(json, EventMesh.class);
-        Assert.assertNotNull(mxsm);
-        Assert.assertEquals("2", mxsm.mxsm);
-        Assert.assertEquals(new GregorianCalendar(2022, 1, 12, 21, 36, 01).getTime().getTime(), mxsm.date.getTime());
+        Assertions.assertNotNull(mxsm);
+        Assertions.assertEquals("2", mxsm.mxsm);
+        Assertions.assertEquals(new GregorianCalendar(2022, 1, 12, 21, 36, 01).getTime().getTime(), mxsm.date.getTime());
         EventMesh mxsm1 = JsonUtils.parseObject(json.getBytes(StandardCharsets.UTF_8), EventMesh.class);
-        Assert.assertNotNull(mxsm1);
-        Assert.assertEquals("2", mxsm1.mxsm);
+        Assertions.assertNotNull(mxsm1);
+        Assertions.assertEquals("2", mxsm1.mxsm);
     }
 
     @Test
     public void getJsonNode() {
         String json = "{\"mxsm\":\"2\",\"date\":\"2022-02-12 21:36:01\"}";
         JsonNode jsonNode = JsonUtils.getJsonNode(json);
-        Assert.assertNotNull(jsonNode);
-        Assert.assertEquals("2", jsonNode.findValue("mxsm").asText());
+        Assertions.assertNotNull(jsonNode);
+        Assertions.assertEquals("2", jsonNode.findValue("mxsm").asText());
     }
 
     @Data

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/NetUtilsTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/NetUtilsTest.java
@@ -27,8 +27,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.sun.net.httpserver.HttpExchange;
@@ -39,23 +39,23 @@ public class NetUtilsTest {
     public void testFormData2Dic() {
         String formData = "";
         Map<String, String> result = NetUtils.formData2Dic(formData);
-        Assert.assertTrue(result.isEmpty());
+        Assertions.assertTrue(result.isEmpty());
 
         formData = "item_id=10081&item_name=test item name";
         result = NetUtils.formData2Dic(formData);
-        Assert.assertEquals("10081", result.get("item_id"));
+        Assertions.assertEquals("10081", result.get("item_id"));
     }
 
     @Test
     public void testAddressToString() {
         List<InetSocketAddress> clients = new ArrayList<>();
         String result = NetUtils.addressToString(clients);
-        Assert.assertEquals("no session had been closed", result);
+        Assertions.assertEquals("no session had been closed", result);
 
         InetSocketAddress localAddress = new InetSocketAddress(80);
         clients.add(localAddress);
         result = NetUtils.addressToString(clients);
-        Assert.assertEquals(localAddress + "|", result);
+        Assertions.assertEquals(localAddress + "|", result);
     }
 
     @Test
@@ -68,7 +68,7 @@ public class NetUtilsTest {
         Mockito.when(exchange.getRequestBody()).thenReturn(inputStream);
 
         String actual = NetUtils.parsePostBody(exchange);
-        Assert.assertEquals(expected, actual);
+        Assertions.assertEquals(expected, actual);
 
     }
 

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/PropertiesUtilsTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/PropertiesUtilsTest.java
@@ -21,8 +21,8 @@ import org.apache.eventmesh.common.config.ConfigService;
 
 import java.util.Properties;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PropertiesUtilsTest {
 
@@ -38,8 +38,8 @@ public class PropertiesUtilsTest {
         from.put(PREFIX + "c.f", "inner f");
         Properties to = PropertiesUtils.getPropertiesByPrefix(from, PREFIX);
 
-        Assert.assertEquals(3, to.size());
-        Assert.assertEquals(2, ((Properties) to.get("c")).size());
+        Assertions.assertEquals(3, to.size());
+        Assertions.assertEquals(2, ((Properties) to.get("c")).size());
     }
 
     @Test
@@ -51,10 +51,10 @@ public class PropertiesUtilsTest {
         String path = configService.getRootPath();
         try {
             PropertiesUtils.loadPropertiesWhenFileExist(properties, path);
-            Assert.assertEquals("env-succeed!!!", properties.get("eventMesh.server.env").toString());
-            Assert.assertEquals("idc-succeed!!!", properties.get("eventMesh.server.idc").toString());
+            Assertions.assertEquals("env-succeed!!!", properties.get("eventMesh.server.env").toString());
+            Assertions.assertEquals("idc-succeed!!!", properties.get("eventMesh.server.idc").toString());
         } catch (Exception e) {
-            Assert.fail();
+            Assertions.fail();
         }
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/RandomStringUtilsTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/RandomStringUtilsTest.java
@@ -19,22 +19,22 @@ package org.apache.eventmesh.common.utils;
 
 import org.apache.commons.lang3.math.NumberUtils;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RandomStringUtilsTest {
 
     @Test
     public void testGenerateNum() {
         String result = RandomStringUtils.generateNum(2);
-        Assert.assertTrue(NumberUtils.isDigits(result));
-        Assert.assertEquals(2, result.length());
+        Assertions.assertTrue(NumberUtils.isDigits(result));
+        Assertions.assertEquals(2, result.length());
     }
 
     @Test
     public void testGenerateUUID() {
         String result = RandomStringUtils.generateUUID();
-        Assert.assertTrue(result.matches("^\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}$"));
+        Assertions.assertTrue(result.matches("^\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}$"));
     }
 
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/ReflectUtilsTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/ReflectUtilsTest.java
@@ -19,8 +19,8 @@ package org.apache.eventmesh.common.utils;
 
 import java.lang.reflect.Field;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ReflectUtilsTest {
 
@@ -44,10 +44,10 @@ public class ReflectUtilsTest {
         Field fieldName = ReflectUtils.lookUpFieldByParentClass(TestObj.class, "name");
         Field fieldAge = ReflectUtils.lookUpFieldByParentClass(TestObj.class, "age");
         Field fieldTel = ReflectUtils.lookUpFieldByParentClass(TestObj.class, "tel");
-        Assert.assertNull(fieldName);
-        Assert.assertNull(fieldAge);
-        Assert.assertNotNull(fieldTel);
-        Assert.assertEquals("tel", fieldTel.getName());
+        Assertions.assertNull(fieldName);
+        Assertions.assertNull(fieldAge);
+        Assertions.assertNotNull(fieldTel);
+        Assertions.assertEquals("tel", fieldTel.getName());
     }
 
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/SystemUtilsTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/SystemUtilsTest.java
@@ -17,29 +17,29 @@
 
 package org.apache.eventmesh.common.utils;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SystemUtilsTest {
 
     @Test
     public void isLinuxPlatform() {
         if (null != SystemUtils.OS_NAME && SystemUtils.OS_NAME.toLowerCase().contains("linux")) {
-            Assert.assertTrue(SystemUtils.isLinuxPlatform());
-            Assert.assertFalse(SystemUtils.isWindowsPlatform());
+            Assertions.assertTrue(SystemUtils.isLinuxPlatform());
+            Assertions.assertFalse(SystemUtils.isWindowsPlatform());
         }
     }
 
     @Test
     public void isWindowsPlatform() {
         if (null != SystemUtils.OS_NAME && SystemUtils.OS_NAME.toLowerCase().contains("windows")) {
-            Assert.assertFalse(SystemUtils.isLinuxPlatform());
-            Assert.assertTrue(SystemUtils.isWindowsPlatform());
+            Assertions.assertFalse(SystemUtils.isLinuxPlatform());
+            Assertions.assertTrue(SystemUtils.isWindowsPlatform());
         }
     }
 
     @Test
     public void getProcessId() {
-        Assert.assertNotEquals("-1", SystemUtils.getProcessId());
+        Assertions.assertNotEquals("-1", SystemUtils.getProcessId());
     }
 }

--- a/eventmesh-connectors/eventmesh-connector-jdbc/build.gradle
+++ b/eventmesh-connectors/eventmesh-connector-jdbc/build.gradle
@@ -47,6 +47,4 @@ dependencies {
     testImplementation "org.assertj:assertj-core"
 
     testImplementation "org.mockito:mockito-core"
-    testImplementation "org.powermock:powermock-module-junit4"
-    testImplementation "org.powermock:powermock-api-mockito2"
 }

--- a/eventmesh-connectors/eventmesh-connector-jdbc/src/test/java/org/apache/eventmesh/connector/jdbc/table/catalog/TableIdTest.java
+++ b/eventmesh-connectors/eventmesh-connector-jdbc/src/test/java/org/apache/eventmesh/connector/jdbc/table/catalog/TableIdTest.java
@@ -17,13 +17,13 @@
 
 package org.apache.eventmesh.connector.jdbc.table.catalog;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TableIdTest {
 

--- a/eventmesh-connectors/eventmesh-connector-jdbc/src/test/java/org/apache/eventmesh/connector/jdbc/utils/Antlr4UtilsTest.java
+++ b/eventmesh-connectors/eventmesh-connector-jdbc/src/test/java/org/apache/eventmesh/connector/jdbc/utils/Antlr4UtilsTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.eventmesh.connector.jdbc.utils;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -25,7 +25,7 @@ import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Antlr4UtilsTest {
 

--- a/eventmesh-connectors/eventmesh-connector-jdbc/src/test/java/org/apache/eventmesh/connector/jdbc/utils/JdbcStringUtilsTest.java
+++ b/eventmesh-connectors/eventmesh-connector-jdbc/src/test/java/org/apache/eventmesh/connector/jdbc/utils/JdbcStringUtilsTest.java
@@ -17,11 +17,11 @@
 
 package org.apache.eventmesh.connector.jdbc.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JdbcStringUtilsTest {
 

--- a/eventmesh-connectors/eventmesh-connector-jdbc/src/test/java/org/apache/eventmesh/connector/jdbc/utils/MysqlUtilsTest.java
+++ b/eventmesh-connectors/eventmesh-connector-jdbc/src/test/java/org/apache/eventmesh/connector/jdbc/utils/MysqlUtilsTest.java
@@ -17,13 +17,13 @@
 
 package org.apache.eventmesh.connector.jdbc.utils;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.apache.eventmesh.connector.jdbc.table.catalog.TableId;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MysqlUtilsTest {
 

--- a/eventmesh-connectors/eventmesh-connector-rocketmq/build.gradle
+++ b/eventmesh-connectors/eventmesh-connector-rocketmq/build.gradle
@@ -24,7 +24,6 @@ List rocketmq = [
         "org.apache.rocketmq:rocketmq-tools:$rocketmq_version",
         "org.apache.rocketmq:rocketmq-remoting:$rocketmq_version",
         "org.apache.rocketmq:rocketmq-logging:$rocketmq_version",
-        "org.apache.rocketmq:rocketmq-test:$rocketmq_version",
         "org.apache.rocketmq:rocketmq-srvutil:$rocketmq_version",
         "org.apache.rocketmq:rocketmq-filter:$rocketmq_version",
         "org.apache.rocketmq:rocketmq-acl:$rocketmq_version",

--- a/eventmesh-connectors/eventmesh-connector-s3/src/test/java/org/apache/eventmesh/connector/s3/source/S3SourceConnectorTest.java
+++ b/eventmesh-connectors/eventmesh-connector-s3/src/test/java/org/apache/eventmesh/connector/s3/source/S3SourceConnectorTest.java
@@ -27,11 +27,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
@@ -39,7 +39,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
-@Ignore
+@Disabled
 public class S3SourceConnectorTest {
 
     private static final S3SourceConfig sourceConfig;
@@ -73,7 +73,7 @@ public class S3SourceConnectorTest {
 
     private S3AsyncClient s3Client;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         AwsBasicCredentials basicCredentials = AwsBasicCredentials.create(this.SOURCE_CONNECTOR_CONFIG.getAccessKey(),
             this.SOURCE_CONNECTOR_CONFIG.getSecretKey());
@@ -84,7 +84,7 @@ public class S3SourceConnectorTest {
         this.writeMockedRecords(200);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         // clear file
         this.s3Client.deleteObject(builder -> builder.bucket(this.SOURCE_CONNECTOR_CONFIG.getBucket())
@@ -102,13 +102,13 @@ public class S3SourceConnectorTest {
             if (connectRecords.isEmpty()) {
                 break;
             }
-            Assert.assertEquals(20, connectRecords.size());
+            Assertions.assertEquals(20, connectRecords.size());
             for (ConnectRecord connectRecord : connectRecords) {
                 byte[] data = (byte[]) connectRecord.getData();
-                Assert.assertEquals(eachRecordSize, data.length);
+                Assertions.assertEquals(eachRecordSize, data.length);
                 ByteBuffer byteBuffer = ByteBuffer.wrap(data);
                 int id = byteBuffer.getInt();
-                Assert.assertEquals(expectedId++, id);
+                Assertions.assertEquals(expectedId++, id);
             }
         }
 

--- a/eventmesh-console/build.gradle
+++ b/eventmesh-console/build.gradle
@@ -74,7 +74,3 @@ dependencies {
     // meta
     implementation("com.alibaba.nacos:nacos-client:${nacosVersion}")
 }
-
-tasks.named('test') {
-    useJUnitPlatform()
-}

--- a/eventmesh-meta/eventmesh-meta-consul/build.gradle
+++ b/eventmesh-meta/eventmesh-meta-consul/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation project(":eventmesh-meta:eventmesh-meta-api")
     implementation project(":eventmesh-common")
     testImplementation "org.mockito:mockito-core"
+    testImplementation "org.mockito:mockito-junit-jupiter"
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/eventmesh-meta/eventmesh-meta-consul/src/test/java/org/apache/eventmesh/meta/consul/service/ConsulMetaServiceTest.java
+++ b/eventmesh-meta/eventmesh-meta-consul/src/test/java/org/apache/eventmesh/meta/consul/service/ConsulMetaServiceTest.java
@@ -27,16 +27,19 @@ import org.apache.eventmesh.common.utils.ConfigurationContextUtil;
 import java.lang.reflect.Field;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class ConsulMetaServiceTest {
 
     @Mock
@@ -46,7 +49,7 @@ public class ConsulMetaServiceTest {
 
     private ConsulMetaService consulMetaService;
 
-    @Before
+    @BeforeEach
     public void registryTest() {
         consulMetaService = new ConsulMetaService();
         CommonConfiguration configuration = new CommonConfiguration();
@@ -60,7 +63,7 @@ public class ConsulMetaServiceTest {
         Mockito.when(eventMeshUnRegisterInfo.getEventMeshName()).thenReturn("eventmesh");
     }
 
-    @After
+    @AfterEach
     public void after() {
         consulMetaService.shutdown();
     }
@@ -69,14 +72,14 @@ public class ConsulMetaServiceTest {
     public void testInit() {
         consulMetaService.init();
         consulMetaService.start();
-        Assert.assertNotNull(consulMetaService.getConsulClient());
+        Assertions.assertNotNull(consulMetaService.getConsulClient());
     }
 
     @Test
     public void testStart() {
         consulMetaService.init();
         consulMetaService.start();
-        Assert.assertNotNull(consulMetaService.getConsulClient());
+        Assertions.assertNotNull(consulMetaService.getConsulClient());
     }
 
     @Test
@@ -84,7 +87,7 @@ public class ConsulMetaServiceTest {
         consulMetaService.init();
         consulMetaService.start();
         consulMetaService.shutdown();
-        Assert.assertNull(consulMetaService.getConsulClient());
+        Assertions.assertNull(consulMetaService.getConsulClient());
         Class<ConsulMetaService> consulRegistryServiceClass = ConsulMetaService.class;
         Field initStatus = consulRegistryServiceClass.getDeclaredField("initStatus");
         initStatus.setAccessible(true);
@@ -94,35 +97,41 @@ public class ConsulMetaServiceTest {
         startStatus.setAccessible(true);
         Object startStatusField = startStatus.get(consulMetaService);
 
-        Assert.assertFalse((Boolean.parseBoolean(initStatusField.toString())));
-        Assert.assertFalse((Boolean.parseBoolean(startStatusField.toString())));
+        Assertions.assertFalse((Boolean.parseBoolean(initStatusField.toString())));
+        Assertions.assertFalse((Boolean.parseBoolean(startStatusField.toString())));
     }
 
-    @Test(expected = MetaException.class)
+    @Test
     public void testRegister() {
-        consulMetaService.init();
-        consulMetaService.start();
-        consulMetaService.register(eventMeshRegisterInfo);
-        List<EventMeshDataInfo> eventmesh = consulMetaService.findEventMeshInfoByCluster("eventmesh");
-        Assert.assertEquals(1, eventmesh.size());
+        Assertions.assertThrows(MetaException.class, () -> {
+            consulMetaService.init();
+            consulMetaService.start();
+            consulMetaService.register(eventMeshRegisterInfo);
+            List<EventMeshDataInfo> eventmesh = consulMetaService.findEventMeshInfoByCluster("eventmesh");
+            Assertions.assertEquals(1, eventmesh.size());
+        });
     }
 
-    @Test(expected = MetaException.class)
+    @Test
     public void testUnRegister() {
-        consulMetaService.init();
-        consulMetaService.start();
-        consulMetaService.unRegister(eventMeshUnRegisterInfo);
-        List<EventMeshDataInfo> eventmesh = consulMetaService.findEventMeshInfoByCluster("eventmesh");
-        Assert.assertEquals(0, eventmesh.size());
+        Assertions.assertThrows(MetaException.class, () -> {
+            consulMetaService.init();
+            consulMetaService.start();
+            consulMetaService.unRegister(eventMeshUnRegisterInfo);
+            List<EventMeshDataInfo> eventmesh = consulMetaService.findEventMeshInfoByCluster("eventmesh");
+            Assertions.assertEquals(0, eventmesh.size());
+        });
     }
 
-    @Test(expected = MetaException.class)
+    @Test
     public void findEventMeshInfoByCluster() {
-        consulMetaService.init();
-        consulMetaService.start();
-        consulMetaService.register(eventMeshRegisterInfo);
-        List<EventMeshDataInfo> eventmesh = consulMetaService.findEventMeshInfoByCluster("eventmesh");
-        Assert.assertEquals(1, eventmesh.size());
-        consulMetaService.unRegister(eventMeshUnRegisterInfo);
+        Assertions.assertThrows(MetaException.class, () -> {
+            consulMetaService.init();
+            consulMetaService.start();
+            consulMetaService.register(eventMeshRegisterInfo);
+            List<EventMeshDataInfo> eventmesh = consulMetaService.findEventMeshInfoByCluster("eventmesh");
+            Assertions.assertEquals(1, eventmesh.size());
+            consulMetaService.unRegister(eventMeshUnRegisterInfo);
+        });
     }
 }

--- a/eventmesh-meta/eventmesh-meta-etcd/build.gradle
+++ b/eventmesh-meta/eventmesh-meta-etcd/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation project(":eventmesh-meta:eventmesh-meta-api")
     implementation project(":eventmesh-common")
     testImplementation "org.mockito:mockito-core"
+    testImplementation "org.mockito:mockito-junit-jupiter"
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/eventmesh-meta/eventmesh-meta-etcd/src/test/java/org/apache/eventmesh/registry/etcd/service/EtcdMetaServiceTest.java
+++ b/eventmesh-meta/eventmesh-meta-etcd/src/test/java/org/apache/eventmesh/registry/etcd/service/EtcdMetaServiceTest.java
@@ -28,15 +28,15 @@ import org.apache.eventmesh.meta.etcd.service.EtcdMetaService;
 import java.lang.reflect.Field;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EtcdMetaServiceTest {
 
     @Mock
@@ -46,7 +46,7 @@ public class EtcdMetaServiceTest {
 
     private EtcdMetaService etcdMetaService;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         etcdMetaService = new EtcdMetaService();
         CommonConfiguration configuration = new CommonConfiguration();
@@ -62,7 +62,7 @@ public class EtcdMetaServiceTest {
         // Mockito.when(eventMeshUnRegisterInfo.getEndPoint()).thenReturn("127.0.0.1:2379");
     }
 
-    @After
+    @AfterEach
     public void after() {
         etcdMetaService.shutdown();
     }
@@ -72,51 +72,60 @@ public class EtcdMetaServiceTest {
         etcdMetaService.init();
     }
 
-    @Test(expected = MetaException.class)
+    @Test
     public void testStart() {
-        etcdMetaService.init();
-        etcdMetaService.start();
-        Assert.assertNotNull(etcdMetaService);
+        Assertions.assertThrows(MetaException.class, () -> {
+            etcdMetaService.init();
+            etcdMetaService.start();
+            Assertions.assertNotNull(etcdMetaService);
+        });
 
     }
 
-    @Test(expected = MetaException.class)
+    @Test
     public void testShutdown() throws NoSuchFieldException, IllegalAccessException {
-        etcdMetaService.init();
-        etcdMetaService.start();
-        etcdMetaService.shutdown();
+        Assertions.assertThrows(MetaException.class, () -> {
+            etcdMetaService.init();
+            etcdMetaService.start();
+            etcdMetaService.shutdown();
 
-        Class<EtcdMetaService> etcdRegistryServiceClass = EtcdMetaService.class;
-        Field initStatus = etcdRegistryServiceClass.getDeclaredField("initStatus");
-        initStatus.setAccessible(true);
-        Object initStatusField = initStatus.get(etcdMetaService);
+            Class<EtcdMetaService> etcdRegistryServiceClass = EtcdMetaService.class;
+            Field initStatus = etcdRegistryServiceClass.getDeclaredField("initStatus");
+            initStatus.setAccessible(true);
+            Object initStatusField = initStatus.get(etcdMetaService);
 
-        Field startStatus = etcdRegistryServiceClass.getDeclaredField("startStatus");
-        startStatus.setAccessible(true);
-        Object startStatusField = startStatus.get(etcdMetaService);
-
+            Field startStatus = etcdRegistryServiceClass.getDeclaredField("startStatus");
+            startStatus.setAccessible(true);
+            Object startStatusField = startStatus.get(etcdMetaService);
+        });
     }
 
-    @Test(expected = MetaException.class)
+    @Test
     public void testRegister() {
-        etcdMetaService.init();
-        etcdMetaService.start();
-        etcdMetaService.register(eventMeshRegisterInfo);
+        Assertions.assertThrows(MetaException.class, () -> {
+            etcdMetaService.init();
+            etcdMetaService.start();
+            etcdMetaService.register(eventMeshRegisterInfo);
+        });
     }
 
-    @Test(expected = MetaException.class)
+    @Test
     public void testFindEventMeshInfo() {
-        etcdMetaService.init();
-        etcdMetaService.start();
-        etcdMetaService.register(eventMeshRegisterInfo);
-        List<EventMeshDataInfo> eventMeshDataInfoList = etcdMetaService.findAllEventMeshInfo();
+        Assertions.assertThrows(MetaException.class, () -> {
+            etcdMetaService.init();
+            etcdMetaService.start();
+            etcdMetaService.register(eventMeshRegisterInfo);
+            List<EventMeshDataInfo> eventMeshDataInfoList = etcdMetaService.findAllEventMeshInfo();
+        });
     }
 
-    @Test(expected = MetaException.class)
+    @Test
     public void testUnRegister() {
-        etcdMetaService.init();
-        etcdMetaService.start();
-        etcdMetaService.unRegister(eventMeshUnRegisterInfo);
+        Assertions.assertThrows(MetaException.class, () -> {
+            etcdMetaService.init();
+            etcdMetaService.start();
+            etcdMetaService.unRegister(eventMeshUnRegisterInfo);
+        });
     }
 
 }

--- a/eventmesh-meta/eventmesh-meta-nacos/build.gradle
+++ b/eventmesh-meta/eventmesh-meta-nacos/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation project(":eventmesh-meta:eventmesh-meta-api")
     implementation project(":eventmesh-common")
     testImplementation "org.mockito:mockito-core"
+    testImplementation "org.mockito:mockito-junit-jupiter"
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/eventmesh-meta/eventmesh-meta-nacos/src/test/java/org/apache/eventmesh/registry/nacos/service/NacosMetaServiceTest.java
+++ b/eventmesh-meta/eventmesh-meta-nacos/src/test/java/org/apache/eventmesh/registry/nacos/service/NacosMetaServiceTest.java
@@ -26,16 +26,19 @@ import org.apache.eventmesh.meta.nacos.service.NacosMetaService;
 
 import java.lang.reflect.Field;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class NacosMetaServiceTest {
 
     @Mock
@@ -45,7 +48,7 @@ public class NacosMetaServiceTest {
 
     private NacosMetaService nacosMetaService;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         nacosMetaService = new NacosMetaService();
         CommonConfiguration configuration = new CommonConfiguration();
@@ -63,7 +66,7 @@ public class NacosMetaServiceTest {
         Mockito.when(eventMeshUnRegisterInfo.getEndPoint()).thenReturn("127.0.0.1:8848");
     }
 
-    @After
+    @AfterEach
     public void after() {
         nacosMetaService.shutdown();
     }
@@ -72,14 +75,14 @@ public class NacosMetaServiceTest {
     public void testInit() {
         nacosMetaService.init();
         nacosMetaService.start();
-        Assert.assertNotNull(nacosMetaService.getServerAddr());
+        Assertions.assertNotNull(nacosMetaService.getServerAddr());
     }
 
     @Test
     public void testStart() {
         nacosMetaService.init();
         nacosMetaService.start();
-        Assert.assertNotNull(nacosMetaService.getNacosNamingService());
+        Assertions.assertNotNull(nacosMetaService.getNacosNamingService());
 
     }
 
@@ -98,22 +101,26 @@ public class NacosMetaServiceTest {
         startStatus.setAccessible(true);
         Object startStatusField = startStatus.get(nacosMetaService);
 
-        Assert.assertFalse((Boolean.parseBoolean(initStatusField.toString())));
-        Assert.assertFalse((Boolean.parseBoolean(startStatusField.toString())));
+        Assertions.assertFalse((Boolean.parseBoolean(initStatusField.toString())));
+        Assertions.assertFalse((Boolean.parseBoolean(startStatusField.toString())));
     }
 
-    @Test(expected = MetaException.class)
+    @Test
     public void testRegister() {
-        nacosMetaService.init();
-        nacosMetaService.start();
-        nacosMetaService.register(eventMeshRegisterInfo);
+        Assertions.assertThrows(MetaException.class, () -> {
+            nacosMetaService.init();
+            nacosMetaService.start();
+            nacosMetaService.register(eventMeshRegisterInfo);
+        });
     }
 
-    @Test(expected = MetaException.class)
+    @Test
     public void testUnRegister() {
-        nacosMetaService.init();
-        nacosMetaService.start();
-        nacosMetaService.unRegister(eventMeshUnRegisterInfo);
+        Assertions.assertThrows(MetaException.class, () -> {
+            nacosMetaService.init();
+            nacosMetaService.start();
+            nacosMetaService.unRegister(eventMeshUnRegisterInfo);
+        });
     }
 
 }

--- a/eventmesh-meta/eventmesh-meta-zookeeper/build.gradle
+++ b/eventmesh-meta/eventmesh-meta-zookeeper/build.gradle
@@ -29,5 +29,6 @@ dependencies {
     implementation project(":eventmesh-common")
 
     testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.apache.curator:curator-test'
 }

--- a/eventmesh-meta/eventmesh-meta-zookeeper/src/test/java/org/apache/eventmesh/registry/zookeeper/service/ZookeeperMetaServiceTest.java
+++ b/eventmesh-meta/eventmesh-meta-zookeeper/src/test/java/org/apache/eventmesh/registry/zookeeper/service/ZookeeperMetaServiceTest.java
@@ -31,18 +31,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import com.google.common.collect.Maps;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class ZookeeperMetaServiceTest {
 
     @Mock
@@ -54,7 +57,7 @@ public class ZookeeperMetaServiceTest {
 
     private TestingServer testingServer;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         testingServer = new TestingServer(1500, true);
         testingServer.start();
@@ -78,7 +81,7 @@ public class ZookeeperMetaServiceTest {
         Mockito.when(eventMeshUnRegisterInfo.getEndPoint()).thenReturn("127.0.0.1:8848");
     }
 
-    @After
+    @AfterEach
     public void after() throws Exception {
         zkRegistryService.shutdown();
         testingServer.close();
@@ -88,14 +91,14 @@ public class ZookeeperMetaServiceTest {
     public void testInit() {
         zkRegistryService.init();
         zkRegistryService.start();
-        Assert.assertNotNull(zkRegistryService.getServerAddr());
+        Assertions.assertNotNull(zkRegistryService.getServerAddr());
     }
 
     @Test
     public void testStart() {
         zkRegistryService.init();
         zkRegistryService.start();
-        Assert.assertNotNull(zkRegistryService.getZkClient());
+        Assertions.assertNotNull(zkRegistryService.getZkClient());
     }
 
     @Test
@@ -113,8 +116,8 @@ public class ZookeeperMetaServiceTest {
         startStatus.setAccessible(true);
         Object startStatusField = startStatus.get(zkRegistryService);
 
-        Assert.assertFalse((Boolean.parseBoolean(initStatusField.toString())));
-        Assert.assertFalse((Boolean.parseBoolean(startStatusField.toString())));
+        Assertions.assertFalse((Boolean.parseBoolean(initStatusField.toString())));
+        Assertions.assertFalse((Boolean.parseBoolean(startStatusField.toString())));
     }
 
     @Test
@@ -125,7 +128,7 @@ public class ZookeeperMetaServiceTest {
 
         final List<EventMeshDataInfo> result = zkRegistryService.findEventMeshInfoByCluster(eventMeshRegisterInfo.getEventMeshClusterName());
 
-        Assert.assertNotNull(result);
+        Assertions.assertNotNull(result);
     }
 
     @Test
@@ -136,7 +139,7 @@ public class ZookeeperMetaServiceTest {
 
         List<EventMeshDataInfo> result = zkRegistryService.findAllEventMeshInfo();
 
-        Assert.assertNotNull(result);
+        Assertions.assertNotNull(result);
     }
 
     @Test
@@ -150,7 +153,7 @@ public class ZookeeperMetaServiceTest {
         List<EventMeshDataInfo> infoList =
             zkRegistryService.findEventMeshInfoByCluster(eventMeshRegisterInfo.getEventMeshClusterName());
 
-        Assert.assertNotNull(infoList);
+        Assertions.assertNotNull(infoList);
     }
 
     @Test
@@ -166,10 +169,10 @@ public class ZookeeperMetaServiceTest {
         zkRegistryService.start();
         boolean register = zkRegistryService.register(eventMeshRegisterInfo);
 
-        Assert.assertTrue(register);
+        Assertions.assertTrue(register);
 
         boolean unRegister = zkRegistryService.unRegister(eventMeshUnRegisterInfo);
 
-        Assert.assertTrue(unRegister);
+        Assertions.assertTrue(unRegister);
     }
 }

--- a/eventmesh-meta/eventmesh-meta-zookeeper/src/test/java/org/apache/eventmesh/registry/zookeeper/service/ZookeeperMetaServiceTest.java
+++ b/eventmesh-meta/eventmesh-meta-zookeeper/src/test/java/org/apache/eventmesh/registry/zookeeper/service/ZookeeperMetaServiceTest.java
@@ -153,14 +153,14 @@ public class ZookeeperMetaServiceTest {
         Assert.assertNotNull(infoList);
     }
 
-    @Test()
+    @Test
     public void testRegister() {
         zkRegistryService.init();
         zkRegistryService.start();
         zkRegistryService.register(eventMeshRegisterInfo);
     }
 
-    @Test()
+    @Test
     public void testUnRegister() {
         zkRegistryService.init();
         zkRegistryService.start();

--- a/eventmesh-metrics-plugin/eventmesh-metrics-api/build.gradle
+++ b/eventmesh-metrics-plugin/eventmesh-metrics-api/build.gradle
@@ -27,5 +27,4 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
 
     testImplementation "org.mockito:mockito-core"
-    testImplementation "org.mockito:mockito-inline"
 }

--- a/eventmesh-metrics-plugin/eventmesh-metrics-api/src/test/java/org/apache/eventmesh/metrics/api/MetricsPluginFactoryTest.java
+++ b/eventmesh-metrics-plugin/eventmesh-metrics-api/src/test/java/org/apache/eventmesh/metrics/api/MetricsPluginFactoryTest.java
@@ -17,14 +17,14 @@
 
 package org.apache.eventmesh.metrics.api;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class MetricsPluginFactoryTest {
 
     @Test
     public void testGetMetricsRegistry_throwException() {
-        Exception exception = Assert.assertThrows(NullPointerException.class, () -> MetricsPluginFactory.getMetricsRegistry("security"));
-        Assert.assertTrue(exception.getMessage().contains("is not supported"));
+        Exception exception = Assertions.assertThrows(NullPointerException.class, () -> MetricsPluginFactory.getMetricsRegistry("security"));
+        Assertions.assertTrue(exception.getMessage().contains("is not supported"));
     }
 }

--- a/eventmesh-metrics-plugin/eventmesh-metrics-api/src/test/java/org/apache/eventmesh/metrics/api/model/GrpcSummaryMetricsTest.java
+++ b/eventmesh-metrics-plugin/eventmesh-metrics-api/src/test/java/org/apache/eventmesh/metrics/api/model/GrpcSummaryMetricsTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.eventmesh.metrics.api.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class GrpcSummaryMetricsTest {
 
@@ -31,12 +31,12 @@ public class GrpcSummaryMetricsTest {
         grpcSummaryMetrics.getClient2EventMeshMsgNum().addAndGet(1024);
 
         grpcSummaryMetrics.refreshTpsMetrics(500);
-        Assert.assertEquals(256, grpcSummaryMetrics.getEventMesh2ClientTPS());
-        Assert.assertEquals(512, grpcSummaryMetrics.getEventMesh2MqTPS());
-        Assert.assertEquals(1024, grpcSummaryMetrics.getMq2EventMeshTPS());
-        Assert.assertEquals(2048, grpcSummaryMetrics.getClient2EventMeshTPS());
+        Assertions.assertEquals(256, grpcSummaryMetrics.getEventMesh2ClientTPS());
+        Assertions.assertEquals(512, grpcSummaryMetrics.getEventMesh2MqTPS());
+        Assertions.assertEquals(1024, grpcSummaryMetrics.getMq2EventMeshTPS());
+        Assertions.assertEquals(2048, grpcSummaryMetrics.getClient2EventMeshTPS());
 
         grpcSummaryMetrics.clearAllMessageCounter();
-        Assert.assertEquals(0, grpcSummaryMetrics.getEventMesh2ClientMsgNum().get());
+        Assertions.assertEquals(0, grpcSummaryMetrics.getEventMesh2ClientMsgNum().get());
     }
 }

--- a/eventmesh-metrics-plugin/eventmesh-metrics-prometheus/src/test/java/org/apache/eventmesh/metrics/prometheus/config/PrometheusConfigurationTest.java
+++ b/eventmesh-metrics-plugin/eventmesh-metrics-prometheus/src/test/java/org/apache/eventmesh/metrics/prometheus/config/PrometheusConfigurationTest.java
@@ -20,8 +20,8 @@ package org.apache.eventmesh.metrics.prometheus.config;
 import org.apache.eventmesh.metrics.api.MetricsPluginFactory;
 import org.apache.eventmesh.metrics.prometheus.PrometheusMetricsRegistry;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PrometheusConfigurationTest {
 
@@ -35,6 +35,6 @@ public class PrometheusConfigurationTest {
     }
 
     private void assertConfig(PrometheusConfiguration config) {
-        Assert.assertEquals(config.getEventMeshPrometheusPort(), 19091);
+        Assertions.assertEquals(config.getEventMeshPrometheusPort(), 19091);
     }
 }

--- a/eventmesh-openconnect/eventmesh-openconnect-offsetmgmt-plugin/eventmesh-openconnect-offsetmgmt-api/build.gradle
+++ b/eventmesh-openconnect/eventmesh-openconnect-offsetmgmt-plugin/eventmesh-openconnect-offsetmgmt-api/build.gradle
@@ -29,5 +29,4 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
 
     testImplementation "org.mockito:mockito-core"
-    testImplementation "org.mockito:mockito-inline"
 }

--- a/eventmesh-protocol-plugin/eventmesh-protocol-grpc/build.gradle
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-grpc/build.gradle
@@ -50,7 +50,3 @@ protobuf {
         }
     }
 }
-
-test {
-    useJUnitPlatform()
-}

--- a/eventmesh-protocol-plugin/eventmesh-protocol-grpc/build.gradle
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-grpc/build.gradle
@@ -36,8 +36,7 @@ dependencies {
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "com.google.protobuf:protobuf-java-util:${protobufVersion}"
     implementation "javax.annotation:javax.annotation-api:1.3.2"
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.6.0'
 }
 
 protobuf {

--- a/eventmesh-protocol-plugin/eventmesh-protocol-http/src/test/java/org/apache/eventmesh/protocol/http/HttpProtocolAdaptorTest.java
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-http/src/test/java/org/apache/eventmesh/protocol/http/HttpProtocolAdaptorTest.java
@@ -21,8 +21,8 @@ import org.apache.eventmesh.common.protocol.ProtocolTransportObject;
 import org.apache.eventmesh.protocol.api.ProtocolAdaptor;
 import org.apache.eventmesh.protocol.api.ProtocolPluginFactory;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class HttpProtocolAdaptorTest {
 
@@ -31,9 +31,9 @@ public class HttpProtocolAdaptorTest {
         ProtocolAdaptor<ProtocolTransportObject> protocolAdaptor =
             ProtocolPluginFactory.getProtocolAdaptor(HttpProtocolConstant.PROTOCOL_NAME);
 
-        Assert.assertNotNull(protocolAdaptor);
-        Assert.assertEquals(
+        Assertions.assertNotNull(protocolAdaptor);
+        Assertions.assertEquals(
             HttpProtocolConstant.PROTOCOL_NAME, protocolAdaptor.getProtocolType());
-        Assert.assertEquals(HttpProtocolAdaptor.class, protocolAdaptor.getClass());
+        Assertions.assertEquals(HttpProtocolAdaptor.class, protocolAdaptor.getClass());
     }
 }

--- a/eventmesh-protocol-plugin/eventmesh-protocol-meshmessage/src/test/java/org/apache/eventmesh/protocol/meshmessage/MeshMessageProtocolAdaptorTest.java
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-meshmessage/src/test/java/org/apache/eventmesh/protocol/meshmessage/MeshMessageProtocolAdaptorTest.java
@@ -21,8 +21,8 @@ import org.apache.eventmesh.common.protocol.ProtocolTransportObject;
 import org.apache.eventmesh.protocol.api.ProtocolAdaptor;
 import org.apache.eventmesh.protocol.api.ProtocolPluginFactory;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class MeshMessageProtocolAdaptorTest {
 
@@ -30,9 +30,9 @@ public class MeshMessageProtocolAdaptorTest {
     public void loadPlugin() {
         ProtocolAdaptor<ProtocolTransportObject> protocolAdaptor =
             ProtocolPluginFactory.getProtocolAdaptor(MeshMessageProtocolConstant.PROTOCOL_NAME);
-        Assert.assertNotNull(protocolAdaptor);
+        Assertions.assertNotNull(protocolAdaptor);
 
-        Assert.assertEquals(
+        Assertions.assertEquals(
             MeshMessageProtocolConstant.PROTOCOL_NAME, protocolAdaptor.getProtocolType());
     }
 

--- a/eventmesh-protocol-plugin/eventmesh-protocol-openmessage/src/test/java/org/apache/eventmesh/protocol/openmessage/OpenMessageProtocolAdaptorTest.java
+++ b/eventmesh-protocol-plugin/eventmesh-protocol-openmessage/src/test/java/org/apache/eventmesh/protocol/openmessage/OpenMessageProtocolAdaptorTest.java
@@ -21,8 +21,8 @@ import org.apache.eventmesh.common.protocol.ProtocolTransportObject;
 import org.apache.eventmesh.protocol.api.ProtocolAdaptor;
 import org.apache.eventmesh.protocol.api.ProtocolPluginFactory;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class OpenMessageProtocolAdaptorTest {
 
@@ -31,9 +31,9 @@ public class OpenMessageProtocolAdaptorTest {
         ProtocolAdaptor<ProtocolTransportObject> protocolAdaptor =
             ProtocolPluginFactory.getProtocolAdaptor(OpenMessageProtocolConstant.PROTOCOL_NAME);
 
-        Assert.assertNotNull(protocolAdaptor);
-        Assert.assertEquals(
+        Assertions.assertNotNull(protocolAdaptor);
+        Assertions.assertEquals(
             OpenMessageProtocolConstant.PROTOCOL_NAME, protocolAdaptor.getProtocolType());
-        Assert.assertEquals(OpenMessageProtocolAdaptor.class, protocolAdaptor.getClass());
+        Assertions.assertEquals(OpenMessageProtocolAdaptor.class, protocolAdaptor.getClass());
     }
 }

--- a/eventmesh-runtime/build.gradle
+++ b/eventmesh-runtime/build.gradle
@@ -80,8 +80,6 @@ dependencies {
 
     testImplementation "org.mockito:mockito-core"
     testImplementation "org.mockito:mockito-inline"
-    testImplementation "org.powermock:powermock-module-junit4"
-    testImplementation "org.powermock:powermock-api-mockito2"
     testImplementation "commons-io:commons-io"
 
     testCompileOnly 'org.projectlombok:lombok'

--- a/eventmesh-runtime/build.gradle
+++ b/eventmesh-runtime/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     implementation project(":eventmesh-webhook:eventmesh-webhook-receive")
 
     testImplementation "org.mockito:mockito-inline"
+    testImplementation "org.mockito:mockito-junit-jupiter"
     testImplementation "commons-io:commons-io"
 
     testCompileOnly 'org.projectlombok:lombok'

--- a/eventmesh-runtime/build.gradle
+++ b/eventmesh-runtime/build.gradle
@@ -78,7 +78,6 @@ dependencies {
     implementation project(":eventmesh-webhook:eventmesh-webhook-api")
     implementation project(":eventmesh-webhook:eventmesh-webhook-receive")
 
-    testImplementation "org.mockito:mockito-core"
     testImplementation "org.mockito:mockito-inline"
     testImplementation "commons-io:commons-io"
 

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/admin/controller/ClientManageControllerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/admin/controller/ClientManageControllerTest.java
@@ -38,8 +38,8 @@ import org.apache.eventmesh.webhook.api.WebHookConfigOperation;
 
 import java.io.IOException;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -89,7 +89,7 @@ public class ClientManageControllerTest {
                 Mockito.doNothing().when(adminController).run(server);
                 controller.start();
             } catch (IOException e) {
-                Assert.fail(e.getMessage());
+                Assertions.fail(e.getMessage());
             }
 
         }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/admin/handler/QueryRecommendEventMeshHandlerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/admin/handler/QueryRecommendEventMeshHandlerTest.java
@@ -37,8 +37,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 
@@ -70,7 +70,7 @@ public class QueryRecommendEventMeshHandlerTest {
             (mock, context) -> when(mock.calculateRecommendEventMesh(anyString(), anyString())).thenReturn(returnValue))) {
             handler.handle(httpExchange);
             String response = outputStream.toString();
-            Assert.assertEquals(returnValue, response);
+            Assertions.assertEquals(returnValue, response);
         }
 
         // case 2: params illegal
@@ -80,7 +80,7 @@ public class QueryRecommendEventMeshHandlerTest {
             dummyStatic.when(() -> StringUtils.isBlank(any())).thenReturn(Boolean.TRUE);
             handler.handle(httpExchange);
             String response = outputStream.toString();
-            Assert.assertEquals("params illegal!", response);
+            Assertions.assertEquals("params illegal!", response);
         }
 
         // case 3: registry disable
@@ -92,7 +92,7 @@ public class QueryRecommendEventMeshHandlerTest {
             (mock, context) -> when(mock.calculateRecommendEventMesh(anyString(), anyString())).thenReturn(returnValue))) {
             handler.handle(httpExchange);
             String response = outputStream.toString();
-            Assert.assertNotEquals(returnValue, response);
+            Assertions.assertNotEquals(returnValue, response);
         }
     }
 }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/admin/handler/RedirectClientByIpPortHandlerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/admin/handler/RedirectClientByIpPortHandlerTest.java
@@ -28,7 +28,7 @@ import java.net.URI;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.powermock.api.mockito.PowerMockito;
+import org.mockito.Mockito;
 
 import com.sun.net.httpserver.HttpExchange;
 
@@ -38,7 +38,7 @@ public class RedirectClientByIpPortHandlerTest {
 
     @Before
     public void init() {
-        EventMeshTCPServer mockServer = PowerMockito.mock(EventMeshTCPServer.class);
+        EventMeshTCPServer mockServer = Mockito.mock(EventMeshTCPServer.class);
         HttpHandlerManager httpHandlerManager = new HttpHandlerManager();
         redirectClientByIpPortHandler = new RedirectClientByIpPortHandler(mockServer, httpHandlerManager);
     }
@@ -48,9 +48,9 @@ public class RedirectClientByIpPortHandlerTest {
         OutputStream outputStream = new ByteArrayOutputStream();
         URI uri = URI.create("ip=127.0.0.1&port=1234&desteventMeshIp=127.0.0.1&desteventMeshPort=");
 
-        HttpExchange mockExchange = PowerMockito.mock(HttpExchange.class);
-        PowerMockito.when(mockExchange.getResponseBody()).thenReturn(outputStream);
-        PowerMockito.when(mockExchange.getRequestURI()).thenReturn(uri);
+        HttpExchange mockExchange = Mockito.mock(HttpExchange.class);
+        Mockito.when(mockExchange.getResponseBody()).thenReturn(outputStream);
+        Mockito.when(mockExchange.getRequestURI()).thenReturn(uri);
 
         redirectClientByIpPortHandler.handle(mockExchange);
 

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/admin/handler/RedirectClientByIpPortHandlerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/admin/handler/RedirectClientByIpPortHandlerTest.java
@@ -25,9 +25,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.sun.net.httpserver.HttpExchange;
@@ -36,7 +36,7 @@ public class RedirectClientByIpPortHandlerTest {
 
     private static transient RedirectClientByIpPortHandler redirectClientByIpPortHandler;
 
-    @Before
+    @BeforeEach
     public void init() {
         EventMeshTCPServer mockServer = Mockito.mock(EventMeshTCPServer.class);
         HttpHandlerManager httpHandlerManager = new HttpHandlerManager();
@@ -55,7 +55,7 @@ public class RedirectClientByIpPortHandlerTest {
         redirectClientByIpPortHandler.handle(mockExchange);
 
         String response = outputStream.toString();
-        Assert.assertEquals("params illegal!", response);
+        Assertions.assertEquals("params illegal!", response);
 
     }
 }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/admin/handler/RedirectClientByPathHandlerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/admin/handler/RedirectClientByPathHandlerTest.java
@@ -45,9 +45,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -60,7 +60,7 @@ public class RedirectClientByPathHandlerTest {
     @Mock
     private static transient EventMeshTCPServer eventMeshTCPServer;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.openMocks(this);
     }
@@ -103,7 +103,7 @@ public class RedirectClientByPathHandlerTest {
                     any())).thenReturn("redirectResult");
                 redirectClientByPathHandler.handle(mockExchange);
                 String response = outputStream.toString(StandardCharsets.UTF_8.name());
-                Assert.assertTrue(response.startsWith("redirectClientByPath success!"));
+                Assertions.assertTrue(response.startsWith("redirectClientByPath success!"));
             }
 
             // case 2: params illegal
@@ -113,7 +113,7 @@ public class RedirectClientByPathHandlerTest {
                 dummyStatic.when(() -> StringUtils.isBlank(any())).thenReturn(Boolean.TRUE);
                 redirectClientByPathHandler.handle(mockExchange);
                 String response = outputStream.toString(StandardCharsets.UTF_8.name());
-                Assert.assertEquals("params illegal!", response);
+                Assertions.assertEquals("params illegal!", response);
             }
 
             // case 3: redirectClient2NewEventMesh fail
@@ -124,7 +124,7 @@ public class RedirectClientByPathHandlerTest {
                     any())).thenThrow(new RuntimeException());
                 redirectClientByPathHandler.handle(mockExchange);
                 String response = outputStream.toString(Constants.DEFAULT_CHARSET.name());
-                Assert.assertTrue(response.startsWith("redirectClientByPath fail!"));
+                Assertions.assertTrue(response.startsWith("redirectClientByPath fail!"));
             }
         }
     }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/boot/EventMeshServerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/boot/EventMeshServerTest.java
@@ -26,8 +26,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class EventMeshServerTest {
 
@@ -60,56 +60,56 @@ public class EventMeshServerTest {
     }
 
     private void assertTCPConfig(EventMeshTCPConfiguration config) {
-        Assert.assertEquals(config.getEventMeshTcpServerPort(), 816);
-        Assert.assertEquals(config.getEventMeshTcpIdleAllSeconds(), 1816);
-        Assert.assertEquals(config.getEventMeshTcpIdleWriteSeconds(), 2816);
-        Assert.assertEquals(config.getEventMeshTcpIdleReadSeconds(), 3816);
-        Assert.assertEquals(config.getEventMeshTcpMsgReqnumPerSecond(), Integer.valueOf(4816));
-        Assert.assertEquals(config.getEventMeshTcpClientMaxNum(), 5816);
-        Assert.assertEquals(config.getEventMeshTcpGlobalScheduler(), 6816);
-        Assert.assertEquals(config.getEventMeshTcpTaskHandleExecutorPoolSize(), 7816);
-        Assert.assertEquals(config.getEventMeshTcpMsgDownStreamExecutorPoolSize(), 8816);
-        Assert.assertEquals(config.getEventMeshTcpSessionExpiredInMills(), 1816);
-        Assert.assertEquals(config.getEventMeshTcpSessionUpstreamBufferSize(), 11816);
-        Assert.assertEquals(config.getEventMeshTcpMsgAsyncRetryTimes(), 12816);
-        Assert.assertEquals(config.getEventMeshTcpMsgSyncRetryTimes(), 13816);
-        Assert.assertEquals(config.getEventMeshTcpMsgRetrySyncDelayInMills(), 14816);
-        Assert.assertEquals(config.getEventMeshTcpMsgRetryAsyncDelayInMills(), 15816);
-        Assert.assertEquals(config.getEventMeshTcpMsgRetryQueueSize(), 16816);
-        Assert.assertEquals(config.getEventMeshTcpRebalanceIntervalInMills(), Integer.valueOf(17816));
-        Assert.assertEquals(config.getEventMeshServerAdminPort(), 18816);
-        Assert.assertEquals(config.isEventMeshTcpSendBackEnabled(), Boolean.TRUE);
-        Assert.assertEquals(config.getEventMeshTcpSendBackMaxTimes(), 3);
-        Assert.assertEquals(config.getEventMeshTcpPushFailIsolateTimeInMills(), 21816);
-        Assert.assertEquals(config.getGracefulShutdownSleepIntervalInMills(), 22816);
-        Assert.assertEquals(config.getSleepIntervalInRebalanceRedirectMills(), 23816);
-        Assert.assertEquals(config.getEventMeshEventSize(), 22816);
-        Assert.assertEquals(config.getEventMeshEventBatchSize(), 23816);
+        Assertions.assertEquals(config.getEventMeshTcpServerPort(), 816);
+        Assertions.assertEquals(config.getEventMeshTcpIdleAllSeconds(), 1816);
+        Assertions.assertEquals(config.getEventMeshTcpIdleWriteSeconds(), 2816);
+        Assertions.assertEquals(config.getEventMeshTcpIdleReadSeconds(), 3816);
+        Assertions.assertEquals(config.getEventMeshTcpMsgReqnumPerSecond(), Integer.valueOf(4816));
+        Assertions.assertEquals(config.getEventMeshTcpClientMaxNum(), 5816);
+        Assertions.assertEquals(config.getEventMeshTcpGlobalScheduler(), 6816);
+        Assertions.assertEquals(config.getEventMeshTcpTaskHandleExecutorPoolSize(), 7816);
+        Assertions.assertEquals(config.getEventMeshTcpMsgDownStreamExecutorPoolSize(), 8816);
+        Assertions.assertEquals(config.getEventMeshTcpSessionExpiredInMills(), 1816);
+        Assertions.assertEquals(config.getEventMeshTcpSessionUpstreamBufferSize(), 11816);
+        Assertions.assertEquals(config.getEventMeshTcpMsgAsyncRetryTimes(), 12816);
+        Assertions.assertEquals(config.getEventMeshTcpMsgSyncRetryTimes(), 13816);
+        Assertions.assertEquals(config.getEventMeshTcpMsgRetrySyncDelayInMills(), 14816);
+        Assertions.assertEquals(config.getEventMeshTcpMsgRetryAsyncDelayInMills(), 15816);
+        Assertions.assertEquals(config.getEventMeshTcpMsgRetryQueueSize(), 16816);
+        Assertions.assertEquals(config.getEventMeshTcpRebalanceIntervalInMills(), Integer.valueOf(17816));
+        Assertions.assertEquals(config.getEventMeshServerAdminPort(), 18816);
+        Assertions.assertEquals(config.isEventMeshTcpSendBackEnabled(), Boolean.TRUE);
+        Assertions.assertEquals(config.getEventMeshTcpSendBackMaxTimes(), 3);
+        Assertions.assertEquals(config.getEventMeshTcpPushFailIsolateTimeInMills(), 21816);
+        Assertions.assertEquals(config.getGracefulShutdownSleepIntervalInMills(), 22816);
+        Assertions.assertEquals(config.getSleepIntervalInRebalanceRedirectMills(), 23816);
+        Assertions.assertEquals(config.getEventMeshEventSize(), 22816);
+        Assertions.assertEquals(config.getEventMeshEventBatchSize(), 23816);
     }
 
     private void assertCommonConfig(CommonConfiguration config) {
-        Assert.assertEquals("env-succeed!!!", config.getEventMeshEnv());
-        Assert.assertEquals("idc-succeed!!!", config.getEventMeshIDC());
-        Assert.assertEquals("cluster-succeed!!!", config.getEventMeshCluster());
-        Assert.assertEquals("name-succeed!!!", config.getEventMeshName());
-        Assert.assertEquals("816", config.getSysID());
-        Assert.assertEquals("connector-succeed!!!", config.getEventMeshConnectorPluginType());
-        Assert.assertEquals("storage-succeed!!!", config.getEventMeshStoragePluginType());
-        Assert.assertEquals("security-succeed!!!", config.getEventMeshSecurityPluginType());
-        Assert.assertEquals("metaStorage-succeed!!!", config.getEventMeshMetaStoragePluginType());
-        Assert.assertEquals("trace-succeed!!!", config.getEventMeshTracePluginType());
-        Assert.assertEquals("hostIp-succeed!!!", config.getEventMeshServerIp());
+        Assertions.assertEquals("env-succeed!!!", config.getEventMeshEnv());
+        Assertions.assertEquals("idc-succeed!!!", config.getEventMeshIDC());
+        Assertions.assertEquals("cluster-succeed!!!", config.getEventMeshCluster());
+        Assertions.assertEquals("name-succeed!!!", config.getEventMeshName());
+        Assertions.assertEquals("816", config.getSysID());
+        Assertions.assertEquals("connector-succeed!!!", config.getEventMeshConnectorPluginType());
+        Assertions.assertEquals("storage-succeed!!!", config.getEventMeshStoragePluginType());
+        Assertions.assertEquals("security-succeed!!!", config.getEventMeshSecurityPluginType());
+        Assertions.assertEquals("metaStorage-succeed!!!", config.getEventMeshMetaStoragePluginType());
+        Assertions.assertEquals("trace-succeed!!!", config.getEventMeshTracePluginType());
+        Assertions.assertEquals("hostIp-succeed!!!", config.getEventMeshServerIp());
 
         List<String> list = new ArrayList<>();
         list.add("metrics-succeed1!!!");
         list.add("metrics-succeed2!!!");
         list.add("metrics-succeed3!!!");
-        Assert.assertEquals(list, config.getEventMeshMetricsPluginType());
+        Assertions.assertEquals(list, config.getEventMeshMetricsPluginType());
 
-        Assert.assertTrue(config.isEventMeshServerSecurityEnable());
-        Assert.assertTrue(config.isEventMeshServerMetaStorageEnable());
-        Assert.assertTrue(config.isEventMeshServerTraceEnable());
+        Assertions.assertTrue(config.isEventMeshServerSecurityEnable());
+        Assertions.assertTrue(config.isEventMeshServerMetaStorageEnable());
+        Assertions.assertTrue(config.isEventMeshServerTraceEnable());
 
-        Assert.assertEquals("eventmesh.idc-succeed!!!", config.getEventMeshWebhookOrigin());
+        Assertions.assertEquals("eventmesh.idc-succeed!!!", config.getEventMeshWebhookOrigin());
     }
 }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/client/impl/PubClientImpl.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/client/impl/PubClientImpl.java
@@ -31,7 +31,7 @@ import org.apache.eventmesh.runtime.client.hook.ReceiveMsgHook;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -127,31 +127,31 @@ public class PubClientImpl extends TCPClient implements PubClient {
      * Add test case assertions on the basis of the original IO
      */
     public Package dispatcher(Package request, long timeout) throws Exception {
-        Assert.assertNotNull(request);
+        Assertions.assertNotNull(request);
         Package response = super.io(request, timeout);
-        Assert.assertNotNull(response);
+        Assertions.assertNotNull(response);
         Command cmd = response.getHeader().getCommand();
         switch (request.getHeader().getCommand()) {
             case RECOMMEND_REQUEST:
-                Assert.assertEquals(Command.RECOMMEND_RESPONSE, cmd);
+                Assertions.assertEquals(Command.RECOMMEND_RESPONSE, cmd);
                 break;
             case HELLO_REQUEST:
-                Assert.assertEquals(Command.HELLO_RESPONSE, cmd);
+                Assertions.assertEquals(Command.HELLO_RESPONSE, cmd);
                 break;
             case HEARTBEAT_REQUEST:
-                Assert.assertEquals(Command.HEARTBEAT_RESPONSE, cmd);
+                Assertions.assertEquals(Command.HEARTBEAT_RESPONSE, cmd);
                 break;
             case CLIENT_GOODBYE_REQUEST:
-                Assert.assertEquals(Command.CLIENT_GOODBYE_RESPONSE, cmd);
+                Assertions.assertEquals(Command.CLIENT_GOODBYE_RESPONSE, cmd);
                 break;
             case BROADCAST_MESSAGE_TO_SERVER:
-                Assert.assertEquals(Command.BROADCAST_MESSAGE_TO_SERVER_ACK, cmd);
+                Assertions.assertEquals(Command.BROADCAST_MESSAGE_TO_SERVER_ACK, cmd);
                 break;
             case ASYNC_MESSAGE_TO_SERVER:
-                Assert.assertEquals(Command.ASYNC_MESSAGE_TO_SERVER_ACK, cmd);
+                Assertions.assertEquals(Command.ASYNC_MESSAGE_TO_SERVER_ACK, cmd);
                 break;
             case REQUEST_TO_SERVER:
-                Assert.assertEquals(Command.RESPONSE_TO_CLIENT, cmd);
+                Assertions.assertEquals(Command.RESPONSE_TO_CLIENT, cmd);
                 break;
             default:
                 break;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/client/impl/SubClientImpl.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/client/impl/SubClientImpl.java
@@ -38,7 +38,7 @@ import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -167,32 +167,32 @@ public class SubClientImpl extends TCPClient implements SubClient {
     }
 
     public Package dispatcher(Package request, long timeout) throws Exception {
-        Assert.assertNotNull(request);
+        Assertions.assertNotNull(request);
         Package response = super.io(request, timeout);
         switch (request.getHeader().getCommand()) {
             case HELLO_REQUEST:
-                Assert.assertEquals(response.getHeader().getCommand(), Command.HELLO_RESPONSE);
+                Assertions.assertEquals(response.getHeader().getCommand(), Command.HELLO_RESPONSE);
                 break;
             case HEARTBEAT_REQUEST:
-                Assert.assertEquals(response.getHeader().getCommand(), Command.HEARTBEAT_RESPONSE);
+                Assertions.assertEquals(response.getHeader().getCommand(), Command.HEARTBEAT_RESPONSE);
                 break;
             case LISTEN_REQUEST:
-                Assert.assertEquals(response.getHeader().getCommand(), Command.LISTEN_RESPONSE);
+                Assertions.assertEquals(response.getHeader().getCommand(), Command.LISTEN_RESPONSE);
                 break;
             case CLIENT_GOODBYE_REQUEST:
-                Assert.assertEquals(response.getHeader().getCommand(), Command.CLIENT_GOODBYE_RESPONSE);
+                Assertions.assertEquals(response.getHeader().getCommand(), Command.CLIENT_GOODBYE_RESPONSE);
                 break;
             case SUBSCRIBE_REQUEST:
-                Assert.assertEquals(response.getHeader().getCommand(), Command.SUBSCRIBE_RESPONSE);
+                Assertions.assertEquals(response.getHeader().getCommand(), Command.SUBSCRIBE_RESPONSE);
                 break;
             case UNSUBSCRIBE_REQUEST:
-                Assert.assertEquals(response.getHeader().getCommand(), Command.UNSUBSCRIBE_RESPONSE);
+                Assertions.assertEquals(response.getHeader().getCommand(), Command.UNSUBSCRIBE_RESPONSE);
                 break;
             case SYS_LOG_TO_LOGSERVER:
-                Assert.assertNull(response);
+                Assertions.assertNull(response);
                 break;
             case TRACE_LOG_TO_LOGSERVER:
-                Assert.assertNull(response);
+                Assertions.assertNull(response);
                 break;
             default:
                 break;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/configuration/EventMeshGrpcConfigurationTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/configuration/EventMeshGrpcConfigurationTest.java
@@ -23,8 +23,8 @@ import org.apache.eventmesh.common.config.ConfigService;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class EventMeshGrpcConfigurationTest {
 
@@ -41,54 +41,54 @@ public class EventMeshGrpcConfigurationTest {
     }
 
     private void assertGrpcConfig(EventMeshGrpcConfiguration config) {
-        Assert.assertEquals(816, config.getGrpcServerPort());
-        Assert.assertEquals(1816, config.getEventMeshSessionExpiredInMills());
-        Assert.assertEquals(Boolean.FALSE, config.isEventMeshServerBatchMsgBatchEnabled());
-        Assert.assertEquals(2816, config.getEventMeshServerBatchMsgThreadNum());
-        Assert.assertEquals(3816, config.getEventMeshServerSendMsgThreadNum());
-        Assert.assertEquals(4816, config.getEventMeshServerPushMsgThreadNum());
-        Assert.assertEquals(5816, config.getEventMeshServerReplyMsgThreadNum());
-        Assert.assertEquals(6816, config.getEventMeshServerSubscribeMsgThreadNum());
-        Assert.assertEquals(7816, config.getEventMeshServerMetaStorageThreadNum());
-        Assert.assertEquals(8816, config.getEventMeshServerAdminThreadNum());
-        Assert.assertEquals(9816, config.getEventMeshServerRetryThreadNum());
-        Assert.assertEquals(11816, config.getEventMeshServerPullMetaStorageInterval());
-        Assert.assertEquals(12816, config.getEventMeshServerAsyncAccumulationThreshold());
-        Assert.assertEquals(13816, config.getEventMeshServerRetryBlockQueueSize());
-        Assert.assertEquals(14816, config.getEventMeshServerBatchBlockQueueSize());
-        Assert.assertEquals(15816, config.getEventMeshServerSendMsgBlockQueueSize());
-        Assert.assertEquals(16816, config.getEventMeshServerPushMsgBlockQueueSize());
-        Assert.assertEquals(17816, config.getEventMeshServerSubscribeMsgBlockQueueSize());
-        Assert.assertEquals(18816, config.getEventMeshServerBusyCheckInterval());
-        Assert.assertEquals(Boolean.TRUE, config.isEventMeshServerConsumerEnabled());
-        Assert.assertEquals(Boolean.TRUE, config.isEventMeshServerUseTls());
-        Assert.assertEquals(21816, config.getEventMeshBatchMsgRequestNumPerSecond());
-        Assert.assertEquals(19816, config.getEventMeshMsgReqNumPerSecond());
+        Assertions.assertEquals(816, config.getGrpcServerPort());
+        Assertions.assertEquals(1816, config.getEventMeshSessionExpiredInMills());
+        Assertions.assertEquals(Boolean.FALSE, config.isEventMeshServerBatchMsgBatchEnabled());
+        Assertions.assertEquals(2816, config.getEventMeshServerBatchMsgThreadNum());
+        Assertions.assertEquals(3816, config.getEventMeshServerSendMsgThreadNum());
+        Assertions.assertEquals(4816, config.getEventMeshServerPushMsgThreadNum());
+        Assertions.assertEquals(5816, config.getEventMeshServerReplyMsgThreadNum());
+        Assertions.assertEquals(6816, config.getEventMeshServerSubscribeMsgThreadNum());
+        Assertions.assertEquals(7816, config.getEventMeshServerMetaStorageThreadNum());
+        Assertions.assertEquals(8816, config.getEventMeshServerAdminThreadNum());
+        Assertions.assertEquals(9816, config.getEventMeshServerRetryThreadNum());
+        Assertions.assertEquals(11816, config.getEventMeshServerPullMetaStorageInterval());
+        Assertions.assertEquals(12816, config.getEventMeshServerAsyncAccumulationThreshold());
+        Assertions.assertEquals(13816, config.getEventMeshServerRetryBlockQueueSize());
+        Assertions.assertEquals(14816, config.getEventMeshServerBatchBlockQueueSize());
+        Assertions.assertEquals(15816, config.getEventMeshServerSendMsgBlockQueueSize());
+        Assertions.assertEquals(16816, config.getEventMeshServerPushMsgBlockQueueSize());
+        Assertions.assertEquals(17816, config.getEventMeshServerSubscribeMsgBlockQueueSize());
+        Assertions.assertEquals(18816, config.getEventMeshServerBusyCheckInterval());
+        Assertions.assertEquals(Boolean.TRUE, config.isEventMeshServerConsumerEnabled());
+        Assertions.assertEquals(Boolean.TRUE, config.isEventMeshServerUseTls());
+        Assertions.assertEquals(21816, config.getEventMeshBatchMsgRequestNumPerSecond());
+        Assertions.assertEquals(19816, config.getEventMeshMsgReqNumPerSecond());
     }
 
     private void assertCommonConfig(CommonConfiguration config) {
-        Assert.assertEquals("env-succeed!!!", config.getEventMeshEnv());
-        Assert.assertEquals("idc-succeed!!!", config.getEventMeshIDC());
-        Assert.assertEquals("cluster-succeed!!!", config.getEventMeshCluster());
-        Assert.assertEquals("name-succeed!!!", config.getEventMeshName());
-        Assert.assertEquals("816", config.getSysID());
-        Assert.assertEquals("connector-succeed!!!", config.getEventMeshConnectorPluginType());
-        Assert.assertEquals("storage-succeed!!!", config.getEventMeshStoragePluginType());
-        Assert.assertEquals("security-succeed!!!", config.getEventMeshSecurityPluginType());
-        Assert.assertEquals("metaStorage-succeed!!!", config.getEventMeshMetaStoragePluginType());
-        Assert.assertEquals("trace-succeed!!!", config.getEventMeshTracePluginType());
-        Assert.assertEquals("hostIp-succeed!!!", config.getEventMeshServerIp());
+        Assertions.assertEquals("env-succeed!!!", config.getEventMeshEnv());
+        Assertions.assertEquals("idc-succeed!!!", config.getEventMeshIDC());
+        Assertions.assertEquals("cluster-succeed!!!", config.getEventMeshCluster());
+        Assertions.assertEquals("name-succeed!!!", config.getEventMeshName());
+        Assertions.assertEquals("816", config.getSysID());
+        Assertions.assertEquals("connector-succeed!!!", config.getEventMeshConnectorPluginType());
+        Assertions.assertEquals("storage-succeed!!!", config.getEventMeshStoragePluginType());
+        Assertions.assertEquals("security-succeed!!!", config.getEventMeshSecurityPluginType());
+        Assertions.assertEquals("metaStorage-succeed!!!", config.getEventMeshMetaStoragePluginType());
+        Assertions.assertEquals("trace-succeed!!!", config.getEventMeshTracePluginType());
+        Assertions.assertEquals("hostIp-succeed!!!", config.getEventMeshServerIp());
 
         List<String> list = new ArrayList<>();
         list.add("metrics-succeed1!!!");
         list.add("metrics-succeed2!!!");
         list.add("metrics-succeed3!!!");
-        Assert.assertEquals(list, config.getEventMeshMetricsPluginType());
+        Assertions.assertEquals(list, config.getEventMeshMetricsPluginType());
 
-        Assert.assertTrue(config.isEventMeshServerSecurityEnable());
-        Assert.assertTrue(config.isEventMeshServerMetaStorageEnable());
-        Assert.assertTrue(config.isEventMeshServerTraceEnable());
+        Assertions.assertTrue(config.isEventMeshServerSecurityEnable());
+        Assertions.assertTrue(config.isEventMeshServerMetaStorageEnable());
+        Assertions.assertTrue(config.isEventMeshServerTraceEnable());
 
-        Assert.assertEquals("eventmesh.idc-succeed!!!", config.getEventMeshWebhookOrigin());
+        Assertions.assertEquals("eventmesh.idc-succeed!!!", config.getEventMeshWebhookOrigin());
     }
 }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/configuration/EventMeshHTTPConfigurationTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/configuration/EventMeshHTTPConfigurationTest.java
@@ -23,8 +23,8 @@ import org.apache.eventmesh.common.config.ConfigService;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import inet.ipaddr.AddressStringException;
 import inet.ipaddr.IPAddress;
@@ -45,65 +45,65 @@ public class EventMeshHTTPConfigurationTest {
     }
 
     private void assertHTTPConfig(EventMeshHTTPConfiguration config) throws AddressStringException {
-        Assert.assertEquals(1816, config.getHttpServerPort());
-        Assert.assertEquals(Boolean.FALSE, config.isEventMeshServerBatchMsgBatchEnabled());
-        Assert.assertEquals(2816, config.getEventMeshServerBatchMsgThreadNum());
-        Assert.assertEquals(3816, config.getEventMeshServerSendMsgThreadNum());
-        Assert.assertEquals(4816, config.getEventMeshServerPushMsgThreadNum());
-        Assert.assertEquals(5816, config.getEventMeshServerReplyMsgThreadNum());
-        Assert.assertEquals(6816, config.getEventMeshServerClientManageThreadNum());
-        Assert.assertEquals(7816, config.getEventMeshServerMetaStorageThreadNum());
-        Assert.assertEquals(8816, config.getEventMeshServerAdminThreadNum());
+        Assertions.assertEquals(1816, config.getHttpServerPort());
+        Assertions.assertEquals(Boolean.FALSE, config.isEventMeshServerBatchMsgBatchEnabled());
+        Assertions.assertEquals(2816, config.getEventMeshServerBatchMsgThreadNum());
+        Assertions.assertEquals(3816, config.getEventMeshServerSendMsgThreadNum());
+        Assertions.assertEquals(4816, config.getEventMeshServerPushMsgThreadNum());
+        Assertions.assertEquals(5816, config.getEventMeshServerReplyMsgThreadNum());
+        Assertions.assertEquals(6816, config.getEventMeshServerClientManageThreadNum());
+        Assertions.assertEquals(7816, config.getEventMeshServerMetaStorageThreadNum());
+        Assertions.assertEquals(8816, config.getEventMeshServerAdminThreadNum());
 
-        Assert.assertEquals(9816, config.getEventMeshServerRetryThreadNum());
-        Assert.assertEquals(11816, config.getEventMeshServerPullMetaStorageInterval());
-        Assert.assertEquals(12816, config.getEventMeshServerAsyncAccumulationThreshold());
-        Assert.assertEquals(13816, config.getEventMeshServerRetryBlockQSize());
-        Assert.assertEquals(14816, config.getEventMeshServerBatchBlockQSize());
-        Assert.assertEquals(15816, config.getEventMeshServerSendMsgBlockQSize());
-        Assert.assertEquals(16816, config.getEventMeshServerPushMsgBlockQSize());
-        Assert.assertEquals(17816, config.getEventMeshServerClientManageBlockQSize());
-        Assert.assertEquals(18816, config.getEventMeshServerBusyCheckInterval());
-        Assert.assertEquals(Boolean.TRUE, config.isEventMeshServerConsumerEnabled());
-        Assert.assertEquals(Boolean.TRUE, config.isEventMeshServerUseTls());
-        Assert.assertEquals(19816, config.getEventMeshHttpMsgReqNumPerSecond());
-        Assert.assertEquals(21816, config.getEventMeshBatchMsgRequestNumPerSecond());
-        Assert.assertEquals(22816, config.getEventMeshEventSize());
-        Assert.assertEquals(23816, config.getEventMeshEventBatchSize());
+        Assertions.assertEquals(9816, config.getEventMeshServerRetryThreadNum());
+        Assertions.assertEquals(11816, config.getEventMeshServerPullMetaStorageInterval());
+        Assertions.assertEquals(12816, config.getEventMeshServerAsyncAccumulationThreshold());
+        Assertions.assertEquals(13816, config.getEventMeshServerRetryBlockQSize());
+        Assertions.assertEquals(14816, config.getEventMeshServerBatchBlockQSize());
+        Assertions.assertEquals(15816, config.getEventMeshServerSendMsgBlockQSize());
+        Assertions.assertEquals(16816, config.getEventMeshServerPushMsgBlockQSize());
+        Assertions.assertEquals(17816, config.getEventMeshServerClientManageBlockQSize());
+        Assertions.assertEquals(18816, config.getEventMeshServerBusyCheckInterval());
+        Assertions.assertEquals(Boolean.TRUE, config.isEventMeshServerConsumerEnabled());
+        Assertions.assertEquals(Boolean.TRUE, config.isEventMeshServerUseTls());
+        Assertions.assertEquals(19816, config.getEventMeshHttpMsgReqNumPerSecond());
+        Assertions.assertEquals(21816, config.getEventMeshBatchMsgRequestNumPerSecond());
+        Assertions.assertEquals(22816, config.getEventMeshEventSize());
+        Assertions.assertEquals(23816, config.getEventMeshEventBatchSize());
 
         List<IPAddress> list4 = new ArrayList<>();
         list4.add(new IPAddressString("127.0.0.1").toAddress());
         list4.add(new IPAddressString("127.0.0.2").toAddress());
-        Assert.assertEquals(list4, config.getEventMeshIpv4BlackList());
+        Assertions.assertEquals(list4, config.getEventMeshIpv4BlackList());
         List<IPAddress> list6 = new ArrayList<>();
         list6.add(new IPAddressString("0:0:0:0:0:0:7f00:01").toAddress());
         list6.add(new IPAddressString("0:0:0:0:0:0:7f00:02").toAddress());
-        Assert.assertEquals(list6, config.getEventMeshIpv6BlackList());
+        Assertions.assertEquals(list6, config.getEventMeshIpv6BlackList());
     }
 
     private void assertCommonConfig(CommonConfiguration config) {
-        Assert.assertEquals("env-succeed!!!", config.getEventMeshEnv());
-        Assert.assertEquals("idc-succeed!!!", config.getEventMeshIDC());
-        Assert.assertEquals("cluster-succeed!!!", config.getEventMeshCluster());
-        Assert.assertEquals("name-succeed!!!", config.getEventMeshName());
-        Assert.assertEquals("816", config.getSysID());
-        Assert.assertEquals("connector-succeed!!!", config.getEventMeshConnectorPluginType());
-        Assert.assertEquals("storage-succeed!!!", config.getEventMeshStoragePluginType());
-        Assert.assertEquals("security-succeed!!!", config.getEventMeshSecurityPluginType());
-        Assert.assertEquals("metaStorage-succeed!!!", config.getEventMeshMetaStoragePluginType());
-        Assert.assertEquals("trace-succeed!!!", config.getEventMeshTracePluginType());
-        Assert.assertEquals("hostIp-succeed!!!", config.getEventMeshServerIp());
+        Assertions.assertEquals("env-succeed!!!", config.getEventMeshEnv());
+        Assertions.assertEquals("idc-succeed!!!", config.getEventMeshIDC());
+        Assertions.assertEquals("cluster-succeed!!!", config.getEventMeshCluster());
+        Assertions.assertEquals("name-succeed!!!", config.getEventMeshName());
+        Assertions.assertEquals("816", config.getSysID());
+        Assertions.assertEquals("connector-succeed!!!", config.getEventMeshConnectorPluginType());
+        Assertions.assertEquals("storage-succeed!!!", config.getEventMeshStoragePluginType());
+        Assertions.assertEquals("security-succeed!!!", config.getEventMeshSecurityPluginType());
+        Assertions.assertEquals("metaStorage-succeed!!!", config.getEventMeshMetaStoragePluginType());
+        Assertions.assertEquals("trace-succeed!!!", config.getEventMeshTracePluginType());
+        Assertions.assertEquals("hostIp-succeed!!!", config.getEventMeshServerIp());
 
         List<String> list = new ArrayList<>();
         list.add("metrics-succeed1!!!");
         list.add("metrics-succeed2!!!");
         list.add("metrics-succeed3!!!");
-        Assert.assertEquals(list, config.getEventMeshMetricsPluginType());
+        Assertions.assertEquals(list, config.getEventMeshMetricsPluginType());
 
-        Assert.assertTrue(config.isEventMeshServerSecurityEnable());
-        Assert.assertTrue(config.isEventMeshServerMetaStorageEnable());
-        Assert.assertTrue(config.isEventMeshServerTraceEnable());
+        Assertions.assertTrue(config.isEventMeshServerSecurityEnable());
+        Assertions.assertTrue(config.isEventMeshServerMetaStorageEnable());
+        Assertions.assertTrue(config.isEventMeshServerTraceEnable());
 
-        Assert.assertEquals("eventmesh.idc-succeed!!!", config.getEventMeshWebhookOrigin());
+        Assertions.assertEquals("eventmesh.idc-succeed!!!", config.getEventMeshWebhookOrigin());
     }
 }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/configuration/EventMeshTCPConfigurationTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/configuration/EventMeshTCPConfigurationTest.java
@@ -23,8 +23,8 @@ import org.apache.eventmesh.common.config.ConfigService;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class EventMeshTCPConfigurationTest {
 
@@ -41,56 +41,56 @@ public class EventMeshTCPConfigurationTest {
     }
 
     private void assertTCPConfig(EventMeshTCPConfiguration config) {
-        Assert.assertEquals(816, config.getEventMeshTcpServerPort());
-        Assert.assertEquals(1816, config.getEventMeshTcpIdleAllSeconds());
-        Assert.assertEquals(2816, config.getEventMeshTcpIdleWriteSeconds());
-        Assert.assertEquals(3816, config.getEventMeshTcpIdleReadSeconds());
-        Assert.assertEquals(Integer.valueOf(4816), config.getEventMeshTcpMsgReqnumPerSecond());
-        Assert.assertEquals(5816, config.getEventMeshTcpClientMaxNum());
-        Assert.assertEquals(6816, config.getEventMeshTcpGlobalScheduler());
-        Assert.assertEquals(7816, config.getEventMeshTcpTaskHandleExecutorPoolSize());
-        Assert.assertEquals(8816, config.getEventMeshTcpMsgDownStreamExecutorPoolSize());
-        Assert.assertEquals(1816, config.getEventMeshTcpSessionExpiredInMills());
-        Assert.assertEquals(11816, config.getEventMeshTcpSessionUpstreamBufferSize());
-        Assert.assertEquals(12816, config.getEventMeshTcpMsgAsyncRetryTimes());
-        Assert.assertEquals(13816, config.getEventMeshTcpMsgSyncRetryTimes());
-        Assert.assertEquals(14816, config.getEventMeshTcpMsgRetrySyncDelayInMills());
-        Assert.assertEquals(15816, config.getEventMeshTcpMsgRetryAsyncDelayInMills());
-        Assert.assertEquals(16816, config.getEventMeshTcpMsgRetryQueueSize());
-        Assert.assertEquals(Integer.valueOf(17816), config.getEventMeshTcpRebalanceIntervalInMills());
-        Assert.assertEquals(18816, config.getEventMeshServerAdminPort());
-        Assert.assertEquals(Boolean.TRUE, config.isEventMeshTcpSendBackEnabled());
-        Assert.assertEquals(3, config.getEventMeshTcpSendBackMaxTimes());
-        Assert.assertEquals(21816, config.getEventMeshTcpPushFailIsolateTimeInMills());
-        Assert.assertEquals(22816, config.getGracefulShutdownSleepIntervalInMills());
-        Assert.assertEquals(23816, config.getSleepIntervalInRebalanceRedirectMills());
-        Assert.assertEquals(22816, config.getEventMeshEventSize());
-        Assert.assertEquals(23816, config.getEventMeshEventBatchSize());
+        Assertions.assertEquals(816, config.getEventMeshTcpServerPort());
+        Assertions.assertEquals(1816, config.getEventMeshTcpIdleAllSeconds());
+        Assertions.assertEquals(2816, config.getEventMeshTcpIdleWriteSeconds());
+        Assertions.assertEquals(3816, config.getEventMeshTcpIdleReadSeconds());
+        Assertions.assertEquals(Integer.valueOf(4816), config.getEventMeshTcpMsgReqnumPerSecond());
+        Assertions.assertEquals(5816, config.getEventMeshTcpClientMaxNum());
+        Assertions.assertEquals(6816, config.getEventMeshTcpGlobalScheduler());
+        Assertions.assertEquals(7816, config.getEventMeshTcpTaskHandleExecutorPoolSize());
+        Assertions.assertEquals(8816, config.getEventMeshTcpMsgDownStreamExecutorPoolSize());
+        Assertions.assertEquals(1816, config.getEventMeshTcpSessionExpiredInMills());
+        Assertions.assertEquals(11816, config.getEventMeshTcpSessionUpstreamBufferSize());
+        Assertions.assertEquals(12816, config.getEventMeshTcpMsgAsyncRetryTimes());
+        Assertions.assertEquals(13816, config.getEventMeshTcpMsgSyncRetryTimes());
+        Assertions.assertEquals(14816, config.getEventMeshTcpMsgRetrySyncDelayInMills());
+        Assertions.assertEquals(15816, config.getEventMeshTcpMsgRetryAsyncDelayInMills());
+        Assertions.assertEquals(16816, config.getEventMeshTcpMsgRetryQueueSize());
+        Assertions.assertEquals(Integer.valueOf(17816), config.getEventMeshTcpRebalanceIntervalInMills());
+        Assertions.assertEquals(18816, config.getEventMeshServerAdminPort());
+        Assertions.assertEquals(Boolean.TRUE, config.isEventMeshTcpSendBackEnabled());
+        Assertions.assertEquals(3, config.getEventMeshTcpSendBackMaxTimes());
+        Assertions.assertEquals(21816, config.getEventMeshTcpPushFailIsolateTimeInMills());
+        Assertions.assertEquals(22816, config.getGracefulShutdownSleepIntervalInMills());
+        Assertions.assertEquals(23816, config.getSleepIntervalInRebalanceRedirectMills());
+        Assertions.assertEquals(22816, config.getEventMeshEventSize());
+        Assertions.assertEquals(23816, config.getEventMeshEventBatchSize());
     }
 
     private void assertCommonConfig(CommonConfiguration config) {
-        Assert.assertEquals("env-succeed!!!", config.getEventMeshEnv());
-        Assert.assertEquals("idc-succeed!!!", config.getEventMeshIDC());
-        Assert.assertEquals("cluster-succeed!!!", config.getEventMeshCluster());
-        Assert.assertEquals("name-succeed!!!", config.getEventMeshName());
-        Assert.assertEquals("816", config.getSysID());
-        Assert.assertEquals("connector-succeed!!!", config.getEventMeshConnectorPluginType());
-        Assert.assertEquals("storage-succeed!!!", config.getEventMeshStoragePluginType());
-        Assert.assertEquals("security-succeed!!!", config.getEventMeshSecurityPluginType());
-        Assert.assertEquals("metaStorage-succeed!!!", config.getEventMeshMetaStoragePluginType());
-        Assert.assertEquals("trace-succeed!!!", config.getEventMeshTracePluginType());
-        Assert.assertEquals("hostIp-succeed!!!", config.getEventMeshServerIp());
+        Assertions.assertEquals("env-succeed!!!", config.getEventMeshEnv());
+        Assertions.assertEquals("idc-succeed!!!", config.getEventMeshIDC());
+        Assertions.assertEquals("cluster-succeed!!!", config.getEventMeshCluster());
+        Assertions.assertEquals("name-succeed!!!", config.getEventMeshName());
+        Assertions.assertEquals("816", config.getSysID());
+        Assertions.assertEquals("connector-succeed!!!", config.getEventMeshConnectorPluginType());
+        Assertions.assertEquals("storage-succeed!!!", config.getEventMeshStoragePluginType());
+        Assertions.assertEquals("security-succeed!!!", config.getEventMeshSecurityPluginType());
+        Assertions.assertEquals("metaStorage-succeed!!!", config.getEventMeshMetaStoragePluginType());
+        Assertions.assertEquals("trace-succeed!!!", config.getEventMeshTracePluginType());
+        Assertions.assertEquals("hostIp-succeed!!!", config.getEventMeshServerIp());
 
         List<String> list = new ArrayList<>();
         list.add("metrics-succeed1!!!");
         list.add("metrics-succeed2!!!");
         list.add("metrics-succeed3!!!");
-        Assert.assertEquals(list, config.getEventMeshMetricsPluginType());
+        Assertions.assertEquals(list, config.getEventMeshMetricsPluginType());
 
-        Assert.assertTrue(config.isEventMeshServerSecurityEnable());
-        Assert.assertTrue(config.isEventMeshServerMetaStorageEnable());
-        Assert.assertTrue(config.isEventMeshServerTraceEnable());
+        Assertions.assertTrue(config.isEventMeshServerSecurityEnable());
+        Assertions.assertTrue(config.isEventMeshServerMetaStorageEnable());
+        Assertions.assertTrue(config.isEventMeshServerTraceEnable());
 
-        Assert.assertEquals("eventmesh.idc-succeed!!!", config.getEventMeshWebhookOrigin());
+        Assertions.assertEquals("eventmesh.idc-succeed!!!", config.getEventMeshWebhookOrigin());
     }
 }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/protocol/processor/WebHookProcessorTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/protocol/processor/WebHookProcessorTest.java
@@ -32,16 +32,16 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.data.BytesCloudEventData;
@@ -53,7 +53,7 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class WebHookProcessorTest {
 
     @Mock
@@ -68,7 +68,7 @@ public class WebHookProcessorTest {
     @InjectMocks
     private transient WebHookController controller = new WebHookController();
 
-    @Before
+    @BeforeEach
     public void init() throws Exception {
         Mockito.when(hookConfigOperationManager.queryWebHookConfigById(any())).thenReturn(buildMockWebhookConfig());
         Mockito.doNothing().when(webHookMQProducer).send(captor.capture(), any());
@@ -82,13 +82,13 @@ public class WebHookProcessorTest {
             processor.handler(buildMockWebhookRequest());
 
             CloudEvent msgSendToMq = captor.getValue();
-            Assert.assertNotNull(msgSendToMq);
-            Assert.assertTrue(StringUtils.isNoneBlank(msgSendToMq.getId()));
-            Assert.assertEquals("www.github.com", msgSendToMq.getSource().getPath());
-            Assert.assertEquals("github.ForkEvent", msgSendToMq.getType());
-            Assert.assertEquals(BytesCloudEventData.wrap("\"mock_data\":0".getBytes(StandardCharsets.UTF_8)), msgSendToMq.getData());
+            Assertions.assertNotNull(msgSendToMq);
+            Assertions.assertTrue(StringUtils.isNoneBlank(msgSendToMq.getId()));
+            Assertions.assertEquals("www.github.com", msgSendToMq.getSource().getPath());
+            Assertions.assertEquals("github.ForkEvent", msgSendToMq.getType());
+            Assertions.assertEquals(BytesCloudEventData.wrap("\"mock_data\":0".getBytes(StandardCharsets.UTF_8)), msgSendToMq.getData());
         } catch (Exception e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/protocol/processor/WebHookProcessorTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/protocol/processor/WebHookProcessorTest.java
@@ -35,10 +35,13 @@ import java.nio.charset.StandardCharsets;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.reflect.Whitebox;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.data.BytesCloudEventData;
@@ -50,28 +53,25 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
 
+@RunWith(MockitoJUnitRunner.class)
 public class WebHookProcessorTest {
 
     @Mock
     private transient HookConfigOperationManager hookConfigOperationManager;
     @Mock
     private transient WebHookMQProducer webHookMQProducer;
-
-    private transient WebHookController controller = new WebHookController();
+    @Spy
+    private transient ProtocolAdaptor<ProtocolTransportObject> protocolAdaptor = ProtocolPluginFactory.getProtocolAdaptor("webhook");
 
     private transient ArgumentCaptor<CloudEvent> captor = ArgumentCaptor.forClass(CloudEvent.class);
 
+    @InjectMocks
+    private transient WebHookController controller = new WebHookController();
+
     @Before
     public void init() throws Exception {
-        hookConfigOperationManager = Mockito.mock(HookConfigOperationManager.class);
         Mockito.when(hookConfigOperationManager.queryWebHookConfigById(any())).thenReturn(buildMockWebhookConfig());
-        webHookMQProducer = Mockito.mock(WebHookMQProducer.class);
         Mockito.doNothing().when(webHookMQProducer).send(captor.capture(), any());
-        ProtocolAdaptor<ProtocolTransportObject> protocolAdaptor = ProtocolPluginFactory.getProtocolAdaptor("webhook");
-
-        Whitebox.setInternalState(controller, HookConfigOperationManager.class, hookConfigOperationManager);
-        Whitebox.setInternalState(controller, WebHookMQProducer.class, webHookMQProducer);
-        Whitebox.setInternalState(controller, ProtocolAdaptor.class, protocolAdaptor);
     }
 
     @Test

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/BannerUtilTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/BannerUtilTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.eventmesh.runtime.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BannerUtilTest {
 
@@ -27,7 +27,7 @@ public class BannerUtilTest {
         try {
             BannerUtil.generateBanner();
         } catch (Exception e) {
-            Assert.fail("BannerUtil.generateBanner() test failed");
+            Assertions.fail("BannerUtil.generateBanner() test failed");
         }
     }
 }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/EventMeshUtilTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/EventMeshUtilTest.java
@@ -38,8 +38,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.regex.Pattern;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.SpecVersion;
@@ -57,52 +57,52 @@ public class EventMeshUtilTest {
     @Test
     public void testBuildPushMsgSeqNo() {
         String seq = EventMeshUtil.buildPushMsgSeqNo();
-        Assert.assertTrue(Pattern.compile("\\d{17}").matcher(seq).matches());
-        Assert.assertEquals(17, seq.length());
+        Assertions.assertTrue(Pattern.compile("\\d{17}").matcher(seq).matches());
+        Assertions.assertEquals(17, seq.length());
     }
 
     @Test
     public void testBuildMeshClientID() {
         String clientGroup = "clientGroup";
         String clientID = EventMeshUtil.buildMeshClientID(clientGroup, "LS");
-        Assert.assertTrue(clientID.contains(clientGroup));
+        Assertions.assertTrue(clientID.contains(clientGroup));
     }
 
     @Test
     public void testBuildMeshTcpClientID() {
         String clientSysId = "clientSysId";
         String clientID = EventMeshUtil.buildMeshTcpClientID(clientSysId, "purpose", "meshCluster");
-        Assert.assertTrue(clientID.contains(clientSysId));
+        Assertions.assertTrue(clientID.contains(clientSysId));
     }
 
     @Test
     public void testBuildClientGroup() {
         String systemId = "systemId";
         String clientGroup = EventMeshUtil.buildClientGroup(systemId);
-        Assert.assertEquals(clientGroup, systemId);
+        Assertions.assertEquals(clientGroup, systemId);
     }
 
     @Test
     public void testStackTrace() {
         Throwable e = new EventMeshException("error");
         String exception = EventMeshUtil.stackTrace(e);
-        Assert.assertTrue(exception.contains(e.getMessage()));
+        Assertions.assertTrue(exception.contains(e.getMessage()));
 
         exception = EventMeshUtil.stackTrace(null);
-        Assert.assertNull(exception);
+        Assertions.assertNull(exception);
     }
 
     @Test
     public void testCreateJsoner() {
         ObjectMapper mapper = EventMeshUtil.createJsoner();
-        Assert.assertNotNull(mapper);
+        Assertions.assertNotNull(mapper);
     }
 
     @Test
     public void testPrintMqMessage() {
         EventMeshMessage meshMessage = new EventMeshMessage();
         String result = EventMeshUtil.printMqMessage(meshMessage);
-        Assert.assertTrue(result.contains("Message"));
+        Assertions.assertTrue(result.contains("Message"));
     }
 
     @Test
@@ -114,7 +114,7 @@ public class EventMeshUtilTest {
             .withType(TYPE)
             .build();
         String result = EventMeshUtil.getMessageBizSeq(cloudEvent);
-        Assert.assertEquals(result, value);
+        Assertions.assertEquals(result, value);
     }
 
     @Test
@@ -126,20 +126,20 @@ public class EventMeshUtilTest {
             .withType(TYPE)
             .build();
         Map<String, String> result = EventMeshUtil.getEventProp(cloudEvent);
-        Assert.assertEquals(result.get(EventMeshConstants.KEYS_LOWERCASE), value);
+        Assertions.assertEquals(result.get(EventMeshConstants.KEYS_LOWERCASE), value);
     }
 
     @Test
     public void testGetLocalAddr() {
         String addr = EventMeshUtil.getLocalAddr();
-        Assert.assertNotNull(addr);
+        Assertions.assertNotNull(addr);
     }
 
     @Test
     public void testNormalizeHostAddress() throws UnknownHostException {
         InetAddress localAddress = InetAddress.getLocalHost();
         String result = EventMeshUtil.normalizeHostAddress(localAddress);
-        Assert.assertNotNull(result);
+        Assertions.assertNotNull(result);
     }
 
     @Test
@@ -151,18 +151,18 @@ public class EventMeshUtilTest {
         UserAgent agent = UserAgent.builder().subsystem(subSystem).host(host)
             .pid(pid).port(port).build();
         String result = EventMeshUtil.buildUserAgentClientId(agent);
-        Assert.assertEquals(result, String.format("%s--%d-%s:%d", subSystem, pid, host, port));
+        Assertions.assertEquals(result, String.format("%s--%d-%s:%d", subSystem, pid, host, port));
 
         result = EventMeshUtil.buildUserAgentClientId(null);
-        Assert.assertNull(result);
+        Assertions.assertNull(result);
     }
 
     @Test
     public void testCloneObject() throws IOException, ClassNotFoundException {
         TopicMetadata topicMetadata = new TopicMetadata("topicName");
         TopicMetadata topicMetadata2 = EventMeshUtil.cloneObject(topicMetadata);
-        Assert.assertNotEquals(System.identityHashCode(topicMetadata), System.identityHashCode(topicMetadata2));
-        Assert.assertEquals(topicMetadata, topicMetadata2);
+        Assertions.assertNotEquals(System.identityHashCode(topicMetadata), System.identityHashCode(topicMetadata2));
+        Assertions.assertEquals(topicMetadata, topicMetadata2);
     }
 
     @Test
@@ -172,7 +172,7 @@ public class EventMeshUtilTest {
                 .createScheduledExecutor(5, new EventMeshThreadFactory("proxy-rebalance-sch", true));
             EventMeshUtil.printState((ThreadPoolExecutor) serviceRebalanceScheduler);
         } catch (Exception e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -181,17 +181,17 @@ public class EventMeshUtilTest {
         URI source = URI.create("uri");
         CloudEventV03 cloudEventV03 = CloudEventBuilder.v03().withId(V03).withSource(source).withType(V03).build();
         Map<String, Object> extMapV03 = EventMeshUtil.getCloudEventExtensionMap(SpecVersion.V03.toString(), cloudEventV03);
-        Assert.assertNotNull(extMapV03);
-        Assert.assertEquals(V03, extMapV03.get("id"));
-        Assert.assertEquals(V03, extMapV03.get(TYPE));
+        Assertions.assertNotNull(extMapV03);
+        Assertions.assertEquals(V03, extMapV03.get("id"));
+        Assertions.assertEquals(V03, extMapV03.get(TYPE));
 
         CloudEventV1 cloudEventV1 = (CloudEventV1) CloudEventBuilder.v1().withId("V1").withSource(source).withType("V1").build();
         Map<String, Object> extMapV1 = EventMeshUtil.getCloudEventExtensionMap(SpecVersion.V1.toString(), cloudEventV1);
-        Assert.assertNotNull(extMapV1);
-        Assert.assertEquals("V1", extMapV1.get("id"));
-        Assert.assertEquals("V1", extMapV1.get(TYPE));
+        Assertions.assertNotNull(extMapV1);
+        Assertions.assertEquals("V1", extMapV1.get("id"));
+        Assertions.assertEquals("V1", extMapV1.get(TYPE));
 
         Map<String, Object> map = EventMeshUtil.getCloudEventExtensionMap(SpecVersion.V03.toString(), cloudEventV1);
-        Assert.assertTrue(map.isEmpty());
+        Assertions.assertTrue(map.isEmpty());
     }
 }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/HttpResponseUtilsTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/HttpResponseUtilsTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.eventmesh.runtime.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
@@ -30,20 +30,20 @@ public class HttpResponseUtilsTest {
 
     @Test
     public void testCreateSuccess() {
-        Assert.assertEquals(HttpVersion.HTTP_1_1, HttpResponseUtils.createSuccess().protocolVersion());
-        Assert.assertEquals(HttpResponseStatus.OK, HttpResponseUtils.createSuccess().status());
+        Assertions.assertEquals(HttpVersion.HTTP_1_1, HttpResponseUtils.createSuccess().protocolVersion());
+        Assertions.assertEquals(HttpResponseStatus.OK, HttpResponseUtils.createSuccess().status());
     }
 
     @Test
     public void testCreateNotFound() {
-        Assert.assertEquals(HttpVersion.HTTP_1_1, HttpResponseUtils.createNotFound().protocolVersion());
-        Assert.assertEquals(HttpResponseStatus.NOT_FOUND, HttpResponseUtils.createNotFound().status());
+        Assertions.assertEquals(HttpVersion.HTTP_1_1, HttpResponseUtils.createNotFound().protocolVersion());
+        Assertions.assertEquals(HttpResponseStatus.NOT_FOUND, HttpResponseUtils.createNotFound().status());
     }
 
     @Test
     public void testCreateInternalServerError() {
-        Assert.assertEquals(HttpVersion.HTTP_1_1, HttpResponseUtils.createInternalServerError().protocolVersion());
-        Assert.assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, HttpResponseUtils.createInternalServerError().status());
+        Assertions.assertEquals(HttpVersion.HTTP_1_1, HttpResponseUtils.createInternalServerError().protocolVersion());
+        Assertions.assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, HttpResponseUtils.createInternalServerError().status());
     }
 
 }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/HttpTinyClientTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/HttpTinyClientTest.java
@@ -30,8 +30,8 @@ import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -44,8 +44,8 @@ public class HttpTinyClientTest {
             dummyStatic.when(() -> IOUtils.toString(any(InputStream.class), any(String.class))).thenReturn(content);
             String requestUrl = "https://eventmesh.apache.org";
             HttpResult result = HttpTinyClient.httpGet(requestUrl, null, null, "utf-8", 0);
-            Assert.assertEquals(content, result.getContent());
-            Assert.assertEquals(HttpURLConnection.HTTP_OK, result.getCode());
+            Assertions.assertEquals(content, result.getContent());
+            Assertions.assertEquals(HttpURLConnection.HTTP_OK, result.getCode());
         }
 
         List<String> paramValues = new ArrayList<>();
@@ -60,8 +60,8 @@ public class HttpTinyClientTest {
             dummyStatic.when(() -> IOUtils.toString(any(InputStream.class), any(String.class))).thenReturn(content);
             String requestUrl = "https://eventmesh.apache.org";
             HttpResult result = HttpTinyClient.httpGet(requestUrl, headers, paramValues, "utf-8", 0);
-            Assert.assertEquals(content, result.getContent());
-            Assert.assertEquals(HttpURLConnection.HTTP_OK, result.getCode());
+            Assertions.assertEquals(content, result.getContent());
+            Assertions.assertEquals(HttpURLConnection.HTTP_OK, result.getCode());
         }
     }
 
@@ -72,8 +72,8 @@ public class HttpTinyClientTest {
             dummyStatic.when(() -> IOUtils.toString(any(InputStream.class), any(String.class))).thenReturn(content);
             String requestUrl = "https://eventmesh.apache.org";
             HttpResult result = HttpTinyClient.httpPost(requestUrl, anyList(), anyList(), "utf-8", 0);
-            Assert.assertEquals(content, result.getContent());
-            Assert.assertEquals(HttpURLConnection.HTTP_OK, result.getCode());
+            Assertions.assertEquals(content, result.getContent());
+            Assertions.assertEquals(HttpURLConnection.HTTP_OK, result.getCode());
         }
     }
 }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/RemotingHelperTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/RemotingHelperTest.java
@@ -20,8 +20,8 @@ package org.apache.eventmesh.runtime.util;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import io.netty.channel.Channel;
@@ -31,15 +31,15 @@ public class RemotingHelperTest {
     @Test
     public void testExceptionSimpleDesc() {
         String result = RemotingHelper.exceptionSimpleDesc(new NullPointerException());
-        Assert.assertNotNull(result);
+        Assertions.assertNotNull(result);
     }
 
     @Test
     public void testString2SocketAddress() {
         String addr = "10.1.1.1:11002";
         InetSocketAddress address = (InetSocketAddress) RemotingHelper.string2SocketAddress(addr);
-        Assert.assertNotNull(address);
-        Assert.assertEquals("10.1.1.1:11002", address.getHostString() + ":" + address.getPort());
+        Assertions.assertNotNull(address);
+        Assertions.assertEquals("10.1.1.1:11002", address.getHostString() + ":" + address.getPort());
     }
 
     @Test
@@ -48,13 +48,13 @@ public class RemotingHelperTest {
         Channel channel = Mockito.mock(Channel.class);
         Mockito.when(channel.remoteAddress()).thenReturn(address);
         String addr = RemotingHelper.parseChannelRemoteAddr(channel);
-        Assert.assertEquals(addr, "127.0.0.1:80");
+        Assertions.assertEquals(addr, "127.0.0.1:80");
     }
 
     @Test
     public void testParseSocketAddressAddr() {
         InetSocketAddress address = new InetSocketAddress("localhost", 80);
         String addr = RemotingHelper.parseSocketAddressAddr(address);
-        Assert.assertEquals("127.0.0.1:80", addr);
+        Assertions.assertEquals("127.0.0.1:80", addr);
     }
 }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/ServerGlobalTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/ServerGlobalTest.java
@@ -19,8 +19,8 @@ package org.apache.eventmesh.runtime.util;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * ServerGlobal test cases.
@@ -30,12 +30,12 @@ public class ServerGlobalTest {
     @Test
     public void testGetMsgCounter() {
         ServerGlobal.getInstance().setMsgCounter(new AtomicLong(1L));
-        Assert.assertEquals(1L, ServerGlobal.getInstance().getMsgCounter().get());
+        Assertions.assertEquals(1L, ServerGlobal.getInstance().getMsgCounter().get());
     }
 
     @Test
     public void testSetMsgCounter() {
         ServerGlobal.getInstance().setMsgCounter(new AtomicLong(1L));
-        Assert.assertEquals(1L, ServerGlobal.getInstance().getMsgCounter().get());
+        Assertions.assertEquals(1L, ServerGlobal.getInstance().getMsgCounter().get());
     }
 }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/ThreadPoolHelperTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/ThreadPoolHelperTest.java
@@ -26,12 +26,12 @@ import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ThreadPoolHelperTest {
 
     @Mock

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/ValueComparatorTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/ValueComparatorTest.java
@@ -24,8 +24,8 @@ import java.io.OutputStream;
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ValueComparatorTest {
 
@@ -36,7 +36,7 @@ public class ValueComparatorTest {
             ObjectOutputStream oos = new ObjectOutputStream(bos)) {
             oos.writeObject(map);
         } catch (IOException e) {
-            Assert.fail();
+            Assertions.fail();
         }
     }
 

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/WebhookUtilTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/WebhookUtilTest.java
@@ -32,8 +32,8 @@ import org.apache.http.message.BasicHeader;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -49,20 +49,20 @@ public class WebhookUtilTest {
             Mockito.when(response.getLastHeader("WebHook-Allowed-Origin"))
                 .thenReturn(new BasicHeader("WebHook-Allowed-Origin", "*"));
             Mockito.when(httpClient.execute(any())).thenReturn(response);
-            Assert.assertTrue("match logic must return true",
-                WebhookUtil.obtainDeliveryAgreement(httpClient, "https://eventmesh.apache.org", "*"));
+            Assertions.assertTrue(WebhookUtil.obtainDeliveryAgreement(httpClient, "https://eventmesh.apache.org", "*"),
+                "match logic must return true");
 
             // abnormal case
             Mockito.when(httpClient2.execute(any())).thenThrow(new RuntimeException());
             try {
-                Assert.assertTrue("when throw exception ,default return true",
-                    WebhookUtil.obtainDeliveryAgreement(httpClient2, "xxx", "*"));
+                Assertions.assertTrue(WebhookUtil.obtainDeliveryAgreement(httpClient2, "xxx", "*"),
+                    "when throw exception ,default return true");
             } catch (RuntimeException e) {
-                Assert.fail(e.getMessage());
+                Assertions.fail(e.getMessage());
             }
 
         } catch (Exception e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -81,7 +81,7 @@ public class WebhookUtilTest {
             dummyStatic.when(() -> EventMeshExtensionFactory.getExtension(AuthService.class, authType)).thenReturn(authService);
             final HttpPost post = new HttpPost();
             WebhookUtil.setWebhookHeaders(post, "application/json", "eventmesh.FT", authType);
-            Assert.assertEquals("match expect value", post.getLastHeader(key).getValue(), value);
+            Assertions.assertEquals(post.getLastHeader(key).getValue(), value, "match expect value");
         }
     }
 }

--- a/eventmesh-sdks/eventmesh-sdk-java/build.gradle
+++ b/eventmesh-sdks/eventmesh-sdk-java/build.gradle
@@ -59,6 +59,5 @@ dependencies {
 
     testImplementation "org.assertj:assertj-core"
 
-    testImplementation "org.mockito:mockito-core"
     testImplementation "org.mockito:mockito-inline"
 }

--- a/eventmesh-sdks/eventmesh-sdk-java/build.gradle
+++ b/eventmesh-sdks/eventmesh-sdk-java/build.gradle
@@ -61,6 +61,4 @@ dependencies {
 
     testImplementation "org.mockito:mockito-core"
     testImplementation "org.mockito:mockito-inline"
-    testImplementation "org.powermock:powermock-module-junit4"
-    testImplementation "org.powermock:powermock-api-mockito2"
 }

--- a/eventmesh-sdks/eventmesh-sdk-java/build.gradle
+++ b/eventmesh-sdks/eventmesh-sdk-java/build.gradle
@@ -60,4 +60,5 @@ dependencies {
     testImplementation "org.assertj:assertj-core"
 
     testImplementation "org.mockito:mockito-inline"
+    testImplementation "org.mockito:mockito-junit-jupiter"
 }

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/consumer/EventMeshGrpcConsumerTest.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/consumer/EventMeshGrpcConsumerTest.java
@@ -44,18 +44,21 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import io.cloudevents.core.v1.CloudEventV1;
 import io.grpc.stub.StreamObserver;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EventMeshGrpcConsumerTest {
 
     @Mock
@@ -66,7 +69,7 @@ public class EventMeshGrpcConsumerTest {
     private HeartbeatServiceBlockingStub heartbeatClient;
     private EventMeshGrpcConsumer eventMeshGrpcConsumer;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         eventMeshGrpcConsumer = new EventMeshGrpcConsumer(EventMeshGrpcClientConfig.builder().build());
         eventMeshGrpcConsumer.init();
@@ -140,7 +143,7 @@ public class EventMeshGrpcConsumerTest {
 
         assertThat(result).hasSize(1).first().isInstanceOf(CloudEventV1.class);
         CloudEventV1 v1 = (CloudEventV1) result.get(0);
-        Assert.assertEquals(new String(v1.getData().toBytes(), Constants.DEFAULT_CHARSET), "mockContent");
+        Assertions.assertEquals(new String(v1.getData().toBytes(), Constants.DEFAULT_CHARSET), "mockContent");
         verify(consumerAsyncClient, times(1)).subscribeStream(any());
         assertThat(eventMeshGrpcConsumer.unsubscribe(Collections.singletonList(buildMockSubscriptionItem()))).isEqualTo(
             Response.builder().build());

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/consumer/EventMeshGrpcConsumerTest.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/consumer/EventMeshGrpcConsumerTest.java
@@ -50,16 +50,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import io.cloudevents.core.v1.CloudEventV1;
 import io.grpc.stub.StreamObserver;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ConsumerServiceBlockingStub.class, ConsumerServiceStub.class, HeartbeatServiceBlockingStub.class})
-@PowerMockIgnore({"javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*"})
+@RunWith(MockitoJUnitRunner.class)
 public class EventMeshGrpcConsumerTest {
 
     @Mock

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/producer/CloudEventProducerTest.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/producer/CloudEventProducerTest.java
@@ -33,13 +33,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({PublisherServiceBlockingStub.class, Response.class})
-@PowerMockIgnore({"javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*"})
+@RunWith(MockitoJUnitRunner.class)
 public class CloudEventProducerTest {
 
     private CloudEventProducer cloudEventProducer;

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/producer/CloudEventProducerTest.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/producer/CloudEventProducerTest.java
@@ -28,14 +28,17 @@ import org.apache.eventmesh.common.protocol.grpc.common.Response;
 
 import java.util.Collections;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class CloudEventProducerTest {
 
     private CloudEventProducer cloudEventProducer;
@@ -45,7 +48,7 @@ public class CloudEventProducerTest {
     @Mock
     private CloudEvent mockCloudEvent;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         cloudEventProducer = new CloudEventProducer(EventMeshGrpcClientConfig.builder().build(), blockingStub);
         when(blockingStub.batchPublish(Mockito.isA(CloudEventBatch.class))).thenReturn(mockCloudEvent);

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/producer/EventMeshGrpcProducerTest.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/producer/EventMeshGrpcProducerTest.java
@@ -40,14 +40,17 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.Silent.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EventMeshGrpcProducerTest {
 
     private EventMeshGrpcProducer producer;
@@ -59,7 +62,7 @@ public class EventMeshGrpcProducerTest {
     @Mock
     private EventMeshMessageProducer eventMeshMessageProducer;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         producer = new EventMeshGrpcProducer(EventMeshGrpcClientConfig.builder().build());
         producer.setCloudEventProducer(cloudEventProducer);

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/producer/EventMeshGrpcProducerTest.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/producer/EventMeshGrpcProducerTest.java
@@ -45,13 +45,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(PublisherServiceBlockingStub.class)
-@PowerMockIgnore({"javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*"})
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EventMeshGrpcProducerTest {
 
     private EventMeshGrpcProducer producer;

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/producer/EventMeshMessageProducerTest.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/producer/EventMeshMessageProducerTest.java
@@ -43,13 +43,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({PublisherServiceBlockingStub.class, Response.class})
-@PowerMockIgnore({"javax.management.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*"})
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EventMeshMessageProducerTest {
 
     private EventMeshMessageProducer eventMeshMessageProducer;

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/producer/EventMeshMessageProducerTest.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/producer/EventMeshMessageProducerTest.java
@@ -38,14 +38,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.Silent.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EventMeshMessageProducerTest {
 
     private EventMeshMessageProducer eventMeshMessageProducer;
@@ -56,7 +59,7 @@ public class EventMeshMessageProducerTest {
     @Mock
     private CloudEvent mockCloudEvent;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         eventMeshMessageProducer = new EventMeshMessageProducer(EventMeshGrpcClientConfig.builder().build(), blockingStub);
         when(blockingStub.batchPublish(Mockito.isA(CloudEventBatch.class))).thenReturn(mockCloudEvent);

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/util/EventMeshCloudEventBuilderTest.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/util/EventMeshCloudEventBuilderTest.java
@@ -38,9 +38,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.cloudevents.core.builder.CloudEventBuilder;
 
@@ -48,7 +48,7 @@ public class EventMeshCloudEventBuilderTest {
 
     private EventMeshGrpcClientConfig clientConfig;
 
-    @Before
+    @BeforeEach
     public void init() {
         clientConfig = EventMeshGrpcClientConfig.builder().build();
     }
@@ -58,17 +58,19 @@ public class EventMeshCloudEventBuilderTest {
 
         Map<String, CloudEventAttributeValue> attributeValueMap = EventMeshCloudEventBuilder.buildCommonCloudEventAttributes(
             clientConfig, EventMeshProtocolType.CLOUD_EVENTS);
-        Assert.assertNotNull(attributeValueMap);
-        Assert.assertEquals(EventMeshProtocolType.CLOUD_EVENTS.protocolTypeName(), attributeValueMap.get(ProtocolKey.PROTOCOL_TYPE).getCeString());
+        Assertions.assertNotNull(attributeValueMap);
+        Assertions.assertEquals(EventMeshProtocolType.CLOUD_EVENTS.protocolTypeName(),
+            attributeValueMap.get(ProtocolKey.PROTOCOL_TYPE).getCeString());
         Map<String, CloudEventAttributeValue> attributeValueMap1 = EventMeshCloudEventBuilder.buildCommonCloudEventAttributes(
             clientConfig, EventMeshProtocolType.EVENT_MESH_MESSAGE);
-        Assert.assertNotNull(attributeValueMap1);
-        Assert.assertEquals(EventMeshProtocolType.EVENT_MESH_MESSAGE.protocolTypeName(),
+        Assertions.assertNotNull(attributeValueMap1);
+        Assertions.assertEquals(EventMeshProtocolType.EVENT_MESH_MESSAGE.protocolTypeName(),
             attributeValueMap1.get(ProtocolKey.PROTOCOL_TYPE).getCeString());
         Map<String, CloudEventAttributeValue> attributeValueMap2 = EventMeshCloudEventBuilder.buildCommonCloudEventAttributes(
             clientConfig, EventMeshProtocolType.OPEN_MESSAGE);
-        Assert.assertNotNull(attributeValueMap2);
-        Assert.assertEquals(EventMeshProtocolType.OPEN_MESSAGE.protocolTypeName(), attributeValueMap2.get(ProtocolKey.PROTOCOL_TYPE).getCeString());
+        Assertions.assertNotNull(attributeValueMap2);
+        Assertions.assertEquals(EventMeshProtocolType.OPEN_MESSAGE.protocolTypeName(),
+            attributeValueMap2.get(ProtocolKey.PROTOCOL_TYPE).getCeString());
 
     }
 
@@ -84,7 +86,7 @@ public class EventMeshCloudEventBuilderTest {
         }
         CloudEvent cloudEvent = EventMeshCloudEventBuilder.buildEventSubscription(clientConfig, EventMeshProtocolType.EVENT_MESH_MESSAGE, "127.0.0.1",
             subscriptionItems);
-        Assert.assertNotNull(cloudEvent);
+        Assertions.assertNotNull(cloudEvent);
     }
 
     @Test
@@ -99,24 +101,24 @@ public class EventMeshCloudEventBuilderTest {
         } catch (ClassCastException e) {
             exception = e;
         }
-        Assert.assertNotNull(exception);
+        Assertions.assertNotNull(exception);
         CloudEvent cloudEvent = EventMeshCloudEventBuilder.buildEventMeshCloudEvent(event, clientConfig, EventMeshProtocolType.CLOUD_EVENTS);
-        Assert.assertNotNull(cloudEvent);
-        Assert.assertEquals("eventmesh", cloudEvent.getType());
-        Assert.assertEquals(id, cloudEvent.getId());
+        Assertions.assertNotNull(cloudEvent);
+        Assertions.assertEquals("eventmesh", cloudEvent.getType());
+        Assertions.assertEquals(id, cloudEvent.getId());
         Exception exception1 = null;
         try {
             EventMeshCloudEventBuilder.buildEventMeshCloudEvent(meshMessage, clientConfig, EventMeshProtocolType.CLOUD_EVENTS);
         } catch (ClassCastException e) {
             exception1 = e;
         }
-        Assert.assertNotNull(exception1);
+        Assertions.assertNotNull(exception1);
         EventMeshMessage meshMessage1 = EventMeshMessage.builder().uniqueId(id).build();
         CloudEvent cloudEvent1 = EventMeshCloudEventBuilder.buildEventMeshCloudEvent(meshMessage1, clientConfig,
             EventMeshProtocolType.EVENT_MESH_MESSAGE);
-        Assert.assertNotNull(cloudEvent1);
-        Assert.assertEquals("org.apache.eventmesh", cloudEvent1.getType());
-        Assert.assertEquals(id, EventMeshCloudEventUtils.getUniqueId(cloudEvent1));
+        Assertions.assertNotNull(cloudEvent1);
+        Assertions.assertEquals("org.apache.eventmesh", cloudEvent1.getType());
+        Assertions.assertEquals(id, EventMeshCloudEventUtils.getUniqueId(cloudEvent1));
 
     }
 
@@ -125,10 +127,10 @@ public class EventMeshCloudEventBuilderTest {
         List<io.cloudevents.CloudEvent> cloudEventList = new ArrayList<>();
         CloudEventBatch cloudEventBatch = EventMeshCloudEventBuilder.buildEventMeshCloudEventBatch(cloudEventList, clientConfig,
             EventMeshProtocolType.CLOUD_EVENTS);
-        Assert.assertNull(cloudEventBatch);
+        Assertions.assertNull(cloudEventBatch);
         CloudEventBatch cloudEventBatch1 = EventMeshCloudEventBuilder.buildEventMeshCloudEventBatch(null, clientConfig,
             EventMeshProtocolType.CLOUD_EVENTS);
-        Assert.assertNull(cloudEventBatch1);
+        Assertions.assertNull(cloudEventBatch1);
         List<io.cloudevents.CloudEvent> cloudEventList2 = new ArrayList<>();
         for (int i = 0; i < 3; ++i) {
             String id = UUID.randomUUID().toString();
@@ -138,7 +140,7 @@ public class EventMeshCloudEventBuilderTest {
         }
         CloudEventBatch cloudEventBatch2 = EventMeshCloudEventBuilder.buildEventMeshCloudEventBatch(cloudEventList2, clientConfig,
             EventMeshProtocolType.CLOUD_EVENTS);
-        Assert.assertNotNull(cloudEventBatch2);
+        Assertions.assertNotNull(cloudEventBatch2);
 
         List<EventMeshMessage> messageList = new ArrayList<>();
         for (int i = 0; i < 3; ++i) {
@@ -147,26 +149,26 @@ public class EventMeshCloudEventBuilderTest {
         }
         CloudEventBatch cloudEventBatch3 = EventMeshCloudEventBuilder.buildEventMeshCloudEventBatch(messageList, clientConfig,
             EventMeshProtocolType.EVENT_MESH_MESSAGE);
-        Assert.assertNotNull(cloudEventBatch3);
-        Assert.assertEquals(3, cloudEventBatch3.getEventsCount());
+        Assertions.assertNotNull(cloudEventBatch3);
+        Assertions.assertEquals(3, cloudEventBatch3.getEventsCount());
     }
 
     @Test
     public void testBuildMessageFromEventMeshCloudEvent() {
 
         Object object = EventMeshCloudEventBuilder.buildMessageFromEventMeshCloudEvent(null, EventMeshProtocolType.CLOUD_EVENTS);
-        Assert.assertNull(object);
+        Assertions.assertNull(object);
         CloudEvent eventmesh = CloudEvent.newBuilder().setSpecVersion("1.0").setType("eventmesh").setSource(URI.create("/").toString())
             .setId(UUID.randomUUID().toString()).build();
         Object event = EventMeshCloudEventBuilder.buildMessageFromEventMeshCloudEvent(eventmesh, EventMeshProtocolType.CLOUD_EVENTS);
-        Assert.assertNull(event);
+        Assertions.assertNull(event);
         CloudEvent eventmesh1 = CloudEvent.newBuilder().setSpecVersion("1.0").setType("eventmesh").setSource(URI.create("/").toString())
             .setId(UUID.randomUUID().toString()).putAttributes(ProtocolKey.SEQ_NUM, CloudEventAttributeValue.newBuilder().setCeString("1").build())
             .build();
         Object event1 = EventMeshCloudEventBuilder.buildMessageFromEventMeshCloudEvent(eventmesh1, EventMeshProtocolType.CLOUD_EVENTS);
-        Assert.assertTrue(event1 instanceof io.cloudevents.CloudEvent);
+        Assertions.assertTrue(event1 instanceof io.cloudevents.CloudEvent);
         Object event2 = EventMeshCloudEventBuilder.buildMessageFromEventMeshCloudEvent(eventmesh1, EventMeshProtocolType.EVENT_MESH_MESSAGE);
-        Assert.assertTrue(event2 instanceof EventMeshMessage);
+        Assertions.assertTrue(event2 instanceof EventMeshMessage);
 
         final Map<String, CloudEventAttributeValue> attributeValueMap = EventMeshCloudEventBuilder.buildCommonCloudEventAttributes(clientConfig,
             EventMeshProtocolType.EVENT_MESH_MESSAGE);
@@ -178,6 +180,6 @@ public class EventMeshCloudEventBuilderTest {
         CloudEvent eventmesh2 = CloudEvent.newBuilder().setSpecVersion("1.0").setType("eventmesh").setSource(URI.create("/").toString())
             .setId(UUID.randomUUID().toString()).putAllAttributes(attributeValueMap).setTextData(JsonUtils.toJSONString(set)).build();
         Object event4 = EventMeshCloudEventBuilder.buildMessageFromEventMeshCloudEvent(eventmesh2, EventMeshProtocolType.CLOUD_EVENTS);
-        Assert.assertTrue(event4 instanceof Set);
+        Assertions.assertTrue(event4 instanceof Set);
     }
 }

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/http/util/HttpLoadBalanceUtilsTest.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/http/util/HttpLoadBalanceUtilsTest.java
@@ -22,8 +22,8 @@ import org.apache.eventmesh.common.exception.EventMeshException;
 import org.apache.eventmesh.common.loadbalance.LoadBalanceSelector;
 import org.apache.eventmesh.common.loadbalance.LoadBalanceType;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class HttpLoadBalanceUtilsTest {
 
@@ -34,7 +34,7 @@ public class HttpLoadBalanceUtilsTest {
             .build();
         LoadBalanceSelector<String> randomSelector = HttpLoadBalanceUtils
             .createEventMeshServerLoadBalanceSelector(eventMeshHttpClientConfig);
-        Assert.assertEquals(LoadBalanceType.RANDOM, randomSelector.getType());
+        Assertions.assertEquals(LoadBalanceType.RANDOM, randomSelector.getType());
     }
 
     @Test
@@ -44,7 +44,7 @@ public class HttpLoadBalanceUtilsTest {
             .loadBalanceType(LoadBalanceType.WEIGHT_ROUND_ROBIN).build();
         LoadBalanceSelector<String> weightRoundRobinSelector = HttpLoadBalanceUtils
             .createEventMeshServerLoadBalanceSelector(eventMeshHttpClientConfig);
-        Assert.assertEquals(LoadBalanceType.WEIGHT_ROUND_ROBIN, weightRoundRobinSelector.getType());
+        Assertions.assertEquals(LoadBalanceType.WEIGHT_ROUND_ROBIN, weightRoundRobinSelector.getType());
     }
 
     @Test
@@ -54,6 +54,6 @@ public class HttpLoadBalanceUtilsTest {
             .loadBalanceType(LoadBalanceType.WEIGHT_RANDOM).build();
         LoadBalanceSelector<String> weightRoundRobinSelector = HttpLoadBalanceUtils
             .createEventMeshServerLoadBalanceSelector(eventMeshHttpClientConfig);
-        Assert.assertEquals(LoadBalanceType.WEIGHT_RANDOM, weightRoundRobinSelector.getType());
+        Assertions.assertEquals(LoadBalanceType.WEIGHT_RANDOM, weightRoundRobinSelector.getType());
     }
 }

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/http/util/HttpUtilsTest.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/http/util/HttpUtilsTest.java
@@ -30,8 +30,8 @@ import org.apache.http.impl.client.CloseableHttpClient;
 
 import java.io.IOException;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.netty.handler.codec.http.HttpMethod;
 
@@ -47,11 +47,11 @@ public class HttpUtilsTest {
             String expectedResult = "Success";
             when(client.execute(any(HttpPost.class), any(ResponseHandler.class))).thenReturn(expectedResult);
             String result = HttpUtils.post(client, uri, requestParam);
-            Assert.assertEquals(expectedResult, result);
+            Assertions.assertEquals(expectedResult, result);
         } catch (IOException e) {
             exception = e;
         }
-        Assert.assertNull(exception);
+        Assertions.assertNull(exception);
     }
 
     @Test
@@ -63,9 +63,9 @@ public class HttpUtilsTest {
         try {
             when(client.execute(any(HttpPost.class), any(ResponseHandler.class))).thenReturn(expectedResult);
             String result = HttpUtils.post(client, uri, requestParam);
-            Assert.assertNotEquals(expectedResult, result);
+            Assertions.assertNotEquals(expectedResult, result);
         } catch (Exception e) {
-            Assert.assertNotNull(e);
+            Assertions.assertNotNull(e);
         }
     }
 
@@ -79,11 +79,11 @@ public class HttpUtilsTest {
         try {
             when(client.execute(any(HttpGet.class), any(ResponseHandler.class))).thenReturn(expectedResult);
             String result = HttpUtils.get(client, uri, requestParam);
-            Assert.assertEquals(expectedResult, result);
+            Assertions.assertEquals(expectedResult, result);
         } catch (IOException e) {
             exception = e;
         }
-        Assert.assertNull(exception);
+        Assertions.assertNull(exception);
     }
 
     @Test
@@ -95,9 +95,9 @@ public class HttpUtilsTest {
         try {
             when(client.execute(any(HttpGet.class), any(ResponseHandler.class))).thenReturn(expectedResult);
             String result = HttpUtils.get(client, uri, requestParam);
-            Assert.assertNotEquals(expectedResult, result);
+            Assertions.assertNotEquals(expectedResult, result);
         } catch (Exception e) {
-            Assert.assertNotNull(e);
+            Assertions.assertNotNull(e);
         }
     }
 }

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/tcp/common/MessageUtilsTest.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/tcp/common/MessageUtilsTest.java
@@ -29,8 +29,8 @@ import org.apache.eventmesh.common.protocol.tcp.UserAgent;
 
 import java.util.UUID;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class MessageUtilsTest {
 
@@ -39,10 +39,10 @@ public class MessageUtilsTest {
         // Positive Test Case
         UserAgent user = new UserAgent();
         Package msg = MessageUtils.hello(user);
-        Assert.assertNotNull(msg);
-        Assert.assertEquals(Command.HELLO_REQUEST, msg.getHeader().getCommand());
-        Assert.assertNotNull(msg.getBody());
-        Assert.assertTrue(msg.getBody() instanceof UserAgent);
+        Assertions.assertNotNull(msg);
+        Assertions.assertEquals(Command.HELLO_REQUEST, msg.getHeader().getCommand());
+        Assertions.assertNotNull(msg.getBody());
+        Assertions.assertTrue(msg.getBody() instanceof UserAgent);
         // Negative Test Case
         user = null;
         try {
@@ -50,7 +50,7 @@ public class MessageUtilsTest {
             msg = MessageUtils.hello(user);
 
         } catch (Exception e) {
-            Assert.assertNull(msg);
+            Assertions.assertNull(msg);
         }
     }
 
@@ -58,36 +58,36 @@ public class MessageUtilsTest {
     public void testHeartBeat() {
         // Positive Test Case
         Package msg = MessageUtils.heartBeat();
-        Assert.assertNotNull(msg);
-        Assert.assertEquals(Command.HEARTBEAT_REQUEST, msg.getHeader().getCommand());
-        Assert.assertNull(msg.getBody());
+        Assertions.assertNotNull(msg);
+        Assertions.assertEquals(Command.HEARTBEAT_REQUEST, msg.getHeader().getCommand());
+        Assertions.assertNull(msg.getBody());
         // Negative Test Case
         msg = null;
-        Assert.assertNull(msg);
+        Assertions.assertNull(msg);
     }
 
     @Test
     public void testGoodbye() {
         // Positive Test Case
         Package msg = MessageUtils.goodbye();
-        Assert.assertNotNull(msg);
-        Assert.assertEquals(Command.CLIENT_GOODBYE_REQUEST, msg.getHeader().getCommand());
-        Assert.assertNull(msg.getBody());
+        Assertions.assertNotNull(msg);
+        Assertions.assertEquals(Command.CLIENT_GOODBYE_REQUEST, msg.getHeader().getCommand());
+        Assertions.assertNull(msg.getBody());
         // Negative Test Case
         msg = null;
-        Assert.assertNull(msg);
+        Assertions.assertNull(msg);
     }
 
     @Test
     public void testListen() {
         // Positive Test Case
         Package msg = MessageUtils.listen();
-        Assert.assertNotNull(msg);
-        Assert.assertEquals(Command.LISTEN_REQUEST, msg.getHeader().getCommand());
-        Assert.assertNull(msg.getBody());
+        Assertions.assertNotNull(msg);
+        Assertions.assertEquals(Command.LISTEN_REQUEST, msg.getHeader().getCommand());
+        Assertions.assertNull(msg.getBody());
         // Negative Test Case
         msg = null;
-        Assert.assertNull(msg);
+        Assertions.assertNull(msg);
     }
 
     @Test
@@ -97,10 +97,10 @@ public class MessageUtilsTest {
         SubscriptionMode subscriptionMode = SubscriptionMode.CLUSTERING;
         SubscriptionType subscriptionType = SubscriptionType.SYNC;
         Package msg = MessageUtils.subscribe(topic, subscriptionMode, subscriptionType);
-        Assert.assertNotNull(msg);
-        Assert.assertEquals(Command.SUBSCRIBE_REQUEST, msg.getHeader().getCommand());
-        Assert.assertNotNull(msg.getBody());
-        Assert.assertTrue(msg.getBody() instanceof Subscription);
+        Assertions.assertNotNull(msg);
+        Assertions.assertEquals(Command.SUBSCRIBE_REQUEST, msg.getHeader().getCommand());
+        Assertions.assertNotNull(msg.getBody());
+        Assertions.assertTrue(msg.getBody() instanceof Subscription);
         // Negative Test Case
         topic = null;
         subscriptionMode = null;
@@ -110,7 +110,7 @@ public class MessageUtilsTest {
             msg = MessageUtils.subscribe(topic, subscriptionMode, subscriptionType);
 
         } catch (Exception e) {
-            Assert.assertNull(msg);
+            Assertions.assertNull(msg);
         }
     }
 
@@ -118,12 +118,12 @@ public class MessageUtilsTest {
     public void testUnsubscribe() {
         // Positive Test Case
         Package msg = MessageUtils.unsubscribe();
-        Assert.assertNotNull(msg);
-        Assert.assertEquals(Command.UNSUBSCRIBE_REQUEST, msg.getHeader().getCommand());
-        Assert.assertNull(msg.getBody());
+        Assertions.assertNotNull(msg);
+        Assertions.assertEquals(Command.UNSUBSCRIBE_REQUEST, msg.getHeader().getCommand());
+        Assertions.assertNull(msg.getBody());
         // Negative Test Case
         msg = null;
-        Assert.assertNull(msg);
+        Assertions.assertNull(msg);
     }
 
     @Test
@@ -134,18 +134,18 @@ public class MessageUtilsTest {
         in.setHeader(header);
         in.setBody("testBody");
         Package msg = MessageUtils.asyncMessageAck(in);
-        Assert.assertNotNull(msg);
-        Assert.assertEquals(Command.ASYNC_MESSAGE_TO_CLIENT_ACK, msg.getHeader().getCommand());
-        Assert.assertEquals(msg.getHeader().getSeq(), in.getHeader().getSeq());
-        Assert.assertNotNull(msg.getBody());
-        Assert.assertEquals(msg.getBody(), in.getBody());
+        Assertions.assertNotNull(msg);
+        Assertions.assertEquals(Command.ASYNC_MESSAGE_TO_CLIENT_ACK, msg.getHeader().getCommand());
+        Assertions.assertEquals(msg.getHeader().getSeq(), in.getHeader().getSeq());
+        Assertions.assertNotNull(msg.getBody());
+        Assertions.assertEquals(msg.getBody(), in.getBody());
         // Negative Test Case
         in = null;
         msg = null;
         try {
             msg = MessageUtils.asyncMessageAck(in);
         } catch (Exception e) {
-            Assert.assertNull(msg);
+            Assertions.assertNull(msg);
         }
     }
 
@@ -156,11 +156,11 @@ public class MessageUtilsTest {
         eventMeshMessage.setBody("111");
         Command command = Command.ASYNC_MESSAGE_TO_SERVER;
         Package msg = MessageUtils.buildPackage(eventMeshMessage, command);
-        Assert.assertNotNull(msg);
-        Assert.assertEquals(msg.getHeader().getCommand(), command);
-        Assert.assertEquals(EventMeshCommon.EM_MESSAGE_PROTOCOL_NAME, msg.getHeader().getProperty(Constants.PROTOCOL_TYPE));
-        Assert.assertEquals("tcp", msg.getHeader().getProperty(Constants.PROTOCOL_DESC));
-        Assert.assertNotNull(msg.getBody());
-        Assert.assertTrue(msg.getBody() instanceof EventMeshMessage);
+        Assertions.assertNotNull(msg);
+        Assertions.assertEquals(msg.getHeader().getCommand(), command);
+        Assertions.assertEquals(EventMeshCommon.EM_MESSAGE_PROTOCOL_NAME, msg.getHeader().getProperty(Constants.PROTOCOL_TYPE));
+        Assertions.assertEquals("tcp", msg.getHeader().getProperty(Constants.PROTOCOL_DESC));
+        Assertions.assertNotNull(msg.getBody());
+        Assertions.assertTrue(msg.getBody() instanceof EventMeshMessage);
     }
 }

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/tcp/impl/EventMeshTCPClientFactoryTest.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/tcp/impl/EventMeshTCPClientFactoryTest.java
@@ -25,8 +25,8 @@ import org.apache.eventmesh.client.tcp.impl.eventmeshmessage.EventMeshMessageTCP
 import org.apache.eventmesh.client.tcp.impl.openmessage.OpenMessageTCPClient;
 import org.apache.eventmesh.common.protocol.tcp.EventMeshMessage;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.cloudevents.CloudEvent;
 import io.openmessaging.api.Message;
@@ -42,14 +42,14 @@ public class EventMeshTCPClientFactoryTest {
 
         EventMeshTCPClient<EventMeshMessage> eventMeshMessageTCPClient =
             EventMeshTCPClientFactory.createEventMeshTCPClient(meshTCPClientConfig, EventMeshMessage.class);
-        Assert.assertEquals(EventMeshMessageTCPClient.class, eventMeshMessageTCPClient.getClass());
+        Assertions.assertEquals(EventMeshMessageTCPClient.class, eventMeshMessageTCPClient.getClass());
 
         EventMeshTCPClient<CloudEvent> cloudEventTCPClient =
             EventMeshTCPClientFactory.createEventMeshTCPClient(meshTCPClientConfig, CloudEvent.class);
-        Assert.assertEquals(CloudEventTCPClient.class, cloudEventTCPClient.getClass());
+        Assertions.assertEquals(CloudEventTCPClient.class, cloudEventTCPClient.getClass());
 
         EventMeshTCPClient<Message> openMessageTCPClient =
             EventMeshTCPClientFactory.createEventMeshTCPClient(meshTCPClientConfig, Message.class);
-        Assert.assertEquals(OpenMessageTCPClient.class, openMessageTCPClient.getClass());
+        Assertions.assertEquals(OpenMessageTCPClient.class, openMessageTCPClient.getClass());
     }
 }

--- a/eventmesh-security-plugin/eventmesh-security-acl/src/test/java/org/apache/eventmesh/acl/impl/AclServiceImplTest.java
+++ b/eventmesh-security-plugin/eventmesh-security-acl/src/test/java/org/apache/eventmesh/acl/impl/AclServiceImplTest.java
@@ -21,15 +21,15 @@ import org.apache.eventmesh.api.acl.AclProperties;
 import org.apache.eventmesh.api.acl.AclService;
 import org.apache.eventmesh.api.exception.AclException;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class AclServiceImplTest {
 
     private static AclService service;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         service = new AclServiceImpl();
     }
@@ -39,7 +39,7 @@ public class AclServiceImplTest {
         try {
             service.init();
         } catch (AclException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -48,7 +48,7 @@ public class AclServiceImplTest {
         try {
             service.start();
         } catch (AclException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -57,7 +57,7 @@ public class AclServiceImplTest {
         try {
             service.shutdown();
         } catch (AclException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -66,7 +66,7 @@ public class AclServiceImplTest {
         try {
             service.doAclCheckInConnect(new AclProperties());
         } catch (AclException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -75,7 +75,7 @@ public class AclServiceImplTest {
         try {
             service.doAclCheckInHeartbeat(new AclProperties());
         } catch (AclException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -84,7 +84,7 @@ public class AclServiceImplTest {
         try {
             service.doAclCheckInSend(new AclProperties());
         } catch (AclException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -93,7 +93,7 @@ public class AclServiceImplTest {
         try {
             service.doAclCheckInReceive(new AclProperties());
         } catch (AclException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 }

--- a/eventmesh-security-plugin/eventmesh-security-api/src/test/java/org/apache/eventmesh/api/acl/AclServiceTest.java
+++ b/eventmesh-security-plugin/eventmesh-security-api/src/test/java/org/apache/eventmesh/api/acl/AclServiceTest.java
@@ -19,9 +19,9 @@ package org.apache.eventmesh.api.acl;
 
 import org.apache.eventmesh.api.exception.AclException;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class AclServiceTest {
 
@@ -65,7 +65,7 @@ public class AclServiceTest {
 
     private static AclService service;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         service = new DemoAclService();
     }
@@ -75,7 +75,7 @@ public class AclServiceTest {
         try {
             service.init();
         } catch (AclException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -84,7 +84,7 @@ public class AclServiceTest {
         try {
             service.start();
         } catch (AclException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -93,7 +93,7 @@ public class AclServiceTest {
         try {
             service.shutdown();
         } catch (AclException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -102,7 +102,7 @@ public class AclServiceTest {
         try {
             service.doAclCheckInConnect(new AclProperties());
         } catch (AclException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -111,7 +111,7 @@ public class AclServiceTest {
         try {
             service.doAclCheckInHeartbeat(new AclProperties());
         } catch (AclException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -120,7 +120,7 @@ public class AclServiceTest {
         try {
             service.doAclCheckInSend(new AclProperties());
         } catch (AclException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -129,7 +129,7 @@ public class AclServiceTest {
         try {
             service.doAclCheckInReceive(new AclProperties());
         } catch (AclException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 

--- a/eventmesh-security-plugin/eventmesh-security-api/src/test/java/org/apache/eventmesh/api/auth/AuthServiceTest.java
+++ b/eventmesh-security-plugin/eventmesh-security-api/src/test/java/org/apache/eventmesh/api/auth/AuthServiceTest.java
@@ -21,9 +21,9 @@ import org.apache.eventmesh.api.exception.AuthException;
 
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class AuthServiceTest {
 
@@ -52,7 +52,7 @@ public class AuthServiceTest {
 
     private static AuthService service;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         service = new DemoAuthService();
     }
@@ -62,7 +62,7 @@ public class AuthServiceTest {
         try {
             service.init();
         } catch (AuthException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -71,7 +71,7 @@ public class AuthServiceTest {
         try {
             service.start();
         } catch (AuthException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -80,7 +80,7 @@ public class AuthServiceTest {
         try {
             service.shutdown();
         } catch (AuthException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -88,9 +88,9 @@ public class AuthServiceTest {
     public void testGetAuthParams() {
         try {
             Map<String, String> authParams = service.getAuthParams();
-            Assert.assertNull(authParams);
+            Assertions.assertNull(authParams);
         } catch (AuthException e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 }

--- a/eventmesh-security-plugin/eventmesh-security-api/src/test/java/org/apache/eventmesh/api/exception/AclExceptionTest.java
+++ b/eventmesh-security-plugin/eventmesh-security-api/src/test/java/org/apache/eventmesh/api/exception/AclExceptionTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.eventmesh.api.exception;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class AclExceptionTest {
 
@@ -29,7 +29,7 @@ public class AclExceptionTest {
 
             new AclException(null);
         } catch (Exception e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -40,7 +40,7 @@ public class AclExceptionTest {
 
             new AclException(null, null);
         } catch (Exception e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 }

--- a/eventmesh-security-plugin/eventmesh-security-auth-http-basic/src/test/java/org/apache/eventmesh/auth/http/basic/config/AuthConfigsTest.java
+++ b/eventmesh-security-plugin/eventmesh-security-auth-http-basic/src/test/java/org/apache/eventmesh/auth/http/basic/config/AuthConfigsTest.java
@@ -21,8 +21,8 @@ import org.apache.eventmesh.api.auth.AuthService;
 import org.apache.eventmesh.auth.http.basic.impl.AuthHttpBasicService;
 import org.apache.eventmesh.spi.EventMeshExtensionFactory;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class AuthConfigsTest {
 
@@ -36,7 +36,7 @@ public class AuthConfigsTest {
     }
 
     private void assertConfig(AuthConfigs config) {
-        Assert.assertEquals(config.getUsername(), "username-success!!!");
-        Assert.assertEquals(config.getPassword(), "password-success!!!");
+        Assertions.assertEquals(config.getUsername(), "username-success!!!");
+        Assertions.assertEquals(config.getPassword(), "password-success!!!");
     }
 }

--- a/eventmesh-security-plugin/eventmesh-security-auth-http-basic/src/test/java/org/apache/eventmesh/auth/http/basic/impl/AuthHttpBasicServiceTest.java
+++ b/eventmesh-security-plugin/eventmesh-security-auth-http-basic/src/test/java/org/apache/eventmesh/auth/http/basic/impl/AuthHttpBasicServiceTest.java
@@ -22,15 +22,15 @@ import org.apache.eventmesh.spi.EventMeshExtensionFactory;
 
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class AuthHttpBasicServiceTest {
 
     private static AuthHttpBasicService service;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         service = (AuthHttpBasicService) EventMeshExtensionFactory.getExtension(
             AuthService.class, "auth-http-basic");
@@ -42,10 +42,10 @@ public class AuthHttpBasicServiceTest {
             service.init();
             Map<String, String> authParams = service.getAuthParams();
             String authorization = authParams.get("Authorization");
-            Assert.assertNotNull(authorization);
-            Assert.assertTrue(authorization.length() > 5);
+            Assertions.assertNotNull(authorization);
+            Assertions.assertTrue(authorization.length() > 5);
         } catch (Exception e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -54,7 +54,7 @@ public class AuthHttpBasicServiceTest {
         try {
             service.start();
         } catch (Exception e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
 
     }
@@ -64,7 +64,7 @@ public class AuthHttpBasicServiceTest {
         try {
             service.shutdown();
         } catch (Exception e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
 
     }

--- a/eventmesh-spi/src/test/java/org/apache/eventmesh/spi/EventMeshExtensionFactoryTest.java
+++ b/eventmesh-spi/src/test/java/org/apache/eventmesh/spi/EventMeshExtensionFactoryTest.java
@@ -21,8 +21,8 @@ import org.apache.eventmesh.spi.example.TestAnotherSingletonExtension;
 import org.apache.eventmesh.spi.example.TestPrototypeExtension;
 import org.apache.eventmesh.spi.example.TestSingletonExtension;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class EventMeshExtensionFactoryTest {
 
@@ -30,13 +30,13 @@ public class EventMeshExtensionFactoryTest {
     public void testGetSingletonExtension() {
         TestSingletonExtension extensionA = EventMeshExtensionFactory.getExtension(TestSingletonExtension.class, "singletonExtension");
         TestSingletonExtension extensionB = EventMeshExtensionFactory.getExtension(TestSingletonExtension.class, "singletonExtension");
-        Assert.assertSame(extensionA, extensionB);
+        Assertions.assertSame(extensionA, extensionB);
 
         TestAnotherSingletonExtension singletonExtension = EventMeshExtensionFactory.getExtension(TestAnotherSingletonExtension.class,
             "singletonExtension");
-        Assert.assertNotNull(singletonExtension);
+        Assertions.assertNotNull(singletonExtension);
         TestSingletonExtension singletonExtension1 = EventMeshExtensionFactory.getExtension(TestSingletonExtension.class, "singletonExtension");
-        Assert.assertNotNull(singletonExtension1);
+        Assertions.assertNotNull(singletonExtension1);
 
     }
 
@@ -44,7 +44,7 @@ public class EventMeshExtensionFactoryTest {
     public void testGetPrototypeExtension() {
         TestPrototypeExtension prototypeExtensionA = EventMeshExtensionFactory.getExtension(TestPrototypeExtension.class, "prototypeExtension");
         TestPrototypeExtension prototypeExtensionB = EventMeshExtensionFactory.getExtension(TestPrototypeExtension.class, "prototypeExtension");
-        Assert.assertNotSame(prototypeExtensionA, prototypeExtensionB);
+        Assertions.assertNotSame(prototypeExtensionA, prototypeExtensionB);
     }
 
     @Test
@@ -57,7 +57,7 @@ public class EventMeshExtensionFactoryTest {
                 exception = (ExtensionException) ex;
             }
         }
-        Assert.assertNotNull(exception);
+        Assertions.assertNotNull(exception);
         exception = null;
         try {
             EventMeshExtensionFactory.getExtension(TestPrototypeExtension.class, null);
@@ -66,6 +66,6 @@ public class EventMeshExtensionFactoryTest {
                 exception = (ExtensionException) ex;
             }
         }
-        Assert.assertNotNull(exception);
+        Assertions.assertNotNull(exception);
     }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-kafka/build.gradle
+++ b/eventmesh-storage-plugin/eventmesh-storage-kafka/build.gradle
@@ -28,8 +28,7 @@ dependencies {
     // https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients
     implementation 'org.apache.kafka:kafka-clients:3.0.0'
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.6.0'
 
     testImplementation project(":eventmesh-storage-plugin:eventmesh-storage-api")
     testImplementation project(":eventmesh-common")

--- a/eventmesh-storage-plugin/eventmesh-storage-kafka/build.gradle
+++ b/eventmesh-storage-plugin/eventmesh-storage-kafka/build.gradle
@@ -34,8 +34,6 @@ dependencies {
     testImplementation project(":eventmesh-common")
 
     testImplementation "org.mockito:mockito-core"
-    testImplementation "org.powermock:powermock-module-junit4"
-    testImplementation "org.powermock:powermock-api-mockito2"
 
     compileOnly 'org.projectlombok:lombok'
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'

--- a/eventmesh-storage-plugin/eventmesh-storage-kafka/src/test/java/org/apache/eventmesh/storage/kafka/config/ClientConfigurationTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-kafka/src/test/java/org/apache/eventmesh/storage/kafka/config/ClientConfigurationTest.java
@@ -21,8 +21,8 @@ import org.apache.eventmesh.api.factory.StoragePluginFactory;
 import org.apache.eventmesh.storage.kafka.consumer.KafkaConsumerImpl;
 import org.apache.eventmesh.storage.kafka.producer.KafkaProducerImpl;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * test config of Kafka SPI Impl
@@ -50,22 +50,22 @@ public class ClientConfigurationTest {
     }
 
     private void assertConfig(ClientConfiguration config) {
-        Assert.assertEquals("127.0.0.1:9092;127.0.0.1:9092", config.getNamesrvAddr());
-        Assert.assertEquals("username-succeed!!!", config.getClientUserName());
-        Assert.assertEquals("password-succeed!!!", config.getClientPass());
-        Assert.assertEquals(Integer.valueOf(1816), config.getConsumeThreadMin());
-        Assert.assertEquals(Integer.valueOf(2816), config.getConsumeThreadMax());
-        Assert.assertEquals(Integer.valueOf(3816), config.getConsumeQueueSize());
-        Assert.assertEquals(Integer.valueOf(4816), config.getPullBatchSize());
-        Assert.assertEquals(Integer.valueOf(5816), config.getAckWindow());
-        Assert.assertEquals(Integer.valueOf(6816), config.getPubWindow());
-        Assert.assertEquals(7816, config.getConsumeTimeout());
-        Assert.assertEquals(Integer.valueOf(8816), config.getPollNameServerInterval());
-        Assert.assertEquals(Integer.valueOf(9816), config.getHeartbeatBrokerInterval());
-        Assert.assertEquals(Integer.valueOf(11816), config.getRebalanceInterval());
-        Assert.assertEquals("cluster-succeed!!!", config.getClusterName());
-        Assert.assertEquals("accessKey-succeed!!!", config.getAccessKey());
-        Assert.assertEquals("secretKey-succeed!!!", config.getSecretKey());
+        Assertions.assertEquals("127.0.0.1:9092;127.0.0.1:9092", config.getNamesrvAddr());
+        Assertions.assertEquals("username-succeed!!!", config.getClientUserName());
+        Assertions.assertEquals("password-succeed!!!", config.getClientPass());
+        Assertions.assertEquals(Integer.valueOf(1816), config.getConsumeThreadMin());
+        Assertions.assertEquals(Integer.valueOf(2816), config.getConsumeThreadMax());
+        Assertions.assertEquals(Integer.valueOf(3816), config.getConsumeQueueSize());
+        Assertions.assertEquals(Integer.valueOf(4816), config.getPullBatchSize());
+        Assertions.assertEquals(Integer.valueOf(5816), config.getAckWindow());
+        Assertions.assertEquals(Integer.valueOf(6816), config.getPubWindow());
+        Assertions.assertEquals(7816, config.getConsumeTimeout());
+        Assertions.assertEquals(Integer.valueOf(8816), config.getPollNameServerInterval());
+        Assertions.assertEquals(Integer.valueOf(9816), config.getHeartbeatBrokerInterval());
+        Assertions.assertEquals(Integer.valueOf(11816), config.getRebalanceInterval());
+        Assertions.assertEquals("cluster-succeed!!!", config.getClusterName());
+        Assertions.assertEquals("accessKey-succeed!!!", config.getAccessKey());
+        Assertions.assertEquals("secretKey-succeed!!!", config.getSecretKey());
 
     }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-pulsar/build.gradle
+++ b/eventmesh-storage-plugin/eventmesh-storage-pulsar/build.gradle
@@ -34,8 +34,6 @@ dependencies {
     testImplementation 'io.cloudevents:cloudevents-json-jackson'
 
     testImplementation "org.mockito:mockito-core"
-    testImplementation "org.powermock:powermock-module-junit4"
-    testImplementation "org.powermock:powermock-api-mockito2"
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/eventmesh-storage-plugin/eventmesh-storage-pulsar/src/test/java/org/apache/eventmesh/storage/pulsar/config/ClientConfigurationTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-pulsar/src/test/java/org/apache/eventmesh/storage/pulsar/config/ClientConfigurationTest.java
@@ -21,8 +21,8 @@ import org.apache.eventmesh.api.factory.StoragePluginFactory;
 import org.apache.eventmesh.storage.pulsar.consumer.PulsarConsumerImpl;
 import org.apache.eventmesh.storage.pulsar.producer.PulsarProducerImpl;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ClientConfigurationTest {
 
@@ -43,8 +43,8 @@ public class ClientConfigurationTest {
     }
 
     private void assertConfig(ClientConfiguration config) {
-        Assert.assertEquals("127.0.0.1:6650", config.getServiceAddr());
-        Assert.assertEquals("authPlugin-success!!!", config.getAuthPlugin());
-        Assert.assertEquals("authParams-success!!!", config.getAuthParams());
+        Assertions.assertEquals("127.0.0.1:6650", config.getServiceAddr());
+        Assertions.assertEquals("authPlugin-success!!!", config.getAuthPlugin());
+        Assertions.assertEquals("authParams-success!!!", config.getAuthParams());
     }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-rabbitmq/build.gradle
+++ b/eventmesh-storage-plugin/eventmesh-storage-rabbitmq/build.gradle
@@ -35,8 +35,6 @@ dependencies {
     testImplementation 'io.cloudevents:cloudevents-json-jackson'
 
     testImplementation "org.mockito:mockito-core"
-    testImplementation "org.powermock:powermock-module-junit4"
-    testImplementation "org.powermock:powermock-api-mockito2"
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/eventmesh-storage-plugin/eventmesh-storage-rabbitmq/src/test/java/org/apache/eventmesh/storage/rabbitmq/RabbitmqServer.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rabbitmq/src/test/java/org/apache/eventmesh/storage/rabbitmq/RabbitmqServer.java
@@ -23,15 +23,15 @@ import org.apache.eventmesh.storage.rabbitmq.producer.RabbitmqProducer;
 
 import java.util.Properties;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 public class RabbitmqServer {
 
     protected RabbitmqConsumer rabbitmqConsumer;
     protected RabbitmqProducer rabbitmqProducer;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         RabbitmqMockConnectionFactory rabbitmqMockConnectionFactory = new RabbitmqMockConnectionFactory();
 
@@ -47,7 +47,7 @@ public class RabbitmqServer {
         rabbitmqProducer.start();
     }
 
-    @After
+    @AfterEach
     public void shutdown() {
         rabbitmqConsumer.shutdown();
         rabbitmqProducer.shutdown();

--- a/eventmesh-storage-plugin/eventmesh-storage-rabbitmq/src/test/java/org/apache/eventmesh/storage/rabbitmq/cloudevent/RabbitmqCloudEventTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rabbitmq/src/test/java/org/apache/eventmesh/storage/rabbitmq/cloudevent/RabbitmqCloudEventTest.java
@@ -21,9 +21,9 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
@@ -32,7 +32,7 @@ public class RabbitmqCloudEventTest {
 
     private CloudEvent cloudEvent;
 
-    @Before
+    @BeforeEach
     public void before() {
         cloudEvent = CloudEventBuilder.v1()
             .withId("1")
@@ -49,22 +49,22 @@ public class RabbitmqCloudEventTest {
     public void toByteArray() throws Exception {
         RabbitmqCloudEventWriter writer = new RabbitmqCloudEventWriter();
         RabbitmqCloudEvent rabbitmqCloudEvent = writer.writeBinary(cloudEvent);
-        Assert.assertEquals("topic", cloudEvent.getSubject());
+        Assertions.assertEquals("topic", cloudEvent.getSubject());
 
         byte[] data = RabbitmqCloudEvent.toByteArray(rabbitmqCloudEvent);
-        Assert.assertNotNull(data);
+        Assertions.assertNotNull(data);
     }
 
     @Test
     public void getFromByteArray() throws Exception {
         RabbitmqCloudEventWriter writer = new RabbitmqCloudEventWriter();
         RabbitmqCloudEvent rabbitmqCloudEvent = writer.writeBinary(cloudEvent);
-        Assert.assertEquals("topic", cloudEvent.getSubject());
+        Assertions.assertEquals("topic", cloudEvent.getSubject());
 
         byte[] data = RabbitmqCloudEvent.toByteArray(rabbitmqCloudEvent);
-        Assert.assertNotNull(data);
+        Assertions.assertNotNull(data);
 
         RabbitmqCloudEvent event = RabbitmqCloudEvent.getFromByteArray(data);
-        Assert.assertEquals("topic", event.getExtensions().get("subject"));
+        Assertions.assertEquals("topic", event.getExtensions().get("subject"));
     }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-rabbitmq/src/test/java/org/apache/eventmesh/storage/rabbitmq/config/ConfigurationHolderTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rabbitmq/src/test/java/org/apache/eventmesh/storage/rabbitmq/config/ConfigurationHolderTest.java
@@ -21,8 +21,8 @@ import org.apache.eventmesh.api.factory.StoragePluginFactory;
 import org.apache.eventmesh.storage.rabbitmq.consumer.RabbitmqConsumer;
 import org.apache.eventmesh.storage.rabbitmq.producer.RabbitmqProducer;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.rabbitmq.client.BuiltinExchangeType;
 
@@ -47,16 +47,16 @@ public class ConfigurationHolderTest {
     }
 
     private void assertConfig(ConfigurationHolder config) {
-        Assert.assertEquals("127.0.0.1", config.getHost());
-        Assert.assertEquals(5672, config.getPort());
-        Assert.assertEquals("username-success!!!", config.getUsername());
-        Assert.assertEquals("passwd-success!!!", config.getPasswd());
-        Assert.assertEquals("virtualHost-success!!!", config.getVirtualHost());
+        Assertions.assertEquals("127.0.0.1", config.getHost());
+        Assertions.assertEquals(5672, config.getPort());
+        Assertions.assertEquals("username-success!!!", config.getUsername());
+        Assertions.assertEquals("passwd-success!!!", config.getPasswd());
+        Assertions.assertEquals("virtualHost-success!!!", config.getVirtualHost());
 
-        Assert.assertEquals(BuiltinExchangeType.TOPIC, config.getExchangeType());
-        Assert.assertEquals("exchangeName-success!!!", config.getExchangeName());
-        Assert.assertEquals("routingKey-success!!!", config.getRoutingKey());
-        Assert.assertEquals("queueName-success!!!", config.getQueueName());
-        Assert.assertTrue(config.isAutoAck());
+        Assertions.assertEquals(BuiltinExchangeType.TOPIC, config.getExchangeType());
+        Assertions.assertEquals("exchangeName-success!!!", config.getExchangeName());
+        Assertions.assertEquals("routingKey-success!!!", config.getRoutingKey());
+        Assertions.assertEquals("queueName-success!!!", config.getQueueName());
+        Assertions.assertTrue(config.isAutoAck());
     }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-rabbitmq/src/test/java/org/apache/eventmesh/storage/rabbitmq/consumer/RabbitmqConsumerTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rabbitmq/src/test/java/org/apache/eventmesh/storage/rabbitmq/consumer/RabbitmqConsumerTest.java
@@ -30,8 +30,8 @@ import java.time.OffsetDateTime;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
@@ -40,12 +40,12 @@ public class RabbitmqConsumerTest extends RabbitmqServer {
 
     @Test
     public void isStarted() {
-        Assert.assertTrue(rabbitmqConsumer.isStarted());
+        Assertions.assertTrue(rabbitmqConsumer.isStarted());
     }
 
     @Test
     public void isClosed() {
-        Assert.assertFalse(rabbitmqConsumer.isClosed());
+        Assertions.assertFalse(rabbitmqConsumer.isClosed());
     }
 
     @Test
@@ -56,7 +56,7 @@ public class RabbitmqConsumerTest extends RabbitmqServer {
         rabbitmqConsumer.registerEventListener((cloudEvent, context) -> {
             downLatch.countDown();
             context.commit(EventMeshAction.CommitMessage);
-            Assert.assertEquals(cloudEvent.getSubject(), "topic");
+            Assertions.assertEquals(cloudEvent.getSubject(), "topic");
         });
 
         rabbitmqConsumer.subscribe("topic");
@@ -77,18 +77,18 @@ public class RabbitmqConsumerTest extends RabbitmqServer {
 
                 @Override
                 public void onSuccess(SendResult sendResult) {
-                    Assert.assertEquals(cloudEvent.getId(), sendResult.getMessageId());
-                    Assert.assertEquals(cloudEvent.getSubject(), sendResult.getTopic());
+                    Assertions.assertEquals(cloudEvent.getId(), sendResult.getMessageId());
+                    Assertions.assertEquals(cloudEvent.getSubject(), sendResult.getTopic());
                 }
 
                 @Override
                 public void onException(OnExceptionContext context) {
-                    Assert.assertEquals(cloudEvent.getId(), context.getMessageId());
-                    Assert.assertEquals(cloudEvent.getSubject(), context.getTopic());
+                    Assertions.assertEquals(cloudEvent.getId(), context.getMessageId());
+                    Assertions.assertEquals(cloudEvent.getSubject(), context.getTopic());
                 }
             });
         }
 
-        Assert.assertTrue(downLatch.await(5, TimeUnit.MINUTES));
+        Assertions.assertTrue(downLatch.await(5, TimeUnit.MINUTES));
     }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-rabbitmq/src/test/java/org/apache/eventmesh/storage/rabbitmq/producer/RabbitmqProducerTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rabbitmq/src/test/java/org/apache/eventmesh/storage/rabbitmq/producer/RabbitmqProducerTest.java
@@ -30,8 +30,8 @@ import java.time.OffsetDateTime;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
@@ -40,12 +40,12 @@ public class RabbitmqProducerTest extends RabbitmqServer {
 
     @Test
     public void isStarted() {
-        Assert.assertTrue(rabbitmqProducer.isStarted());
+        Assertions.assertTrue(rabbitmqProducer.isStarted());
     }
 
     @Test
     public void isClosed() {
-        Assert.assertFalse(rabbitmqProducer.isClosed());
+        Assertions.assertFalse(rabbitmqProducer.isClosed());
     }
 
     @Test
@@ -56,7 +56,7 @@ public class RabbitmqProducerTest extends RabbitmqServer {
         rabbitmqConsumer.registerEventListener((cloudEvent, context) -> {
             downLatch.countDown();
             context.commit(EventMeshAction.CommitMessage);
-            Assert.assertEquals(cloudEvent.getSubject(), "topic");
+            Assertions.assertEquals(cloudEvent.getSubject(), "topic");
         });
 
         rabbitmqConsumer.subscribe("topic");
@@ -77,18 +77,18 @@ public class RabbitmqProducerTest extends RabbitmqServer {
 
                 @Override
                 public void onSuccess(SendResult sendResult) {
-                    Assert.assertEquals(cloudEvent.getId(), sendResult.getMessageId());
-                    Assert.assertEquals(cloudEvent.getSubject(), sendResult.getTopic());
+                    Assertions.assertEquals(cloudEvent.getId(), sendResult.getMessageId());
+                    Assertions.assertEquals(cloudEvent.getSubject(), sendResult.getTopic());
                 }
 
                 @Override
                 public void onException(OnExceptionContext context) {
-                    Assert.assertEquals(cloudEvent.getId(), context.getMessageId());
-                    Assert.assertEquals(cloudEvent.getSubject(), context.getTopic());
+                    Assertions.assertEquals(cloudEvent.getId(), context.getMessageId());
+                    Assertions.assertEquals(cloudEvent.getSubject(), context.getTopic());
                 }
             });
         }
 
-        Assert.assertTrue(downLatch.await(5, TimeUnit.MINUTES));
+        Assertions.assertTrue(downLatch.await(5, TimeUnit.MINUTES));
     }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-redis/src/test/java/org/apache/eventmesh/storage/redis/AbstractRedisServer.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-redis/src/test/java/org/apache/eventmesh/storage/redis/AbstractRedisServer.java
@@ -17,8 +17,8 @@
 
 package org.apache.eventmesh.storage.redis;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 import ai.grakn.redismock.RedisServer;
 
@@ -26,13 +26,13 @@ public abstract class AbstractRedisServer {
 
     private static RedisServer redisServer;
 
-    @BeforeClass
+    @BeforeAll
     public static void setupRedisServer() throws Exception {
         redisServer = RedisServer.newRedisServer(6379);
         redisServer.start();
     }
 
-    @AfterClass
+    @AfterAll
     public static void shutdownRedisServer() {
         if (redisServer != null) {
             redisServer.stop();

--- a/eventmesh-storage-plugin/eventmesh-storage-redis/src/test/java/org/apache/eventmesh/storage/redis/client/RedissonClientTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-redis/src/test/java/org/apache/eventmesh/storage/redis/client/RedissonClientTest.java
@@ -19,13 +19,13 @@ package org.apache.eventmesh.storage.redis.client;
 
 import org.apache.eventmesh.storage.redis.AbstractRedisServer;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RedissonClientTest extends AbstractRedisServer {
 
     @Test
     public void testInstance() {
-        Assert.assertNotNull(RedissonClient.INSTANCE);
+        Assertions.assertNotNull(RedissonClient.INSTANCE);
     }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-redis/src/test/java/org/apache/eventmesh/storage/redis/config/RedisPropertiesTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-redis/src/test/java/org/apache/eventmesh/storage/redis/config/RedisPropertiesTest.java
@@ -21,8 +21,8 @@ import org.apache.eventmesh.common.config.ConfigService;
 
 import java.util.Properties;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RedisPropertiesTest {
 
@@ -34,14 +34,14 @@ public class RedisPropertiesTest {
     }
 
     private void assertConfig(RedisProperties config) {
-        Assert.assertEquals("redis://127.0.0.1:6379", config.getServerAddress());
-        Assert.assertEquals(RedisProperties.ServerType.SINGLE, config.getServerType());
-        Assert.assertEquals("serverMasterName-success!!!", config.getServerMasterName());
+        Assertions.assertEquals("redis://127.0.0.1:6379", config.getServerAddress());
+        Assertions.assertEquals(RedisProperties.ServerType.SINGLE, config.getServerType());
+        Assertions.assertEquals("serverMasterName-success!!!", config.getServerMasterName());
 
         Properties properties = new Properties();
         properties.put("threads", "2");
         properties.put("nettyThreads", "2");
         Properties redissonProperties = config.getRedissonProperties();
-        Assert.assertEquals(properties, redissonProperties);
+        Assertions.assertEquals(properties, redissonProperties);
     }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-redis/src/test/java/org/apache/eventmesh/storage/redis/connector/UnitTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-redis/src/test/java/org/apache/eventmesh/storage/redis/connector/UnitTest.java
@@ -33,10 +33,10 @@ import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
@@ -47,7 +47,7 @@ public class UnitTest extends AbstractRedisServer {
 
     private RedisConsumer redisConsumer;
 
-    @Before
+    @BeforeEach
     public void setup() {
         redisProducer = new RedisProducer();
         redisProducer.init(new Properties());
@@ -58,7 +58,7 @@ public class UnitTest extends AbstractRedisServer {
         redisConsumer.start();
     }
 
-    @After
+    @AfterEach
     public void shutdown() {
         redisProducer.shutdown();
         redisConsumer.shutdown();
@@ -104,6 +104,6 @@ public class UnitTest extends AbstractRedisServer {
             });
         }
 
-        Assert.assertTrue(downLatch.await(5, TimeUnit.MINUTES));
+        Assertions.assertTrue(downLatch.await(5, TimeUnit.MINUTES));
     }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-redis/src/test/java/org/apache/eventmesh/storage/redis/consumer/RedisConsumerTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-redis/src/test/java/org/apache/eventmesh/storage/redis/consumer/RedisConsumerTest.java
@@ -28,10 +28,10 @@ import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.redisson.api.RTopic;
 
 import io.cloudevents.CloudEvent;
@@ -41,14 +41,14 @@ public class RedisConsumerTest extends AbstractRedisServer {
 
     private RedisConsumer redisConsumer;
 
-    @Before
+    @BeforeEach
     public void setup() {
         redisConsumer = new RedisConsumer();
         redisConsumer.init(new Properties());
         redisConsumer.start();
     }
 
-    @After
+    @AfterEach
     public void shutdown() {
         redisConsumer.shutdown();
     }
@@ -83,7 +83,7 @@ public class RedisConsumerTest extends AbstractRedisServer {
             redissonTopic.publish(cloudEvent);
         }
 
-        Assert.assertTrue(downLatch.await(5, TimeUnit.MINUTES));
+        Assertions.assertTrue(downLatch.await(5, TimeUnit.MINUTES));
 
         redisConsumer.unsubscribe(topic);
     }

--- a/eventmesh-storage-plugin/eventmesh-storage-redis/src/test/java/org/apache/eventmesh/storage/redis/producer/RedisProducerTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-redis/src/test/java/org/apache/eventmesh/storage/redis/producer/RedisProducerTest.java
@@ -29,10 +29,10 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
@@ -41,14 +41,14 @@ public class RedisProducerTest extends AbstractRedisServer {
 
     private RedisProducer redisProducer;
 
-    @Before
+    @BeforeEach
     public void setup() {
         redisProducer = new RedisProducer();
         redisProducer.init(new Properties());
         redisProducer.start();
     }
 
-    @After
+    @AfterEach
     public void shutdown() {
         redisProducer.shutdown();
     }
@@ -74,15 +74,15 @@ public class RedisProducerTest extends AbstractRedisServer {
                 @Override
                 public void onSuccess(SendResult sendResult) {
                     downLatch.countDown();
-                    Assert.assertEquals(cloudEvent.getId(), sendResult.getMessageId());
-                    Assert.assertEquals(cloudEvent.getSubject(), sendResult.getTopic());
+                    Assertions.assertEquals(cloudEvent.getId(), sendResult.getMessageId());
+                    Assertions.assertEquals(cloudEvent.getSubject(), sendResult.getTopic());
                 }
 
                 @Override
                 public void onException(OnExceptionContext context) {
                     downLatch.countDown();
-                    Assert.assertEquals(cloudEvent.getId(), context.getMessageId());
-                    Assert.assertEquals(cloudEvent.getSubject(), context.getTopic());
+                    Assertions.assertEquals(cloudEvent.getId(), context.getMessageId());
+                    Assertions.assertEquals(cloudEvent.getSubject(), context.getTopic());
                 }
             });
         }

--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq/build.gradle
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq/build.gradle
@@ -46,8 +46,6 @@ dependencies {
     testImplementation project(":eventmesh-common")
 
     testImplementation "org.mockito:mockito-core"
-    testImplementation "org.powermock:powermock-module-junit4"
-    testImplementation "org.powermock:powermock-api-mockito2"
 
     testImplementation rocketmq
 

--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq/build.gradle
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     testImplementation project(":eventmesh-common")
 
     testImplementation "org.mockito:mockito-core"
+    testImplementation "org.mockito:mockito-junit-jupiter"
 
     testImplementation rocketmq
 

--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq/build.gradle
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq/build.gradle
@@ -29,7 +29,6 @@ List rocketmq = [
         "org.apache.rocketmq:rocketmq-tools:$rocketmq_version",
         "org.apache.rocketmq:rocketmq-remoting:$rocketmq_version",
         "org.apache.rocketmq:rocketmq-logging:$rocketmq_version",
-        "org.apache.rocketmq:rocketmq-test:$rocketmq_version",
         "org.apache.rocketmq:rocketmq-srvutil:$rocketmq_version",
         "org.apache.rocketmq:rocketmq-filter:$rocketmq_version",
         "org.apache.rocketmq:rocketmq-acl:$rocketmq_version",

--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/test/java/org/apache/eventmesh/storage/rocketmq/cloudevent/RocketMQMessageFactoryTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/test/java/org/apache/eventmesh/storage/rocketmq/cloudevent/RocketMQMessageFactoryTest.java
@@ -21,9 +21,9 @@ import org.apache.eventmesh.storage.rocketmq.cloudevent.impl.RocketMQHeaders;
 
 import org.apache.rocketmq.common.message.Message;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.cloudevents.SpecVersion;
 
@@ -31,7 +31,7 @@ public class RocketMQMessageFactoryTest {
 
     private Message message;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         message = new Message();
         message.putUserProperty(RocketMQHeaders.SPEC_VERSION, SpecVersion.V03.toString());
@@ -40,6 +40,6 @@ public class RocketMQMessageFactoryTest {
 
     @Test
     public void testCreateReader() {
-        Assert.assertNotNull(RocketMQMessageFactory.createReader(message));
+        Assertions.assertNotNull(RocketMQMessageFactory.createReader(message));
     }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/test/java/org/apache/eventmesh/storage/rocketmq/config/ClientConfigurationTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/test/java/org/apache/eventmesh/storage/rocketmq/config/ClientConfigurationTest.java
@@ -21,8 +21,8 @@ import org.apache.eventmesh.api.factory.StoragePluginFactory;
 import org.apache.eventmesh.storage.rocketmq.consumer.RocketMQConsumerImpl;
 import org.apache.eventmesh.storage.rocketmq.producer.RocketMQProducerImpl;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ClientConfigurationTest {
 
@@ -43,21 +43,21 @@ public class ClientConfigurationTest {
     }
 
     private void assertConfig(ClientConfiguration config) {
-        Assert.assertEquals("127.0.0.1:9876;127.0.0.1:9876", config.getNamesrvAddr());
-        Assert.assertEquals("username-succeed!!!", config.getClientUserName());
-        Assert.assertEquals("password-succeed!!!", config.getClientPass());
-        Assert.assertEquals(Integer.valueOf(1816), config.getConsumeThreadMin());
-        Assert.assertEquals(Integer.valueOf(2816), config.getConsumeThreadMax());
-        Assert.assertEquals(Integer.valueOf(3816), config.getConsumeQueueSize());
-        Assert.assertEquals(Integer.valueOf(4816), config.getPullBatchSize());
-        Assert.assertEquals(Integer.valueOf(5816), config.getAckWindow());
-        Assert.assertEquals(Integer.valueOf(6816), config.getPubWindow());
-        Assert.assertEquals(7816, config.getConsumeTimeout());
-        Assert.assertEquals(Integer.valueOf(8816), config.getPollNameServerInterval());
-        Assert.assertEquals(Integer.valueOf(9816), config.getHeartbeatBrokerInterval());
-        Assert.assertEquals(Integer.valueOf(11816), config.getRebalanceInterval());
-        Assert.assertEquals("cluster-succeed!!!", config.getClusterName());
-        Assert.assertEquals("accessKey-succeed!!!", config.getAccessKey());
-        Assert.assertEquals("secretKey-succeed!!!", config.getSecretKey());
+        Assertions.assertEquals("127.0.0.1:9876;127.0.0.1:9876", config.getNamesrvAddr());
+        Assertions.assertEquals("username-succeed!!!", config.getClientUserName());
+        Assertions.assertEquals("password-succeed!!!", config.getClientPass());
+        Assertions.assertEquals(Integer.valueOf(1816), config.getConsumeThreadMin());
+        Assertions.assertEquals(Integer.valueOf(2816), config.getConsumeThreadMax());
+        Assertions.assertEquals(Integer.valueOf(3816), config.getConsumeQueueSize());
+        Assertions.assertEquals(Integer.valueOf(4816), config.getPullBatchSize());
+        Assertions.assertEquals(Integer.valueOf(5816), config.getAckWindow());
+        Assertions.assertEquals(Integer.valueOf(6816), config.getPubWindow());
+        Assertions.assertEquals(7816, config.getConsumeTimeout());
+        Assertions.assertEquals(Integer.valueOf(8816), config.getPollNameServerInterval());
+        Assertions.assertEquals(Integer.valueOf(9816), config.getHeartbeatBrokerInterval());
+        Assertions.assertEquals(Integer.valueOf(11816), config.getRebalanceInterval());
+        Assertions.assertEquals("cluster-succeed!!!", config.getClusterName());
+        Assertions.assertEquals("accessKey-succeed!!!", config.getAccessKey());
+        Assertions.assertEquals("secretKey-succeed!!!", config.getSecretKey());
     }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/test/java/org/apache/eventmesh/storage/rocketmq/consumer/PushConsumerImplTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/test/java/org/apache/eventmesh/storage/rocketmq/consumer/PushConsumerImplTest.java
@@ -27,15 +27,15 @@ import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.Properties;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PushConsumerImplTest {
 
     private PushConsumerImpl consumer;
@@ -43,7 +43,7 @@ public class PushConsumerImplTest {
     @Mock
     private DefaultMQPushConsumer rocketmqPushConsumer;
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         Properties consumerProp = new Properties();
         // consumerProp.setProperty(OMSBuiltinKeys.DRIVER_IMPL,
@@ -67,7 +67,7 @@ public class PushConsumerImplTest {
         consumer.start();
     }
 
-    @After
+    @AfterEach
     public void after() throws Exception {
         Mockito.verify(rocketmqPushConsumer).getMessageListener();
         consumer.shutdown();

--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/test/java/org/apache/eventmesh/storage/rocketmq/producer/DefaultProducerImplTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/test/java/org/apache/eventmesh/storage/rocketmq/producer/DefaultProducerImplTest.java
@@ -17,16 +17,16 @@
 
 package org.apache.eventmesh.storage.rocketmq.producer;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 public class DefaultProducerImplTest {
 
-    @Before
+    @BeforeEach
     public void before() {
     }
 
-    @After
+    @AfterEach
     public void after() {
         // TBD:Remove topic
     }

--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/test/java/org/apache/eventmesh/storage/rocketmq/producer/ProducerImplTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/test/java/org/apache/eventmesh/storage/rocketmq/producer/ProducerImplTest.java
@@ -39,18 +39,18 @@ import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.Properties;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ProducerImplTest {
 
     private ProducerImpl producer;
@@ -58,7 +58,7 @@ public class ProducerImplTest {
     @Mock
     private DefaultMQProducer rocketmqProducer;
 
-    @Before
+    @BeforeEach
     public void before() throws NoSuchFieldException, IllegalAccessException {
         Properties config = new Properties();
         config.setProperty("access_points", "IP1:9876,IP2:9876");
@@ -72,7 +72,7 @@ public class ProducerImplTest {
 
     }
 
-    @After
+    @AfterEach
     public void after() {
         producer.shutdown();
     }

--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/test/java/org/apache/eventmesh/storage/rocketmq/utils/BeanUtilsTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/test/java/org/apache/eventmesh/storage/rocketmq/utils/BeanUtilsTest.java
@@ -22,9 +22,9 @@ import org.apache.eventmesh.storage.rocketmq.domain.NonStandardKeys;
 
 import java.util.Properties;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BeanUtilsTest {
 
@@ -69,7 +69,7 @@ public class BeanUtilsTest {
         }
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         properties.put(NonStandardKeys.MAX_REDELIVERY_TIMES, 120);
         properties.put(CustomizedConfig.STRING_TEST, "kaka");
@@ -84,12 +84,12 @@ public class BeanUtilsTest {
     public void testPopulate() {
         CustomizedConfig config = BeanUtils.populate(properties, CustomizedConfig.class);
 
-        Assert.assertEquals(120, config.getRmqMaxRedeliveryTimes());
-        Assert.assertEquals("kaka", config.getStringTest());
-        Assert.assertEquals("Default_Consumer_Group", config.getRmqConsumerGroup());
-        Assert.assertEquals(101, config.getRmqMessageConsumeTimeout());
-        Assert.assertEquals(1234567890L, config.getLongTest());
-        Assert.assertEquals(10.234, config.getDoubleTest(), 0.000001);
+        Assertions.assertEquals(120, config.getRmqMaxRedeliveryTimes());
+        Assertions.assertEquals("kaka", config.getStringTest());
+        Assertions.assertEquals("Default_Consumer_Group", config.getRmqConsumerGroup());
+        Assertions.assertEquals(101, config.getRmqMessageConsumeTimeout());
+        Assertions.assertEquals(1234567890L, config.getLongTest());
+        Assertions.assertEquals(10.234, config.getDoubleTest(), 0.000001);
     }
 
     @Test
@@ -97,16 +97,16 @@ public class BeanUtilsTest {
         CustomizedConfig config = new CustomizedConfig();
         config.setConsumerId("NewConsumerId");
 
-        Assert.assertEquals("NewConsumerId", config.getConsumerId());
+        Assertions.assertEquals("NewConsumerId", config.getConsumerId());
 
         BeanUtils.populate(properties, config);
 
-        Assert.assertEquals(120, config.getRmqMaxRedeliveryTimes());
-        Assert.assertEquals("kaka", config.getStringTest());
-        Assert.assertEquals("Default_Consumer_Group", config.getRmqConsumerGroup());
-        Assert.assertEquals(101, config.getRmqMessageConsumeTimeout());
-        Assert.assertEquals(1234567890L, config.getLongTest());
-        Assert.assertEquals(10.234, config.getDoubleTest(), 0.000001);
+        Assertions.assertEquals(120, config.getRmqMaxRedeliveryTimes());
+        Assertions.assertEquals("kaka", config.getStringTest());
+        Assertions.assertEquals("Default_Consumer_Group", config.getRmqConsumerGroup());
+        Assertions.assertEquals(101, config.getRmqMessageConsumeTimeout());
+        Assertions.assertEquals(1234567890L, config.getLongTest());
+        Assertions.assertEquals(10.234, config.getDoubleTest(), 0.000001);
     }
 
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-standalone/build.gradle
+++ b/eventmesh-storage-plugin/eventmesh-storage-standalone/build.gradle
@@ -23,4 +23,5 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation "org.mockito:mockito-inline"
+    testImplementation "org.mockito:mockito-junit-jupiter"
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-standalone/build.gradle
+++ b/eventmesh-storage-plugin/eventmesh-storage-standalone/build.gradle
@@ -22,6 +22,5 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    testImplementation "org.mockito:mockito-core"
     testImplementation "org.mockito:mockito-inline"
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/admin/StandaloneAdminTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/admin/StandaloneAdminTest.java
@@ -31,18 +31,21 @@ import org.apache.eventmesh.storage.standalone.broker.model.MessageEntity;
 
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import io.cloudevents.CloudEvent;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class StandaloneAdminTest {
 
     @Mock
@@ -50,7 +53,7 @@ public class StandaloneAdminTest {
 
     private StandaloneAdmin standaloneAdmin;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         initStaticInstance();
     }
@@ -58,19 +61,19 @@ public class StandaloneAdminTest {
     @Test
     public void testIsStarted() {
         standaloneAdmin.start();
-        Assert.assertTrue(standaloneAdmin.isStarted());
+        Assertions.assertTrue(standaloneAdmin.isStarted());
     }
 
     @Test
     public void testIsClosed() {
         standaloneAdmin.shutdown();
-        Assert.assertTrue(standaloneAdmin.isClosed());
+        Assertions.assertTrue(standaloneAdmin.isClosed());
     }
 
     @Test
     public void testGetTopic() throws Exception {
-        Assert.assertNotNull(standaloneAdmin.getTopic());
-        Assert.assertFalse(standaloneAdmin.getTopic().isEmpty());
+        Assertions.assertNotNull(standaloneAdmin.getTopic());
+        Assertions.assertFalse(standaloneAdmin.getTopic().isEmpty());
     }
 
     @Test
@@ -90,15 +93,15 @@ public class StandaloneAdminTest {
         Mockito.when(standaloneBroker.checkTopicExist(TEST_TOPIC)).thenReturn(TOPIC_EXISTS);
         Mockito.when(standaloneBroker.getMessage(TEST_TOPIC, OFF_SET)).thenReturn(createDefaultCloudEvent());
         List<CloudEvent> events = standaloneAdmin.getEvent(TEST_TOPIC, OFF_SET, LENGTH);
-        Assert.assertNotNull(events);
-        Assert.assertFalse(events.isEmpty());
+        Assertions.assertNotNull(events);
+        Assertions.assertFalse(events.isEmpty());
     }
 
     @Test
     public void testGetEvent_throwException() {
         Mockito.when(standaloneBroker.checkTopicExist(TEST_TOPIC)).thenReturn(TOPIC_DO_NOT_EXISTS);
-        Exception exception = Assert.assertThrows(Exception.class, () -> standaloneAdmin.getEvent(TEST_TOPIC, OFF_SET, LENGTH));
-        Assert.assertEquals("The topic name doesn't exist in the message queue", exception.getMessage());
+        Exception exception = Assertions.assertThrows(Exception.class, () -> standaloneAdmin.getEvent(TEST_TOPIC, OFF_SET, LENGTH));
+        Assertions.assertEquals("The topic name doesn't exist in the message queue", exception.getMessage());
     }
 
     @Test

--- a/eventmesh-storage-plugin/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/broker/MessageQueueTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/broker/MessageQueueTest.java
@@ -24,9 +24,9 @@ import org.apache.eventmesh.storage.standalone.broker.model.MessageEntity;
 import java.util.Arrays;
 import java.util.Objects;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MessageQueueTest {
 
@@ -36,79 +36,79 @@ public class MessageQueueTest {
     private static final int WRONG_OFFSET = 4;
     private MessageQueue messageQueue;
 
-    @Before
+    @BeforeEach
     public void setUp() throws InterruptedException {
         initMessageQueue();
     }
 
     @Test
     public void testPut() {
-        Assert.assertTrue(Arrays.stream(messageQueue.getItems()).findAny().isPresent());
+        Assertions.assertTrue(Arrays.stream(messageQueue.getItems()).findAny().isPresent());
     }
 
     @Test
     public void testTake() throws InterruptedException {
         MessageEntity takeMessage = messageQueue.take();
-        Assert.assertNotNull(takeMessage);
-        Assert.assertTrue(Arrays.stream(messageQueue.getItems()).findAny().isPresent());
+        Assertions.assertNotNull(takeMessage);
+        Assertions.assertTrue(Arrays.stream(messageQueue.getItems()).findAny().isPresent());
     }
 
     @Test
     public void testPeek() {
         MessageEntity peekMessage = messageQueue.peek();
-        Assert.assertNotNull(peekMessage);
-        Assert.assertTrue(Arrays.stream(messageQueue.getItems()).findAny().isPresent());
+        Assertions.assertNotNull(peekMessage);
+        Assertions.assertTrue(Arrays.stream(messageQueue.getItems()).findAny().isPresent());
     }
 
     @Test
     public void testGetHead() {
         MessageEntity headMessage = messageQueue.getHead();
-        Assert.assertNotNull(headMessage);
-        Assert.assertTrue(Arrays.stream(messageQueue.getItems()).findAny().isPresent());
+        Assertions.assertNotNull(headMessage);
+        Assertions.assertTrue(Arrays.stream(messageQueue.getItems()).findAny().isPresent());
     }
 
     @Test
     public void testGetTail() {
         MessageEntity tailMessage = messageQueue.getHead();
-        Assert.assertNotNull(tailMessage);
-        Assert.assertTrue(Arrays.stream(messageQueue.getItems()).findAny().isPresent());
+        Assertions.assertNotNull(tailMessage);
+        Assertions.assertTrue(Arrays.stream(messageQueue.getItems()).findAny().isPresent());
     }
 
     @Test
     public void testGetByOffset() {
         MessageEntity offSetMessageEntity = messageQueue.getByOffset(DEFAULT_OFFSET);
-        Assert.assertNotNull(offSetMessageEntity);
-        Assert.assertTrue(Arrays.stream(messageQueue.getItems()).findAny().isPresent());
-        Assert.assertEquals(DEFAULT_OFFSET, offSetMessageEntity.getOffset());
+        Assertions.assertNotNull(offSetMessageEntity);
+        Assertions.assertTrue(Arrays.stream(messageQueue.getItems()).findAny().isPresent());
+        Assertions.assertEquals(DEFAULT_OFFSET, offSetMessageEntity.getOffset());
     }
 
     @Test
     public void testGetByOffset_whenOffSetIsWrong_thenReturnsNull() {
         MessageEntity offSetMessageEntity = messageQueue.getByOffset(WRONG_OFFSET);
-        Assert.assertNull(offSetMessageEntity);
+        Assertions.assertNull(offSetMessageEntity);
     }
 
     @Test
     public void testRemoveHead() {
         messageQueue.removeHead();
-        Assert.assertTrue(Arrays.stream(messageQueue.getItems()).anyMatch(Objects::isNull));
+        Assertions.assertTrue(Arrays.stream(messageQueue.getItems()).anyMatch(Objects::isNull));
     }
 
     @Test
     public void testGetSize() {
-        Assert.assertEquals(ITEMS_COUNT, messageQueue.getSize());
+        Assertions.assertEquals(ITEMS_COUNT, messageQueue.getSize());
     }
 
     @Test
     public void testGetTakeIndex() throws InterruptedException {
         MessageEntity takeIndexMessageEntity = messageQueue.take();
-        Assert.assertNotNull(takeIndexMessageEntity);
-        Assert.assertEquals(1, messageQueue.getPutIndex());
+        Assertions.assertNotNull(takeIndexMessageEntity);
+        Assertions.assertEquals(1, messageQueue.getPutIndex());
     }
 
     @Test
     public void testGetPutIndex() {
-        Assert.assertEquals(1, messageQueue.getPutIndex());
+        Assertions.assertEquals(1, messageQueue.getPutIndex());
     }
 
     private void initMessageQueue() throws InterruptedException {

--- a/eventmesh-storage-plugin/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/broker/StandaloneBrokerTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/broker/StandaloneBrokerTest.java
@@ -27,8 +27,8 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.cloudevents.CloudEvent;
 
@@ -36,14 +36,14 @@ public class StandaloneBrokerTest {
 
     @Test
     public void testGetInstance() {
-        Assert.assertNotNull(StandaloneBroker.getInstance());
+        Assertions.assertNotNull(StandaloneBroker.getInstance());
     }
 
     @Test
     public void testCreateTopicIfAbsent() {
         StandaloneBroker instance = StandaloneBroker.getInstance();
         Pair<MessageQueue, AtomicLong> pair = instance.createTopicIfAbsent(TEST_TOPIC);
-        Assert.assertNotNull(pair);
+        Assertions.assertNotNull(pair);
     }
 
     @Test
@@ -51,7 +51,7 @@ public class StandaloneBrokerTest {
         StandaloneBroker instance = StandaloneBroker.getInstance();
         CloudEvent cloudEvent = createDefaultCloudEvent();
         MessageEntity messageEntity = instance.putMessage(TEST_TOPIC, cloudEvent);
-        Assert.assertNotNull(messageEntity);
+        Assertions.assertNotNull(messageEntity);
     }
 
     @Test
@@ -60,7 +60,7 @@ public class StandaloneBrokerTest {
         CloudEvent cloudEvent = createDefaultCloudEvent();
         instance.putMessage(TEST_TOPIC, cloudEvent);
         CloudEvent message = instance.takeMessage(TEST_TOPIC);
-        Assert.assertNotNull(message);
+        Assertions.assertNotNull(message);
     }
 
     @Test
@@ -69,7 +69,7 @@ public class StandaloneBrokerTest {
         CloudEvent cloudEvent = createDefaultCloudEvent();
         instance.putMessage(TEST_TOPIC, cloudEvent);
         CloudEvent cloudEventResult = instance.getMessage(TEST_TOPIC);
-        Assert.assertNotNull(cloudEventResult);
+        Assertions.assertNotNull(cloudEventResult);
     }
 
     @Test
@@ -78,7 +78,7 @@ public class StandaloneBrokerTest {
         CloudEvent cloudEvent = createDefaultCloudEvent();
         instance.putMessage(TEST_TOPIC, cloudEvent);
         CloudEvent cloudEventResult = instance.getMessage(TEST_TOPIC, OFF_SET);
-        Assert.assertNotNull(cloudEventResult);
+        Assertions.assertNotNull(cloudEventResult);
     }
 
     @Test
@@ -87,7 +87,7 @@ public class StandaloneBrokerTest {
         CloudEvent cloudEvent = createDefaultCloudEvent();
         instance.putMessage(TEST_TOPIC, cloudEvent);
         boolean exists = instance.checkTopicExist(TEST_TOPIC);
-        Assert.assertTrue(exists);
+        Assertions.assertTrue(exists);
     }
 
     @Test
@@ -97,6 +97,6 @@ public class StandaloneBrokerTest {
         instance.putMessage(TEST_TOPIC, cloudEvent);
         instance.deleteTopicIfExist(TEST_TOPIC);
         boolean exists = instance.checkTopicExist(TEST_TOPIC);
-        Assert.assertFalse(exists);
+        Assertions.assertFalse(exists);
     }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/broker/task/HistoryMessageClearTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/broker/task/HistoryMessageClearTest.java
@@ -32,9 +32,9 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class HistoryMessageClearTest {
 
@@ -42,7 +42,7 @@ public class HistoryMessageClearTest {
     private ConcurrentHashMap<TopicMetadata, MessageQueue> messageContainer;
     private HistoryMessageClear historyMessageClear;
 
-    @Before
+    @BeforeEach
     public void setUp() throws InterruptedException {
         messageEntity = createMessageEntity(new TopicMetadata(TEST_TOPIC), createDefaultCloudEvent(), OFF_SET, EXCEEDED_MESSAGE_STORE_WINDOW);
         messageContainer = createMessageContainer(new TopicMetadata(TEST_TOPIC), messageEntity);
@@ -53,6 +53,6 @@ public class HistoryMessageClearTest {
     public void testClearMessages() {
         historyMessageClear.clearMessages();
         MessageQueue updatedMessageQueue = messageContainer.get(new TopicMetadata(TEST_TOPIC));
-        Assert.assertTrue(Arrays.stream(updatedMessageQueue.getItems()).allMatch(Objects::isNull));
+        Assertions.assertTrue(Arrays.stream(updatedMessageQueue.getItems()).allMatch(Objects::isNull));
     }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/broker/task/SubscribeTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/broker/task/SubscribeTest.java
@@ -28,16 +28,16 @@ import org.apache.eventmesh.api.EventListener;
 import org.apache.eventmesh.api.EventMeshAsyncConsumeContext;
 import org.apache.eventmesh.storage.standalone.broker.StandaloneBroker;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.cloudevents.CloudEvent;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SubscribeTest {
 
     @Mock
@@ -59,6 +59,6 @@ public class SubscribeTest {
     @Test
     public void testShutdown() {
         subscribe = new Subscribe(TEST_TOPIC, standaloneBroker, eventListener);
-        Assert.assertTrue(subscribe.isRunning());
+        Assertions.assertTrue(subscribe.isRunning());
     }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/consumer/StandaloneConsumerTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/consumer/StandaloneConsumerTest.java
@@ -25,16 +25,16 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.cloudevents.CloudEvent;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class StandaloneConsumerTest {
 
     @Mock
@@ -42,7 +42,7 @@ public class StandaloneConsumerTest {
     private StandaloneConsumer standaloneConsumer;
     private List<CloudEvent> cloudEvents;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         standaloneConsumer = new StandaloneConsumer(new Properties());
         cloudEvents = createCloudEvents();
@@ -50,23 +50,23 @@ public class StandaloneConsumerTest {
 
     @Test
     public void testIsStarted() {
-        Assert.assertFalse(standaloneConsumer.isStarted());
+        Assertions.assertFalse(standaloneConsumer.isStarted());
     }
 
     @Test
     public void testIsClosed() {
-        Assert.assertTrue(standaloneConsumer.isClosed());
+        Assertions.assertTrue(standaloneConsumer.isClosed());
     }
 
     @Test
     public void testStart() {
         standaloneConsumer.start();
-        Assert.assertTrue(standaloneConsumer.isStarted());
+        Assertions.assertTrue(standaloneConsumer.isStarted());
     }
 
     @Test
     public void testShutdown() {
         standaloneConsumer.shutdown();
-        Assert.assertTrue(standaloneConsumer.isClosed());
+        Assertions.assertTrue(standaloneConsumer.isClosed());
     }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/producer/StandaloneProducerTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-standalone/src/test/java/org/apache/eventmesh/storage/standalone/producer/StandaloneProducerTest.java
@@ -22,9 +22,9 @@ import org.apache.eventmesh.storage.standalone.TestUtils;
 
 import java.util.Properties;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.cloudevents.CloudEvent;
 
@@ -32,37 +32,37 @@ public class StandaloneProducerTest {
 
     private StandaloneProducer standaloneProducer;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         standaloneProducer = new StandaloneProducer(new Properties());
     }
 
     @Test
     public void testIsStarted() {
-        Assert.assertFalse(standaloneProducer.isStarted());
+        Assertions.assertFalse(standaloneProducer.isStarted());
     }
 
     @Test
     public void testIsClosed() {
-        Assert.assertTrue(standaloneProducer.isClosed());
+        Assertions.assertTrue(standaloneProducer.isClosed());
     }
 
     @Test
     public void testStart() {
         standaloneProducer.start();
-        Assert.assertTrue(standaloneProducer.isStarted());
+        Assertions.assertTrue(standaloneProducer.isStarted());
     }
 
     @Test
     public void testShutdown() {
         standaloneProducer.shutdown();
-        Assert.assertTrue(standaloneProducer.isClosed());
+        Assertions.assertTrue(standaloneProducer.isClosed());
     }
 
     @Test
     public void testPublish() {
         CloudEvent cloudEvent = TestUtils.createDefaultCloudEvent();
         SendResult sendResult = standaloneProducer.publish(cloudEvent);
-        Assert.assertNotNull(sendResult);
+        Assertions.assertNotNull(sendResult);
     }
 }

--- a/eventmesh-trace-plugin/eventmesh-trace-api/src/test/java/org/apache/eventmesh/trace/api/config/ExporterConfigurationTest.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-api/src/test/java/org/apache/eventmesh/trace/api/config/ExporterConfigurationTest.java
@@ -19,8 +19,8 @@ package org.apache.eventmesh.trace.api.config;
 
 import org.apache.eventmesh.common.config.ConfigService;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ExporterConfigurationTest {
 
@@ -29,9 +29,9 @@ public class ExporterConfigurationTest {
         ConfigService configService = ConfigService.getInstance();
         ExporterConfiguration config = configService.buildConfigInstance(ExporterConfiguration.class);
 
-        Assert.assertEquals(816, config.getEventMeshTraceMaxExportSize());
-        Assert.assertEquals(1816, config.getEventMeshTraceMaxQueueSize());
-        Assert.assertEquals(2816, config.getEventMeshTraceExportTimeout());
-        Assert.assertEquals(3816, config.getEventMeshTraceExportInterval());
+        Assertions.assertEquals(816, config.getEventMeshTraceMaxExportSize());
+        Assertions.assertEquals(1816, config.getEventMeshTraceMaxQueueSize());
+        Assertions.assertEquals(2816, config.getEventMeshTraceExportTimeout());
+        Assertions.assertEquals(3816, config.getEventMeshTraceExportInterval());
     }
 }

--- a/eventmesh-trace-plugin/eventmesh-trace-jaeger/build.gradle
+++ b/eventmesh-trace-plugin/eventmesh-trace-jaeger/build.gradle
@@ -36,6 +36,5 @@ dependencies {
 
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
-    testImplementation "org.mockito:mockito-core"
     testImplementation "org.mockito:mockito-inline"
 }

--- a/eventmesh-trace-plugin/eventmesh-trace-jaeger/src/test/java/org/apache/eventmesh/trace/jaeger/JaegerTraceServiceTest.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-jaeger/src/test/java/org/apache/eventmesh/trace/jaeger/JaegerTraceServiceTest.java
@@ -17,16 +17,16 @@
 
 package org.apache.eventmesh.trace.jaeger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.eventmesh.common.utils.ReflectUtils;
 import org.apache.eventmesh.trace.api.TracePluginFactory;
 
 import java.lang.reflect.Field;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import io.opentelemetry.sdk.trace.SdkTracerProvider;

--- a/eventmesh-trace-plugin/eventmesh-trace-jaeger/src/test/java/org/apache/eventmesh/trace/jaeger/config/JaegerConfigurationTest.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-jaeger/src/test/java/org/apache/eventmesh/trace/jaeger/config/JaegerConfigurationTest.java
@@ -17,13 +17,13 @@
 
 package org.apache.eventmesh.trace.jaeger.config;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.eventmesh.trace.api.TracePluginFactory;
 import org.apache.eventmesh.trace.api.config.ExporterConfiguration;
 import org.apache.eventmesh.trace.jaeger.JaegerTraceService;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JaegerConfigurationTest {
 

--- a/eventmesh-trace-plugin/eventmesh-trace-pinpoint/build.gradle
+++ b/eventmesh-trace-plugin/eventmesh-trace-pinpoint/build.gradle
@@ -46,6 +46,5 @@ dependencies {
     implementation "io.grpc:grpc-netty"
     implementation "io.grpc:grpc-netty-shaded"
 
-    testImplementation "org.mockito:mockito-core"
     testImplementation "org.mockito:mockito-inline"
 }

--- a/eventmesh-trace-plugin/eventmesh-trace-pinpoint/src/test/java/org/apache/eventmesh/trace/pinpoint/PinpointTraceServiceTest.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-pinpoint/src/test/java/org/apache/eventmesh/trace/pinpoint/PinpointTraceServiceTest.java
@@ -17,15 +17,15 @@
 
 package org.apache.eventmesh.trace.pinpoint;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.eventmesh.common.utils.ReflectUtils;
 import org.apache.eventmesh.trace.api.TracePluginFactory;
 
 import java.lang.reflect.Field;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -40,7 +40,7 @@ public class PinpointTraceServiceTest {
 
         IllegalArgumentException illegalArgumentException =
             assertThrows(IllegalArgumentException.class, () -> Runtime.getRuntime().addShutdownHook(pinpointTraceService.getShutdownHook()));
-        Assert.assertEquals(illegalArgumentException.getMessage(), "Hook previously registered");
+        Assertions.assertEquals(illegalArgumentException.getMessage(), "Hook previously registered");
     }
 
     @Test

--- a/eventmesh-trace-plugin/eventmesh-trace-pinpoint/src/test/java/org/apache/eventmesh/trace/pinpoint/config/PinpointConfigurationTest.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-pinpoint/src/test/java/org/apache/eventmesh/trace/pinpoint/config/PinpointConfigurationTest.java
@@ -21,8 +21,8 @@ import org.apache.eventmesh.trace.api.TracePluginFactory;
 import org.apache.eventmesh.trace.api.config.ExporterConfiguration;
 import org.apache.eventmesh.trace.pinpoint.PinpointTraceService;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.navercorp.pinpoint.profiler.context.grpc.config.GrpcTransportConfig;
 
@@ -40,25 +40,25 @@ public class PinpointConfigurationTest {
     }
 
     private void assertClientConfig(PinpointConfiguration config) {
-        Assert.assertEquals("eventmesh", config.getApplicationName());
-        Assert.assertEquals("eventmesh", config.getAgentName());
-        Assert.assertEquals("eventmesh-01", config.getAgentId());
+        Assertions.assertEquals("eventmesh", config.getApplicationName());
+        Assertions.assertEquals("eventmesh", config.getAgentName());
+        Assertions.assertEquals("eventmesh-01", config.getAgentId());
 
         GrpcTransportConfig grpcTransportConfig = config.getGrpcTransportConfig();
-        Assert.assertNotNull(grpcTransportConfig);
-        Assert.assertEquals("127.0.0.1", grpcTransportConfig.getAgentCollectorIp());
-        Assert.assertEquals(9991, grpcTransportConfig.getAgentCollectorPort());
-        Assert.assertEquals("localhost", grpcTransportConfig.getSpanCollectorIp());
-        Assert.assertEquals(9993, grpcTransportConfig.getSpanCollectorPort());
+        Assertions.assertNotNull(grpcTransportConfig);
+        Assertions.assertEquals("127.0.0.1", grpcTransportConfig.getAgentCollectorIp());
+        Assertions.assertEquals(9991, grpcTransportConfig.getAgentCollectorPort());
+        Assertions.assertEquals("localhost", grpcTransportConfig.getSpanCollectorIp());
+        Assertions.assertEquals(9993, grpcTransportConfig.getSpanCollectorPort());
 
-        Assert.assertEquals(123, grpcTransportConfig.getSpanClientOption().getLimitCount());
-        Assert.assertEquals(6700, grpcTransportConfig.getSpanClientOption().getLimitTime());
+        Assertions.assertEquals(123, grpcTransportConfig.getSpanClientOption().getLimitCount());
+        Assertions.assertEquals(6700, grpcTransportConfig.getSpanClientOption().getLimitTime());
     }
 
     private void assertBaseConfig(ExporterConfiguration config) {
-        Assert.assertEquals(816, config.getEventMeshTraceMaxExportSize());
-        Assert.assertEquals(1816, config.getEventMeshTraceMaxQueueSize());
-        Assert.assertEquals(2816, config.getEventMeshTraceExportTimeout());
-        Assert.assertEquals(3816, config.getEventMeshTraceExportInterval());
+        Assertions.assertEquals(816, config.getEventMeshTraceMaxExportSize());
+        Assertions.assertEquals(1816, config.getEventMeshTraceMaxQueueSize());
+        Assertions.assertEquals(2816, config.getEventMeshTraceExportTimeout());
+        Assertions.assertEquals(3816, config.getEventMeshTraceExportInterval());
     }
 }

--- a/eventmesh-trace-plugin/eventmesh-trace-pinpoint/src/test/java/org/apache/eventmesh/trace/pinpoint/exporter/PinpointSpanExporterTest.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-pinpoint/src/test/java/org/apache/eventmesh/trace/pinpoint/exporter/PinpointSpanExporterTest.java
@@ -27,9 +27,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanContext;
@@ -48,7 +48,7 @@ public class PinpointSpanExporterTest {
 
     private PinpointSpanExporter exporter;
 
-    @Before
+    @BeforeEach
     public void setup() {
         PinpointTraceService pinpointTrace =
             (PinpointTraceService) TracePluginFactory.getEventMeshTraceService("pinpoint");
@@ -65,24 +65,24 @@ public class PinpointSpanExporterTest {
     @Test
     public void exportTest() {
         Collection<SpanData> spans = new ArrayList<>();
-        Assert.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
+        Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
 
         spans.add(null);
-        Assert.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
+        Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
 
         spans.clear();
         spans.add(new SpanDateTest());
-        Assert.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
+        Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
     }
 
     @Test
     public void flushTest() {
-        Assert.assertEquals(CompletableResultCode.ofSuccess(), exporter.flush());
+        Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.flush());
     }
 
     @Test
     public void shutdownTest() {
-        Assert.assertEquals(CompletableResultCode.ofSuccess(), exporter.shutdown());
+        Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.shutdown());
     }
 
     /**

--- a/eventmesh-trace-plugin/eventmesh-trace-zipkin/build.gradle
+++ b/eventmesh-trace-plugin/eventmesh-trace-zipkin/build.gradle
@@ -30,6 +30,5 @@ dependencies {
 
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
-    testImplementation "org.mockito:mockito-core"
     testImplementation "org.mockito:mockito-inline"
 }

--- a/eventmesh-trace-plugin/eventmesh-trace-zipkin/src/test/java/org/apache/eventmesh/trace/zipkin/TracePluginFactoryTest.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-zipkin/src/test/java/org/apache/eventmesh/trace/zipkin/TracePluginFactoryTest.java
@@ -17,33 +17,30 @@
 
 package org.apache.eventmesh.trace.zipkin;
 
-import static org.hamcrest.CoreMatchers.is;
-
 import org.apache.eventmesh.trace.api.EventMeshTraceService;
 import org.apache.eventmesh.trace.api.TracePluginFactory;
 
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TracePluginFactoryTest {
 
     @Test
     public void testFailedGetTraceService() {
-        NullPointerException nullPointerException1 = Assert.assertThrows(NullPointerException.class,
+        NullPointerException nullPointerException1 = Assertions.assertThrows(NullPointerException.class,
             () -> TracePluginFactory.getEventMeshTraceService(null));
-        MatcherAssert.assertThat(nullPointerException1.getMessage(), is("traceServiceType cannot be null"));
+        Assertions.assertEquals("traceServiceType cannot be null", nullPointerException1.getMessage());
 
         String traceServiceType = "non-Existing";
         NullPointerException nullPointerException2 =
-            Assert.assertThrows(NullPointerException.class, () -> TracePluginFactory.getEventMeshTraceService(traceServiceType));
-        MatcherAssert.assertThat(nullPointerException2.getMessage(), is("traceServiceType: " + traceServiceType + " is not supported"));
+            Assertions.assertThrows(NullPointerException.class, () -> TracePluginFactory.getEventMeshTraceService(traceServiceType));
+        Assertions.assertEquals("traceServiceType: " + traceServiceType + " is not supported", nullPointerException2.getMessage());
     }
 
     @Test
     public void testSuccessfulGetTraceService() {
         EventMeshTraceService zipkinTraceService = TracePluginFactory.getEventMeshTraceService("zipkin");
-        Assert.assertNotNull(zipkinTraceService);
-        Assert.assertTrue(zipkinTraceService instanceof ZipkinTraceService);
+        Assertions.assertNotNull(zipkinTraceService);
+        Assertions.assertTrue(zipkinTraceService instanceof ZipkinTraceService);
     }
 }

--- a/eventmesh-trace-plugin/eventmesh-trace-zipkin/src/test/java/org/apache/eventmesh/trace/zipkin/ZipkinTraceServiceTest.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-zipkin/src/test/java/org/apache/eventmesh/trace/zipkin/ZipkinTraceServiceTest.java
@@ -17,15 +17,15 @@
 
 package org.apache.eventmesh.trace.zipkin;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.eventmesh.common.utils.ReflectUtils;
 import org.apache.eventmesh.trace.api.TracePluginFactory;
 
 import java.lang.reflect.Field;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -38,13 +38,13 @@ public class ZipkinTraceServiceTest {
             (ZipkinTraceService) TracePluginFactory.getEventMeshTraceService("zipkin");
         zipkinTraceService.init();
 
-        Assert.assertNotNull(zipkinTraceService.getSdkTracerProvider());
-        Assert.assertNotNull(zipkinTraceService.getShutdownHook());
+        Assertions.assertNotNull(zipkinTraceService.getSdkTracerProvider());
+        Assertions.assertNotNull(zipkinTraceService.getShutdownHook());
 
         IllegalArgumentException illegalArgumentException =
             assertThrows(IllegalArgumentException.class,
                 () -> Runtime.getRuntime().addShutdownHook(zipkinTraceService.getShutdownHook()));
-        Assert.assertEquals(illegalArgumentException.getMessage(), "Hook previously registered");
+        Assertions.assertEquals(illegalArgumentException.getMessage(), "Hook previously registered");
     }
 
     @Test

--- a/eventmesh-trace-plugin/eventmesh-trace-zipkin/src/test/java/org/apache/eventmesh/trace/zipkin/config/ZipkinConfigurationTest.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-zipkin/src/test/java/org/apache/eventmesh/trace/zipkin/config/ZipkinConfigurationTest.java
@@ -21,8 +21,8 @@ import org.apache.eventmesh.trace.api.TracePluginFactory;
 import org.apache.eventmesh.trace.api.config.ExporterConfiguration;
 import org.apache.eventmesh.trace.zipkin.ZipkinTraceService;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ZipkinConfigurationTest {
 
@@ -38,14 +38,14 @@ public class ZipkinConfigurationTest {
     }
 
     private void assertConfig(ZipkinConfiguration config) {
-        Assert.assertEquals("127.0.0.1", config.getEventMeshZipkinIP());
-        Assert.assertEquals(816, config.getEventMeshZipkinPort());
+        Assertions.assertEquals("127.0.0.1", config.getEventMeshZipkinIP());
+        Assertions.assertEquals(816, config.getEventMeshZipkinPort());
     }
 
     private void assertBaseConfig(ExporterConfiguration config) {
-        Assert.assertEquals(816, config.getEventMeshTraceMaxExportSize());
-        Assert.assertEquals(1816, config.getEventMeshTraceMaxQueueSize());
-        Assert.assertEquals(2816, config.getEventMeshTraceExportTimeout());
-        Assert.assertEquals(3816, config.getEventMeshTraceExportInterval());
+        Assertions.assertEquals(816, config.getEventMeshTraceMaxExportSize());
+        Assertions.assertEquals(1816, config.getEventMeshTraceMaxQueueSize());
+        Assertions.assertEquals(2816, config.getEventMeshTraceExportTimeout());
+        Assertions.assertEquals(3816, config.getEventMeshTraceExportInterval());
     }
 }

--- a/eventmesh-webhook/eventmesh-webhook-admin/src/test/java/org/apache/eventmesh/webhook/admin/AdminWebHookConfigOperationManagerTest.java
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/test/java/org/apache/eventmesh/webhook/admin/AdminWebHookConfigOperationManagerTest.java
@@ -19,8 +19,8 @@ package org.apache.eventmesh.webhook.admin;
 
 import org.apache.eventmesh.common.config.ConfigService;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class AdminWebHookConfigOperationManagerTest {
 
@@ -32,7 +32,7 @@ public class AdminWebHookConfigOperationManagerTest {
         AdminWebHookConfigOperationManager adminWebHookConfigOperationManage = new AdminWebHookConfigOperationManager();
         adminWebHookConfigOperationManage.init();
 
-        Assert.assertTrue(
+        Assertions.assertTrue(
             adminWebHookConfigOperationManage.getWebHookConfigOperation() instanceof FileWebHookConfigOperation);
     }
 }

--- a/eventmesh-webhook/eventmesh-webhook-admin/src/test/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperationTest.java
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/test/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperationTest.java
@@ -28,8 +28,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class FileWebHookConfigOperationTest {
 
@@ -49,15 +49,15 @@ public class FileWebHookConfigOperationTest {
         try {
             FileWebHookConfigOperation fileWebHookConfigOperation = new FileWebHookConfigOperation(properties);
             Integer result = fileWebHookConfigOperation.insertWebHookConfig(config);
-            Assert.assertTrue(Objects.nonNull(result) && result == 1);
+            Assertions.assertTrue(Objects.nonNull(result) && result == 1);
 
             WebHookConfig queryConfig = new WebHookConfig();
             queryConfig.setManufacturerName("github");
             List<WebHookConfig> queryResult = fileWebHookConfigOperation.queryWebHookConfigByManufacturer(queryConfig, 1, 1);
-            Assert.assertTrue(Objects.nonNull(queryResult) && queryResult.size() == 1);
-            Assert.assertEquals(queryResult.get(0).getCallbackPath(), config.getCallbackPath());
+            Assertions.assertTrue(Objects.nonNull(queryResult) && queryResult.size() == 1);
+            Assertions.assertEquals(queryResult.get(0).getCallbackPath(), config.getCallbackPath());
         } catch (Exception e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         } finally {
             deleteDir("test_dir");
         }

--- a/eventmesh-webhook/eventmesh-webhook-admin/src/test/java/org/apache/eventmesh/webhook/config/AdminConfigurationTest.java
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/test/java/org/apache/eventmesh/webhook/config/AdminConfigurationTest.java
@@ -21,8 +21,8 @@ import org.apache.eventmesh.common.config.ConfigService;
 
 import java.util.Properties;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class AdminConfigurationTest {
 
@@ -38,11 +38,11 @@ public class AdminConfigurationTest {
     }
 
     private void assertAdminConfiguration(AdminConfiguration config) {
-        Assert.assertTrue(config.isAdminStart());
-        Assert.assertEquals("file", config.getOperationMode());
+        Assertions.assertTrue(config.isAdminStart());
+        Assertions.assertEquals("file", config.getOperationMode());
 
         Properties properties = new Properties();
         properties.put("filePath", ".");
-        Assert.assertEquals(properties, config.getOperationProperties());
+        Assertions.assertEquals(properties, config.getOperationProperties());
     }
 }

--- a/eventmesh-webhook/eventmesh-webhook-receive/src/test/java/org/apache/eventmesh/webhook/receive/config/ReceiveConfigurationTest.java
+++ b/eventmesh-webhook/eventmesh-webhook-receive/src/test/java/org/apache/eventmesh/webhook/receive/config/ReceiveConfigurationTest.java
@@ -21,8 +21,8 @@ import org.apache.eventmesh.common.config.ConfigService;
 
 import java.util.Properties;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ReceiveConfigurationTest {
 
@@ -33,19 +33,19 @@ public class ReceiveConfigurationTest {
         configService.setRootConfig("classPath://eventmesh.properties");
 
         Properties rootConfig = ConfigService.getInstance().getRootConfig();
-        Assert.assertEquals("DEFAULT", rootConfig.get("eventMesh.server.idc"));
+        Assertions.assertEquals("DEFAULT", rootConfig.get("eventMesh.server.idc"));
 
         ReceiveConfiguration config = configService.buildConfigInstance(ReceiveConfiguration.class);
         assertReceiveConfiguration(config);
     }
 
     private void assertReceiveConfiguration(ReceiveConfiguration config) {
-        Assert.assertEquals("nacos", config.getOperationMode());
+        Assertions.assertEquals("nacos", config.getOperationMode());
 
         Properties properties = new Properties();
         properties.put("serverAddr", "127.0.0.1:8848");
-        Assert.assertEquals(properties, config.getOperationProperties());
-        Assert.assertEquals("standalone", config.getStoragePluginType());
-        Assert.assertEquals(".", config.getFilePath());
+        Assertions.assertEquals(properties, config.getOperationProperties());
+        Assertions.assertEquals("standalone", config.getStoragePluginType());
+        Assertions.assertEquals(".", config.getFilePath());
     }
 }

--- a/tools/dependency-check/known-dependencies.txt
+++ b/tools/dependency-check/known-dependencies.txt
@@ -1,7 +1,6 @@
 amqp-client-5.16.0.jar
 animal-sniffer-annotations-1.19.jar
 annotations-4.1.1.4.jar
-annotations-api-6.0.53.jar
 aopalliance-1.0.jar
 asm-9.2.jar
 asm-analysis-9.2.jar
@@ -64,7 +63,6 @@ grpc-stub-1.43.2.jar
 gson-2.8.2.jar
 guava-31.0.1-jre.jar
 guice-4.2.2.jar
-hamcrest-core-1.3.jar
 httpasyncclient-4.1.3.jar
 httpclient-4.5.13.jar
 httpcore-4.4.13.jar
@@ -95,10 +93,8 @@ jna-4.2.2.jar
 jodd-bean-5.1.6.jar
 jodd-core-5.1.6.jar
 jsr305-3.0.2.jar
-junit-4.13.2.jar
 kafka-clients-3.0.0.jar
 listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
-log4j-1.2.17.jar
 log4j-api-2.17.1.jar
 log4j-core-2.17.1.jar
 log4j-slf4j-impl-2.17.1.jar
@@ -208,7 +204,6 @@ rocketmq-namesrv-4.9.5.jar
 rocketmq-remoting-4.9.5.jar
 rocketmq-srvutil-4.9.5.jar
 rocketmq-store-4.9.5.jar
-rocketmq-test-4.9.5.jar
 rocketmq-tools-4.9.5.jar
 rxjava-3.0.12.jar
 simpleclient-0.8.1.jar
@@ -217,8 +212,6 @@ simpleclient_httpserver-0.8.1.jar
 slf4j-api-1.7.30.jar
 snakeyaml-1.30.jar
 snappy-java-1.1.8.1.jar
-system-rules-1.16.1.jar
-truth-0.30.jar
 validation-api-1.1.0.Final.jar
 zipkin-2.23.2.jar
 zipkin-reporter-2.16.3.jar


### PR DESCRIPTION
Fixes  #4478

### Motivation

In its current form, the project has some JUnit 4 and some JUnit 5 (Jupiter) tests. This PR aims to align all the tests to a single modern framework, JUnit Jupiter, in order to make future development easier.

### Modifications

As this PR is already pretty large as-is, it attempts to be non-opinionated and simply replace JUnit 4 calls with the closed JUnit Jupiter equivalents. Subsequent work may want to change some tests to take further advantage of JUnit Jupiter's features.

This PR includes the following changes:

1. Gradle dependencies:
   1. All the dependencies under `org.junit.jupiter` were consolidated to use the single artifact `org.junit.jupiter:junit-jupiter`.
   1. The `junit:junit` dependency was removed in favor of `org.junit.jupiter:junit-jupiter` mentioned in 1.i.
   1. The Mockito dependencies `org.mockito:mockito-core` and `org.mockito:mockito-inline` duplications were cleaned up, and each module was left only with the relevant dependency.
   1. The `org.mockito:mockito-junit-jupiter` dependency was added to provide the integration with Mockito.
   2. The `org.powermock:powermock-module-junit4` dependency was removed.
   3. The `org.powermock:powermock-api-mockito2` dependency was removed.
   4. The `com.github.stefanbirkner:system-rules` dependency was removed in favor of `org.junit-pioneer:junit-pioneer` that was used to provide the same functionality as mentioned in 2.ix.
   5. The `"org.apache.rocketmq:rocketmq-test` dependency was never really used, and was removed

1. Annotations
   1. `org.junit.jupiter.api.BeforeEach` was used as a drop-in replacement for `org.junit.Before`.
   1. `org.junit.jupiter.api.BeforeAll` was used as a drop-in replacement for `org.junit.BeforeClass`.
   1.  `org.junit.jupiter.api.AfterEach` was used as a drop-in replacement for `org.junit.After`.
   1. `org.junit.jupiter.api.AfterAll` was used as a drop-in replacement for `org.junit.AfterClass`.
   1.  `org.junit.jupiter.api.AfterEach` was used as a drop-in replacement for `org.junit.After`.
   1.  `org.junit.jupiter.api.Disabled` was used as a drop-in replacement for `org.junit.Ignore`.
   1.  `org.junit.jupiter.api.Test` was used as a replacement for `org.junit.Test`, although with some caveats:
       1. For the simple case with no arguments, `org.junit.jupiter.api.Test` was used as a drop-in replacement for `org.junit.Test`.
       1. For the case where `org.junit.Test` was used with a `timeout` argument, a combination of `org.junit.jupiter.api.Test` and `org.junit.jupiter.api.Timeout` was used.
       1. For the case where `org.junit.Test` was used with an `expected` argument, `org.junit.jupiter.api.Test` was used, but the assertion on the exception begin thrown is done explicitly in the test's code, see 3.i. below.
   1.  `org.junit.jupiter.api.extension.ExtendWith` was used as a replacement for `org.junit.runner.RunWith` with an extension corresponding to the runner being replaced.
       1. `org.mockito.junit.jupiter.MockitoExtension` was used to provide the same functionality as `org.mockito.junit.MockitoJUnitRunner`. Since the extension is stricter than the runner, in some cases `org.mockito.junit.jupiter.MockitoSettings` was used to explicitly make the mocking more lenient.
       6.  `org.mockito.junit.jupiter.MockitoExtension` was used to replace usages of `org.powermock.modules.junit4.PowerMockRunner` and its associated annotations.
    1.  `org.junitpioneer.jupiter.SetEnvironmentVariable` was used in order to set environment variables in the tests instead of
          explicitly calling `org.junit.contrib.java.lang.system.EnvironmentVariables` in the test's body. As an added bonus, using this annotation also cleans up the changes to the environment variables when the test is over and prevents it from inadvertently effecting other tests.


1. Assertions
   1. `org.junit.jupiter.api.Assertions` was used as a drop-in replacement for `org.junit.Assert` for the case where the assertion was performed without a message.
   1. `org.junit.jupiter.api.Assertions` was used instead of `org.junit.Assert` in the cases where an assertion method was used with a message, but the argument were permuted to fit the new method's signature.
   1. `org.junit.jupiter.api.Assertions` does not have an equivalent of `org.junit.Asser`t's `assertThat` method, but luckily it was only used in a few places, and always used the `org.hamcrest.CoreMatchers.is` matcher. These assertions were rewritten as straight-forward `assertEquals` assertions.
   1. `org.junit.jupiter.api.Assertions` does not have an equivalent of `org.hamcrest.MatcherAssert`'s `assertThat` method, but luckily it was only used in a few places, and always used the `org.hamcrest.CoreMatchers.is` matcher. These assertions were rewritten as straight-forward `assertEquals` assertions.
   1. `org.junit.jupiter.api.Assertions`' `assertThrows` was used to assert an expected exception is thrown instead of using `org.junit.Test` with the `expected` annotation.

1. Mocking
    1. Usages of `org.powermock.api.mockito.PowerMockito` were deemed to be unnescary, and replaced with straight-forward usages of `org.mockito.Mockito`.
    7. Usages of `org.powermock.reflect.Whitebox` were cleaned, and the `org.mockito.InjectMocks` was used instead in order to inject mocks to the object under test.
    8. 




### Documentation

- Does this pull request introduce a new feature? no