### PR TITLE
[ISSUE #4483] Standardize exception handling in tests

### DIFF
--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/ResetCountDownLatchTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/ResetCountDownLatchTest.java
@@ -27,11 +27,8 @@ public class ResetCountDownLatchTest {
 
     @Test
     public void testConstructorParameterError() {
-        try {
-            new ResetCountDownLatch(-1);
-        } catch (IllegalArgumentException e) {
-            Assertions.assertEquals(e.getMessage(), "count must be greater than or equal to 0");
-        }
+        IllegalArgumentException e = Assertions.assertThrows(IllegalArgumentException.class, () -> new ResetCountDownLatch(-1));
+        Assertions.assertEquals(e.getMessage(), "count must be greater than or equal to 0");
         ResetCountDownLatch resetCountDownLatch = new ResetCountDownLatch(1);
         Assertions.assertEquals(1, resetCountDownLatch.getCount());
     }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/PropertiesUtilsTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/PropertiesUtilsTest.java
@@ -49,12 +49,8 @@ public class PropertiesUtilsTest {
         configService.setRootConfig("classPath://configuration.properties");
         properties = configService.getRootConfig();
         String path = configService.getRootPath();
-        try {
-            PropertiesUtils.loadPropertiesWhenFileExist(properties, path);
-            Assertions.assertEquals("env-succeed!!!", properties.get("eventMesh.server.env").toString());
-            Assertions.assertEquals("idc-succeed!!!", properties.get("eventMesh.server.idc").toString());
-        } catch (Exception e) {
-            Assertions.fail();
-        }
+        PropertiesUtils.loadPropertiesWhenFileExist(properties, path);
+        Assertions.assertEquals("env-succeed!!!", properties.get("eventMesh.server.env").toString());
+        Assertions.assertEquals("idc-succeed!!!", properties.get("eventMesh.server.idc").toString());
     }
 }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/admin/controller/ClientManageControllerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/admin/controller/ClientManageControllerTest.java
@@ -36,8 +36,6 @@ import org.apache.eventmesh.runtime.metrics.tcp.EventMeshTcpMonitor;
 import org.apache.eventmesh.webhook.admin.AdminWebHookConfigOperationManager;
 import org.apache.eventmesh.webhook.api.WebHookConfigOperation;
 
-import java.io.IOException;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -85,13 +83,8 @@ public class ClientManageControllerTest {
         try (MockedStatic<HttpServer> dummyStatic = Mockito.mockStatic(HttpServer.class)) {
             HttpServer server = mock(HttpServer.class);
             dummyStatic.when(() -> HttpServer.create(any(), anyInt())).thenReturn(server);
-            try {
-                Mockito.doNothing().when(adminController).run(server);
-                controller.start();
-            } catch (IOException e) {
-                Assertions.fail(e.getMessage());
-            }
-
+            Mockito.doNothing().when(adminController).run(server);
+            Assertions.assertDoesNotThrow(controller::start);
         }
     }
 }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/protocol/processor/WebHookProcessorTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/protocol/processor/WebHookProcessorTest.java
@@ -76,20 +76,16 @@ public class WebHookProcessorTest {
 
     @Test
     public void testHandler() {
-        try {
-            WebHookProcessor processor = new WebHookProcessor();
-            processor.setWebHookController(controller);
-            processor.handler(buildMockWebhookRequest());
+        WebHookProcessor processor = new WebHookProcessor();
+        processor.setWebHookController(controller);
+        processor.handler(buildMockWebhookRequest());
 
-            CloudEvent msgSendToMq = captor.getValue();
-            Assertions.assertNotNull(msgSendToMq);
-            Assertions.assertTrue(StringUtils.isNoneBlank(msgSendToMq.getId()));
-            Assertions.assertEquals("www.github.com", msgSendToMq.getSource().getPath());
-            Assertions.assertEquals("github.ForkEvent", msgSendToMq.getType());
-            Assertions.assertEquals(BytesCloudEventData.wrap("\"mock_data\":0".getBytes(StandardCharsets.UTF_8)), msgSendToMq.getData());
-        } catch (Exception e) {
-            Assertions.fail(e.getMessage());
-        }
+        CloudEvent msgSendToMq = captor.getValue();
+        Assertions.assertNotNull(msgSendToMq);
+        Assertions.assertTrue(StringUtils.isNoneBlank(msgSendToMq.getId()));
+        Assertions.assertEquals("www.github.com", msgSendToMq.getSource().getPath());
+        Assertions.assertEquals("github.ForkEvent", msgSendToMq.getType());
+        Assertions.assertEquals(BytesCloudEventData.wrap("\"mock_data\":0".getBytes(StandardCharsets.UTF_8)), msgSendToMq.getData());
     }
 
     private HttpRequest buildMockWebhookRequest() {

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/BannerUtilTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/BannerUtilTest.java
@@ -24,10 +24,6 @@ public class BannerUtilTest {
 
     @Test
     public void testGenerateBanner() {
-        try {
-            BannerUtil.generateBanner();
-        } catch (Exception e) {
-            Assertions.fail("BannerUtil.generateBanner() test failed");
-        }
+        Assertions.assertDoesNotThrow(BannerUtil::generateBanner);
     }
 }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/EventMeshUtilTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/EventMeshUtilTest.java
@@ -167,13 +167,9 @@ public class EventMeshUtilTest {
 
     @Test
     public void testPrintState() {
-        try {
-            ScheduledExecutorService serviceRebalanceScheduler = ThreadPoolFactory
-                .createScheduledExecutor(5, new EventMeshThreadFactory("proxy-rebalance-sch", true));
-            EventMeshUtil.printState((ThreadPoolExecutor) serviceRebalanceScheduler);
-        } catch (Exception e) {
-            Assertions.fail(e.getMessage());
-        }
+        ScheduledExecutorService serviceRebalanceScheduler = ThreadPoolFactory
+            .createScheduledExecutor(5, new EventMeshThreadFactory("proxy-rebalance-sch", true));
+        Assertions.assertDoesNotThrow(() -> EventMeshUtil.printState((ThreadPoolExecutor) serviceRebalanceScheduler));
     }
 
     @Test

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/ValueComparatorTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/ValueComparatorTest.java
@@ -30,13 +30,11 @@ import org.junit.jupiter.api.Test;
 public class ValueComparatorTest {
 
     @Test
-    public void testSerializeOrderedCollection() {
+    public void testSerializeOrderedCollection() throws IOException {
         Map<Map.Entry<String, Integer>, Integer> map = new TreeMap<>(new ValueComparator());
         try (OutputStream bos = new ByteArrayOutputStream();
             ObjectOutputStream oos = new ObjectOutputStream(bos)) {
-            oos.writeObject(map);
-        } catch (IOException e) {
-            Assertions.fail();
+            Assertions.assertDoesNotThrow(() -> oos.writeObject(map));
         }
     }
 

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/WebhookUtilTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/util/WebhookUtilTest.java
@@ -40,7 +40,7 @@ import org.mockito.Mockito;
 public class WebhookUtilTest {
 
     @Test
-    public void testObtainDeliveryAgreement() {
+    public void testObtainDeliveryAgreement() throws Exception {
         // normal case
         try (CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
             CloseableHttpResponse response = mock(CloseableHttpResponse.class);
@@ -54,15 +54,8 @@ public class WebhookUtilTest {
 
             // abnormal case
             Mockito.when(httpClient2.execute(any())).thenThrow(new RuntimeException());
-            try {
-                Assertions.assertTrue(WebhookUtil.obtainDeliveryAgreement(httpClient2, "xxx", "*"),
-                    "when throw exception ,default return true");
-            } catch (RuntimeException e) {
-                Assertions.fail(e.getMessage());
-            }
-
-        } catch (Exception e) {
-            Assertions.fail(e.getMessage());
+            Assertions.assertTrue(WebhookUtil.obtainDeliveryAgreement(httpClient2, "xxx", "*"),
+                "when throw exception ,default return true");
         }
     }
 

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/producer/EventMeshGrpcProducerTest.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/producer/EventMeshGrpcProducerTest.java
@@ -18,6 +18,7 @@
 package org.apache.eventmesh.client.grpc.producer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -94,7 +95,8 @@ public class EventMeshGrpcProducerTest {
     @Test
     public void testPublishWithException() {
         try {
-            producer.publish(defaultEventMeshMessageBuilder().content("mockExceptionContent").build());
+            producer.publish("Not a supported message");
+            failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
         } catch (Exception e) {
             assertThat(e).isNotNull();
         }

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/producer/EventMeshGrpcProducerTest.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/producer/EventMeshGrpcProducerTest.java
@@ -18,7 +18,7 @@
 package org.apache.eventmesh.client.grpc.producer;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -94,12 +94,7 @@ public class EventMeshGrpcProducerTest {
 
     @Test
     public void testPublishWithException() {
-        try {
-            producer.publish("Not a supported message");
-            failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
-        } catch (Exception e) {
-            assertThat(e).isNotNull();
-        }
+        assertThrows(IllegalArgumentException.class, () -> producer.publish("Not a supported message"));
     }
 
     @Test

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/util/EventMeshCloudEventBuilderTest.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/grpc/util/EventMeshCloudEventBuilderTest.java
@@ -95,24 +95,14 @@ public class EventMeshCloudEventBuilderTest {
         io.cloudevents.CloudEvent event =
             CloudEventBuilder.v1().withType("eventmesh").withSource(URI.create("/")).withId(id).build();
         EventMeshMessage meshMessage = EventMeshMessage.builder().build();
-        Exception exception = null;
-        try {
-            EventMeshCloudEventBuilder.buildEventMeshCloudEvent(event, clientConfig, EventMeshProtocolType.EVENT_MESH_MESSAGE);
-        } catch (ClassCastException e) {
-            exception = e;
-        }
-        Assertions.assertNotNull(exception);
+        Assertions.assertThrows(Exception.class,
+            () -> EventMeshCloudEventBuilder.buildEventMeshCloudEvent(event, clientConfig, EventMeshProtocolType.EVENT_MESH_MESSAGE));
         CloudEvent cloudEvent = EventMeshCloudEventBuilder.buildEventMeshCloudEvent(event, clientConfig, EventMeshProtocolType.CLOUD_EVENTS);
         Assertions.assertNotNull(cloudEvent);
         Assertions.assertEquals("eventmesh", cloudEvent.getType());
         Assertions.assertEquals(id, cloudEvent.getId());
-        Exception exception1 = null;
-        try {
-            EventMeshCloudEventBuilder.buildEventMeshCloudEvent(meshMessage, clientConfig, EventMeshProtocolType.CLOUD_EVENTS);
-        } catch (ClassCastException e) {
-            exception1 = e;
-        }
-        Assertions.assertNotNull(exception1);
+        Assertions.assertThrows(Exception.class,
+            () -> EventMeshCloudEventBuilder.buildEventMeshCloudEvent(meshMessage, clientConfig, EventMeshProtocolType.CLOUD_EVENTS));
         EventMeshMessage meshMessage1 = EventMeshMessage.builder().uniqueId(id).build();
         CloudEvent cloudEvent1 = EventMeshCloudEventBuilder.buildEventMeshCloudEvent(meshMessage1, clientConfig,
             EventMeshProtocolType.EVENT_MESH_MESSAGE);

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/http/util/HttpUtilsTest.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/http/util/HttpUtilsTest.java
@@ -38,66 +38,44 @@ import io.netty.handler.codec.http.HttpMethod;
 public class HttpUtilsTest {
 
     @Test
-    public void testPostPositive() {
+    public void testPostPositive() throws IOException {
         CloseableHttpClient client = mock(CloseableHttpClient.class);
         String uri = "http://example.com";
         RequestParam requestParam = new RequestParam(HttpMethod.POST);
-        IOException exception = null;
-        try {
-            String expectedResult = "Success";
-            when(client.execute(any(HttpPost.class), any(ResponseHandler.class))).thenReturn(expectedResult);
-            String result = HttpUtils.post(client, uri, requestParam);
-            Assertions.assertEquals(expectedResult, result);
-        } catch (IOException e) {
-            exception = e;
-        }
-        Assertions.assertNull(exception);
+        String expectedResult = "Success";
+        when(client.execute(any(HttpPost.class), any(ResponseHandler.class))).thenReturn(expectedResult);
+        String result = HttpUtils.post(client, uri, requestParam);
+        Assertions.assertEquals(expectedResult, result);
     }
 
     @Test
-    public void testPostNegative() {
+    public void testPostNegative() throws IOException {
         CloseableHttpClient client = mock(CloseableHttpClient.class);
         String uri = "http://example.com";
         RequestParam requestParam = new RequestParam(HttpMethod.GET);
         String expectedResult = "Failure";
-        try {
-            when(client.execute(any(HttpPost.class), any(ResponseHandler.class))).thenReturn(expectedResult);
-            String result = HttpUtils.post(client, uri, requestParam);
-            Assertions.assertNotEquals(expectedResult, result);
-        } catch (Exception e) {
-            Assertions.assertNotNull(e);
-        }
+        when(client.execute(any(HttpPost.class), any(ResponseHandler.class))).thenReturn(expectedResult);
+        Assertions.assertThrows(Exception.class, () -> HttpUtils.post(client, uri, requestParam));
     }
 
     @Test
-    public void testGetPositive() {
+    public void testGetPositive() throws IOException {
         CloseableHttpClient client = mock(CloseableHttpClient.class);
         String uri = "http://example.com";
         RequestParam requestParam = new RequestParam(HttpMethod.GET);
         String expectedResult = "Success";
-        IOException exception = null;
-        try {
-            when(client.execute(any(HttpGet.class), any(ResponseHandler.class))).thenReturn(expectedResult);
-            String result = HttpUtils.get(client, uri, requestParam);
-            Assertions.assertEquals(expectedResult, result);
-        } catch (IOException e) {
-            exception = e;
-        }
-        Assertions.assertNull(exception);
+        when(client.execute(any(HttpGet.class), any(ResponseHandler.class))).thenReturn(expectedResult);
+        String result = HttpUtils.get(client, uri, requestParam);
+        Assertions.assertEquals(expectedResult, result);
     }
 
     @Test
-    public void testGetNegative() {
+    public void testGetNegative() throws IOException {
         CloseableHttpClient client = mock(CloseableHttpClient.class);
         String uri = "http://example.com";
         RequestParam requestParam = new RequestParam(HttpMethod.POST);
         String expectedResult = "Failure";
-        try {
-            when(client.execute(any(HttpGet.class), any(ResponseHandler.class))).thenReturn(expectedResult);
-            String result = HttpUtils.get(client, uri, requestParam);
-            Assertions.assertNotEquals(expectedResult, result);
-        } catch (Exception e) {
-            Assertions.assertNotNull(e);
-        }
+        when(client.execute(any(HttpGet.class), any(ResponseHandler.class))).thenReturn(expectedResult);
+        Assertions.assertThrows(Exception.class, () -> HttpUtils.get(client, uri, requestParam));
     }
 }

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/tcp/common/MessageUtilsTest.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/tcp/common/MessageUtilsTest.java
@@ -44,14 +44,7 @@ public class MessageUtilsTest {
         Assertions.assertNotNull(msg.getBody());
         Assertions.assertTrue(msg.getBody() instanceof UserAgent);
         // Negative Test Case
-        user = null;
-        try {
-            msg = null;
-            msg = MessageUtils.hello(user);
-
-        } catch (Exception e) {
-            Assertions.assertNull(msg);
-        }
+        Assertions.assertDoesNotThrow(() -> MessageUtils.hello(null));
     }
 
     @Test
@@ -102,16 +95,7 @@ public class MessageUtilsTest {
         Assertions.assertNotNull(msg.getBody());
         Assertions.assertTrue(msg.getBody() instanceof Subscription);
         // Negative Test Case
-        topic = null;
-        subscriptionMode = null;
-        subscriptionType = null;
-        try {
-            msg = null;
-            msg = MessageUtils.subscribe(topic, subscriptionMode, subscriptionType);
-
-        } catch (Exception e) {
-            Assertions.assertNull(msg);
-        }
+        Assertions.assertDoesNotThrow(() -> MessageUtils.subscribe(null, null, null));
     }
 
     @Test
@@ -140,13 +124,7 @@ public class MessageUtilsTest {
         Assertions.assertNotNull(msg.getBody());
         Assertions.assertEquals(msg.getBody(), in.getBody());
         // Negative Test Case
-        in = null;
-        msg = null;
-        try {
-            msg = MessageUtils.asyncMessageAck(in);
-        } catch (Exception e) {
-            Assertions.assertNull(msg);
-        }
+        Assertions.assertThrows(Exception.class, () -> MessageUtils.asyncMessageAck(null));
     }
 
     @Test

--- a/eventmesh-security-plugin/eventmesh-security-acl/src/test/java/org/apache/eventmesh/acl/impl/AclServiceImplTest.java
+++ b/eventmesh-security-plugin/eventmesh-security-acl/src/test/java/org/apache/eventmesh/acl/impl/AclServiceImplTest.java
@@ -19,7 +19,6 @@ package org.apache.eventmesh.acl.impl;
 
 import org.apache.eventmesh.api.acl.AclProperties;
 import org.apache.eventmesh.api.acl.AclService;
-import org.apache.eventmesh.api.exception.AclException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -36,64 +35,36 @@ public class AclServiceImplTest {
 
     @Test
     public void testInit() {
-        try {
-            service.init();
-        } catch (AclException e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(service::init);
     }
 
     @Test
     public void testStart() {
-        try {
-            service.start();
-        } catch (AclException e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(service::start);
     }
 
     @Test
     public void testShutdown() {
-        try {
-            service.shutdown();
-        } catch (AclException e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(service::shutdown);
     }
 
     @Test
     public void testDoAclCheckInConnect() {
-        try {
-            service.doAclCheckInConnect(new AclProperties());
-        } catch (AclException e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(() -> service.doAclCheckInConnect(new AclProperties()));
     }
 
     @Test
     public void testDoAclCheckInHeartbeat() {
-        try {
-            service.doAclCheckInHeartbeat(new AclProperties());
-        } catch (AclException e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(() -> service.doAclCheckInHeartbeat(new AclProperties()));
     }
 
     @Test
     public void testDoAclCheckInSend() {
-        try {
-            service.doAclCheckInSend(new AclProperties());
-        } catch (AclException e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(() -> service.doAclCheckInSend(new AclProperties()));
     }
 
     @Test
     public void testDoAclCheckInReceive() {
-        try {
-            service.doAclCheckInReceive(new AclProperties());
-        } catch (AclException e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(() -> service.doAclCheckInReceive(new AclProperties()));
     }
 }

--- a/eventmesh-security-plugin/eventmesh-security-api/src/test/java/org/apache/eventmesh/api/acl/AclServiceTest.java
+++ b/eventmesh-security-plugin/eventmesh-security-api/src/test/java/org/apache/eventmesh/api/acl/AclServiceTest.java
@@ -72,65 +72,37 @@ public class AclServiceTest {
 
     @Test
     public void testInit() {
-        try {
-            service.init();
-        } catch (AclException e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(service::init);
     }
 
     @Test
     public void testStart() {
-        try {
-            service.start();
-        } catch (AclException e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(service::start);
     }
 
     @Test
     public void testShutdown() {
-        try {
-            service.shutdown();
-        } catch (AclException e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(service::shutdown);
     }
 
     @Test
     public void testDoAclCheckInConnect() {
-        try {
-            service.doAclCheckInConnect(new AclProperties());
-        } catch (AclException e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(() -> service.doAclCheckInConnect(new AclProperties()));
     }
 
     @Test
     public void testDoAclCheckInHeartbeat() {
-        try {
-            service.doAclCheckInHeartbeat(new AclProperties());
-        } catch (AclException e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(() -> service.doAclCheckInHeartbeat(new AclProperties()));
     }
 
     @Test
     public void testDoAclCheckInSend() {
-        try {
-            service.doAclCheckInSend(new AclProperties());
-        } catch (AclException e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(() -> service.doAclCheckInSend(new AclProperties()));
     }
 
     @Test
     public void testDoAclCheckInReceive() {
-        try {
-            service.doAclCheckInReceive(new AclProperties());
-        } catch (AclException e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(() -> service.doAclCheckInReceive(new AclProperties()));
     }
 
 }

--- a/eventmesh-security-plugin/eventmesh-security-api/src/test/java/org/apache/eventmesh/api/auth/AuthServiceTest.java
+++ b/eventmesh-security-plugin/eventmesh-security-api/src/test/java/org/apache/eventmesh/api/auth/AuthServiceTest.java
@@ -59,38 +59,22 @@ public class AuthServiceTest {
 
     @Test
     public void testInit() {
-        try {
-            service.init();
-        } catch (AuthException e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(service::init);
     }
 
     @Test
     public void testStart() {
-        try {
-            service.start();
-        } catch (AuthException e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(service::start);
     }
 
     @Test
     public void testShutdown() {
-        try {
-            service.shutdown();
-        } catch (AuthException e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(service::shutdown);
     }
 
     @Test
     public void testGetAuthParams() {
-        try {
-            Map<String, String> authParams = service.getAuthParams();
-            Assertions.assertNull(authParams);
-        } catch (AuthException e) {
-            Assertions.fail(e.getMessage());
-        }
+        Map<String, String> authParams = service.getAuthParams();
+        Assertions.assertNull(authParams);
     }
 }

--- a/eventmesh-security-plugin/eventmesh-security-api/src/test/java/org/apache/eventmesh/api/exception/AclExceptionTest.java
+++ b/eventmesh-security-plugin/eventmesh-security-api/src/test/java/org/apache/eventmesh/api/exception/AclExceptionTest.java
@@ -24,23 +24,13 @@ public class AclExceptionTest {
 
     @Test
     public void testConstructWithMsg() {
-        try {
-            new AclException("test");
-
-            new AclException(null);
-        } catch (Exception e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(() -> new AclException("test"));
+        Assertions.assertDoesNotThrow(() -> new AclException(null));
     }
 
     @Test
     public void testConstructWithMsgAndExption() {
-        try {
-            new AclException("test", new Exception("test1"));
-
-            new AclException(null, null);
-        } catch (Exception e) {
-            Assertions.fail(e.getMessage());
-        }
+        Assertions.assertDoesNotThrow(() -> new AclException("test", new Exception("test1")));
+        Assertions.assertDoesNotThrow(() -> new AclException(null, null));
     }
 }

--- a/eventmesh-security-plugin/eventmesh-security-auth-http-basic/src/test/java/org/apache/eventmesh/auth/http/basic/impl/AuthHttpBasicServiceTest.java
+++ b/eventmesh-security-plugin/eventmesh-security-auth-http-basic/src/test/java/org/apache/eventmesh/auth/http/basic/impl/AuthHttpBasicServiceTest.java
@@ -38,34 +38,20 @@ public class AuthHttpBasicServiceTest {
 
     @Test
     public void testInitAndGetAuthParams() {
-        try {
-            service.init();
-            Map<String, String> authParams = service.getAuthParams();
-            String authorization = authParams.get("Authorization");
-            Assertions.assertNotNull(authorization);
-            Assertions.assertTrue(authorization.length() > 5);
-        } catch (Exception e) {
-            Assertions.fail(e.getMessage());
-        }
+        service.init();
+        Map<String, String> authParams = service.getAuthParams();
+        String authorization = authParams.get("Authorization");
+        Assertions.assertNotNull(authorization);
+        Assertions.assertTrue(authorization.length() > 5);
     }
 
     @Test
     public void testStart() {
-        try {
-            service.start();
-        } catch (Exception e) {
-            Assertions.fail(e.getMessage());
-        }
-
+        Assertions.assertDoesNotThrow(service::start);
     }
 
     @Test
     public void testShutdown() {
-        try {
-            service.shutdown();
-        } catch (Exception e) {
-            Assertions.fail(e.getMessage());
-        }
-
+        Assertions.assertDoesNotThrow(service::shutdown);
     }
 }

--- a/eventmesh-spi/src/test/java/org/apache/eventmesh/spi/EventMeshExtensionFactoryTest.java
+++ b/eventmesh-spi/src/test/java/org/apache/eventmesh/spi/EventMeshExtensionFactoryTest.java
@@ -49,23 +49,7 @@ public class EventMeshExtensionFactoryTest {
 
     @Test
     public void testGetExtension() {
-        ExtensionException exception = null;
-        try {
-            EventMeshExtensionFactory.getExtension(null, "eventmesh");
-        } catch (Exception ex) {
-            if (ex instanceof ExtensionException) {
-                exception = (ExtensionException) ex;
-            }
-        }
-        Assertions.assertNotNull(exception);
-        exception = null;
-        try {
-            EventMeshExtensionFactory.getExtension(TestPrototypeExtension.class, null);
-        } catch (Exception ex) {
-            if (ex instanceof ExtensionException) {
-                exception = (ExtensionException) ex;
-            }
-        }
-        Assertions.assertNotNull(exception);
+        Assertions.assertThrows(ExtensionException.class, () -> EventMeshExtensionFactory.getExtension(null, "eventmesh"));
+        Assertions.assertThrows(ExtensionException.class, () -> EventMeshExtensionFactory.getExtension(TestPrototypeExtension.class, null));
     }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/test/java/org/apache/eventmesh/storage/rocketmq/producer/ProducerImplTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/test/java/org/apache/eventmesh/storage/rocketmq/producer/ProducerImplTest.java
@@ -18,7 +18,6 @@
 package org.apache.eventmesh.storage.rocketmq.producer;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Fail.failBecauseExceptionWasNotThrown;
 import static org.mockito.ArgumentMatchers.any;
 
 import org.apache.eventmesh.api.exception.StorageRuntimeException;
@@ -40,6 +39,7 @@ import java.net.URI;
 import java.util.Properties;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -117,7 +117,7 @@ public class ProducerImplTest {
         MQClientException exception = new MQClientException("Send message to RocketMQ broker failed.", new Exception());
         Mockito.when(rocketmqProducer.send(any(Message.class))).thenThrow(exception);
 
-        try {
+        StorageRuntimeException e = Assertions.assertThrows(StorageRuntimeException.class, () -> {
             CloudEvent cloudEvent = CloudEventBuilder.v1()
                 .withId("id1")
                 .withSource(URI.create("https://github.com/cloudevents/*****"))
@@ -126,10 +126,8 @@ public class ProducerImplTest {
                 .withData(new byte[]{'a'})
                 .build();
             producer.send(cloudEvent);
-            failBecauseExceptionWasNotThrown(StorageRuntimeException.class);
-        } catch (Exception e) {
-            assertThat(e).hasMessageContaining("Send message to RocketMQ broker failed.");
-        }
+        });
+        assertThat(e).hasMessageContaining("Send message to RocketMQ broker failed.");
 
         Mockito.verify(rocketmqProducer).send(any(Message.class));
     }

--- a/eventmesh-webhook/eventmesh-webhook-admin/src/test/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperationTest.java
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/test/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperationTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 public class FileWebHookConfigOperationTest {
 
     @Test
-    public void testInsertWebHookConfig() {
+    public void testInsertWebHookConfig() throws Exception {
         Properties properties = new Properties();
         properties.setProperty("filePath", "test_dir");
 
@@ -56,8 +56,6 @@ public class FileWebHookConfigOperationTest {
             List<WebHookConfig> queryResult = fileWebHookConfigOperation.queryWebHookConfigByManufacturer(queryConfig, 1, 1);
             Assertions.assertTrue(Objects.nonNull(queryResult) && queryResult.size() == 1);
             Assertions.assertEquals(queryResult.get(0).getCallbackPath(), config.getCallbackPath());
-        } catch (Exception e) {
-            Assertions.fail(e.getMessage());
         } finally {
             deleteDir("test_dir");
         }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
-->

Fixes #4483.

### Motivation

Following 750825158253d4004e023cfb8ab515c39bc20a71 (#4475), the upgrade to JUnit Jupiter allows us to standardize the way exceptions are handled in tests and reduce boilerplate code.



### Modifications

- There is no need to catch an exception and explicitly fail the test. The test should be allowed to throw the exception and error-out, which is technically the correct behavior (the test didn't really fail on any logic test).
  - In the cases where the only assertion was explicitly failing the test in case an exception was thrown, `Assertions.assertDoesNotThrow` was used instead.
- In order to test cases when an exception must be thrown, `Assertions.assertThrows` can be used. There is no need to catch the exception and assert it's not null.
  - It's also worth noting that some instances that used the idiom of catching an expected exception did not fail the test in case the exception was never thrown, meaning this patch not only improves the tests' style, but also their correctness.
- The original `org.apache.eventmesh.client.grpc.producer.EventMeshGrpcProducerTest#testPublishWithException` test did not in fact test an assertion was thrown, despite the intent hinted by the name. This test was fixed to perform the action it was intended to test.


### Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
