### PR TITLE
Avoid unnecessary boxing by using plain == for primitive types

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/convert/converter/BaseDataTypeConverter.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/convert/converter/BaseDataTypeConverter.java
@@ -42,7 +42,7 @@ public class BaseDataTypeConverter {
         @Override
         public Boolean convert(ConvertInfo convertInfo) {
             String value = (String) convertInfo.getValue();
-            if (Objects.equals(value.length(), 1)) {
+            if (value.length() == 1) {
                 return Objects.equals(convertInfo.getValue(), "1") ? Boolean.TRUE : Boolean.FALSE;
             }
 


### PR DESCRIPTION
fix issue #4030 
