### PR TITLE
[ISSUE #4474] Uniformly manage duplicate static variables

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/Constants.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/Constants.java
@@ -193,4 +193,6 @@ public class Constants {
      * application/cloudevents+json Content-type
      */
     public static final String CONTENT_TYPE_CLOUDEVENTS_JSON = "application/cloudevents+json";
+
+
 }

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/Constants.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/Constants.java
@@ -194,5 +194,9 @@ public class Constants {
      */
     public static final String CONTENT_TYPE_CLOUDEVENTS_JSON = "application/cloudevents+json";
 
+    public static final String HTTP = "HTTP";
 
+    public static final String TCP = "TCP";
+
+    public static final String GRPC = "GRPC";
 }

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/CommonConfiguration.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/CommonConfiguration.java
@@ -17,7 +17,8 @@
 
 package org.apache.eventmesh.common.config;
 
-import org.apache.eventmesh.common.utils.ConfigurationContextUtil;
+import static org.apache.eventmesh.common.Constants.HTTP;
+
 import org.apache.eventmesh.common.utils.IPUtils;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -118,7 +119,7 @@ public class CommonConfiguration {
         }
 
         if (CollectionUtils.isEmpty(eventMeshProvideServerProtocols)) {
-            this.eventMeshProvideServerProtocols = Collections.singletonList(ConfigurationContextUtil.HTTP);
+            this.eventMeshProvideServerProtocols = Collections.singletonList(HTTP);
         }
 
         meshGroup = String.join("-", this.eventMeshEnv, this.eventMeshIDC, this.eventMeshCluster, this.sysID);

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/ConfigurationContextUtil.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/ConfigurationContextUtil.java
@@ -17,6 +17,10 @@
 
 package org.apache.eventmesh.common.utils;
 
+import static org.apache.eventmesh.common.Constants.GRPC;
+import static org.apache.eventmesh.common.Constants.HTTP;
+import static org.apache.eventmesh.common.Constants.TCP;
+
 import org.apache.eventmesh.common.config.CommonConfiguration;
 
 import java.util.List;
@@ -31,10 +35,6 @@ import com.google.common.collect.Lists;
 public class ConfigurationContextUtil {
 
     private static final ConcurrentHashMap<String, CommonConfiguration> CONFIGURATION_MAP = new ConcurrentHashMap<>();
-
-    public static final String HTTP = "HTTP";
-    public static final String TCP = "TCP";
-    public static final String GRPC = "GRPC";
 
     public static final List<String> KEYS = Lists.newArrayList(HTTP, TCP, GRPC);
 

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/ConfigurationContextUtilTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/ConfigurationContextUtilTest.java
@@ -17,6 +17,9 @@
 
 package org.apache.eventmesh.common.utils;
 
+import static org.apache.eventmesh.common.Constants.GRPC;
+import static org.apache.eventmesh.common.Constants.TCP;
+
 import org.apache.eventmesh.common.config.CommonConfiguration;
 
 import org.junit.jupiter.api.Assertions;
@@ -31,21 +34,21 @@ public class ConfigurationContextUtilTest {
     public void setUp() {
         grpcConfig = new CommonConfiguration();
         grpcConfig.setEventMeshName("grpc");
-        ConfigurationContextUtil.putIfAbsent(ConfigurationContextUtil.GRPC, grpcConfig);
+        ConfigurationContextUtil.putIfAbsent(GRPC, grpcConfig);
     }
 
     @Test
     public void testPutIfAbsent() {
         CommonConfiguration tcpConfig = new CommonConfiguration();
         tcpConfig.setEventMeshName("tpc");
-        ConfigurationContextUtil.putIfAbsent(ConfigurationContextUtil.TCP, tcpConfig);
-        CommonConfiguration get = ConfigurationContextUtil.get(ConfigurationContextUtil.TCP);
+        ConfigurationContextUtil.putIfAbsent(TCP, tcpConfig);
+        CommonConfiguration get = ConfigurationContextUtil.get(TCP);
         Assertions.assertNotNull(get);
         Assertions.assertEquals(tcpConfig, get);
         CommonConfiguration newGrpc = new CommonConfiguration();
         newGrpc.setEventMeshName("newGrpc");
-        ConfigurationContextUtil.putIfAbsent(ConfigurationContextUtil.GRPC, newGrpc);
-        CommonConfiguration getGrpc = ConfigurationContextUtil.get(ConfigurationContextUtil.GRPC);
+        ConfigurationContextUtil.putIfAbsent(GRPC, newGrpc);
+        CommonConfiguration getGrpc = ConfigurationContextUtil.get(GRPC);
         Assertions.assertNotNull(getGrpc);
         Assertions.assertEquals(grpcConfig, getGrpc);
         Assertions.assertNotEquals(newGrpc, getGrpc);
@@ -53,17 +56,17 @@ public class ConfigurationContextUtilTest {
 
     @Test
     public void testGet() {
-        CommonConfiguration result = ConfigurationContextUtil.get(ConfigurationContextUtil.GRPC);
+        CommonConfiguration result = ConfigurationContextUtil.get(GRPC);
         Assertions.assertNotNull(result);
         Assertions.assertEquals(grpcConfig, result);
     }
 
     @Test
     public void testClear() {
-        CommonConfiguration result0 = ConfigurationContextUtil.get(ConfigurationContextUtil.GRPC);
+        CommonConfiguration result0 = ConfigurationContextUtil.get(GRPC);
         Assertions.assertNotNull(result0);
         ConfigurationContextUtil.clear();
-        CommonConfiguration result = ConfigurationContextUtil.get(ConfigurationContextUtil.GRPC);
+        CommonConfiguration result = ConfigurationContextUtil.get(GRPC);
         Assertions.assertNull(result);
     }
 }

--- a/eventmesh-connectors/eventmesh-connector-openfunction/src/main/java/org/apache/eventmesh/connector/openfunction/client/CloudEventsPublishInstance.java
+++ b/eventmesh-connectors/eventmesh-connector-openfunction/src/main/java/org/apache/eventmesh/connector/openfunction/client/CloudEventsPublishInstance.java
@@ -17,9 +17,10 @@
 
 package org.apache.eventmesh.connector.openfunction.client;
 
+import static org.apache.eventmesh.common.Constants.CLOUD_EVENTS_PROTOCOL_NAME;
+
 import org.apache.eventmesh.client.grpc.config.EventMeshGrpcClientConfig;
 import org.apache.eventmesh.client.grpc.producer.EventMeshGrpcProducer;
-import org.apache.eventmesh.client.tcp.common.EventMeshCommon;
 import org.apache.eventmesh.common.Constants;
 import org.apache.eventmesh.common.utils.JsonUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
@@ -80,7 +81,7 @@ public class CloudEventsPublishInstance {
             .withSubject("TEST-TOPIC-FUNCTION")
             .withSource(URI.create("/"))
             .withDataContentType("application/cloudevents+json")
-            .withType(EventMeshCommon.CLOUD_EVENTS_PROTOCOL_NAME)
+            .withType(CLOUD_EVENTS_PROTOCOL_NAME)
             .withData(JsonUtils.toJSONString(content).getBytes(StandardCharsets.UTF_8))
             .withExtension(Constants.EVENTMESH_MESSAGE_CONST_TTL, String.valueOf(4 * 1000))
             .build();

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/GrpcAbstractDemo.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/GrpcAbstractDemo.java
@@ -17,8 +17,9 @@
 
 package org.apache.eventmesh.grpc;
 
+import static org.apache.eventmesh.common.Constants.CLOUD_EVENTS_PROTOCOL_NAME;
+
 import org.apache.eventmesh.client.grpc.config.EventMeshGrpcClientConfig;
-import org.apache.eventmesh.client.tcp.common.EventMeshCommon;
 import org.apache.eventmesh.common.Constants;
 import org.apache.eventmesh.common.EventMeshMessage;
 import org.apache.eventmesh.common.ExampleConstants;
@@ -59,7 +60,7 @@ public class GrpcAbstractDemo {
             .withSubject(topic)
             .withSource(URI.create("/"))
             .withDataContentType(ExampleConstants.CLOUDEVENT_CONTENT_TYPE)
-            .withType(EventMeshCommon.CLOUD_EVENTS_PROTOCOL_NAME)
+            .withType(CLOUD_EVENTS_PROTOCOL_NAME)
             .withData(JsonUtils.toJSONString(content).getBytes(StandardCharsets.UTF_8))
             .withExtension(Constants.EVENTMESH_MESSAGE_CONST_TTL, String.valueOf(4 * 1000))
             .build();

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/http/demo/HttpAbstractDemo.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/http/demo/HttpAbstractDemo.java
@@ -17,8 +17,9 @@
 
 package org.apache.eventmesh.http.demo;
 
+import static org.apache.eventmesh.common.Constants.CLOUD_EVENTS_PROTOCOL_NAME;
+
 import org.apache.eventmesh.client.http.conf.EventMeshHttpClientConfig;
-import org.apache.eventmesh.client.tcp.common.EventMeshCommon;
 import org.apache.eventmesh.common.Constants;
 import org.apache.eventmesh.common.EventMeshMessage;
 import org.apache.eventmesh.common.ExampleConstants;
@@ -75,7 +76,7 @@ public class HttpAbstractDemo {
             .withSubject(ExampleConstants.EVENTMESH_HTTP_ASYNC_TEST_TOPIC)
             .withSource(URI.create("/"))
             .withDataContentType(ExampleConstants.CLOUDEVENT_CONTENT_TYPE)
-            .withType(EventMeshCommon.CLOUD_EVENTS_PROTOCOL_NAME)
+            .withType(CLOUD_EVENTS_PROTOCOL_NAME)
             .withData(JsonUtils.toJSONString(content).getBytes(StandardCharsets.UTF_8))
             .withExtension(Constants.EVENTMESH_MESSAGE_CONST_TTL, String.valueOf(4_000))
             .build();

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/http/demo/sub/controller/SubController.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/http/demo/sub/controller/SubController.java
@@ -17,7 +17,8 @@
 
 package org.apache.eventmesh.http.demo.sub.controller;
 
-import org.apache.eventmesh.client.tcp.common.EventMeshCommon;
+import static org.apache.eventmesh.common.Constants.CLOUD_EVENTS_PROTOCOL_NAME;
+
 import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.utils.JsonUtils;
 import org.apache.eventmesh.http.demo.sub.service.SubService;
@@ -59,7 +60,7 @@ public class SubController {
         }
         @SuppressWarnings("unchecked")
         final Map<String, String> contentMap = JsonUtils.parseObject(content, HashMap.class);
-        if (StringUtils.equals(EventMeshCommon.CLOUD_EVENTS_PROTOCOL_NAME, contentMap.get(ProtocolKey.PROTOCOL_TYPE))) {
+        if (StringUtils.equals(CLOUD_EVENTS_PROTOCOL_NAME, contentMap.get(ProtocolKey.PROTOCOL_TYPE))) {
             final EventFormat eventFormat = EventFormatProvider.getInstance().resolveFormat(JsonFormat.CONTENT_TYPE);
             if (eventFormat != null) {
                 final CloudEvent event = eventFormat.deserialize(content.getBytes(StandardCharsets.UTF_8));

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/common/EventMeshTestUtils.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/common/EventMeshTestUtils.java
@@ -17,9 +17,9 @@
 
 package org.apache.eventmesh.tcp.common;
 
+import static org.apache.eventmesh.common.Constants.CLOUD_EVENTS_PROTOCOL_NAME;
 import static org.apache.eventmesh.common.protocol.tcp.Command.RESPONSE_TO_SERVER;
 
-import org.apache.eventmesh.client.tcp.common.EventMeshCommon;
 import org.apache.eventmesh.client.tcp.common.MessageUtils;
 import org.apache.eventmesh.common.Constants;
 import org.apache.eventmesh.common.ExampleConstants;
@@ -156,7 +156,7 @@ public class EventMeshTestUtils {
             .withSubject(ExampleConstants.EVENTMESH_TCP_ASYNC_TEST_TOPIC)
             .withSource(URI.create("/"))
             .withDataContentType(ExampleConstants.CLOUDEVENT_CONTENT_TYPE)
-            .withType(EventMeshCommon.CLOUD_EVENTS_PROTOCOL_NAME)
+            .withType(CLOUD_EVENTS_PROTOCOL_NAME)
             .withData(Objects.requireNonNull(JsonUtils.toJSONString(content)).getBytes(StandardCharsets.UTF_8))
             .withExtension(UtilsConstants.TTL, DEFAULT_TTL_MS)
             .build();
@@ -171,7 +171,7 @@ public class EventMeshTestUtils {
             .withSubject(ExampleConstants.EVENTMESH_TCP_SYNC_TEST_TOPIC)
             .withSource(URI.create("/"))
             .withDataContentType(ExampleConstants.CLOUDEVENT_CONTENT_TYPE)
-            .withType(EventMeshCommon.CLOUD_EVENTS_PROTOCOL_NAME)
+            .withType(CLOUD_EVENTS_PROTOCOL_NAME)
             .withData(Objects.requireNonNull(JsonUtils.toJSONString(content)).getBytes(StandardCharsets.UTF_8))
             .withExtension(UtilsConstants.TTL, DEFAULT_TTL_MS)
             .withExtension(UtilsConstants.MSG_TYPE, "persistent")

--- a/eventmesh-meta/eventmesh-meta-consul/src/test/java/org/apache/eventmesh/meta/consul/service/ConsulMetaServiceTest.java
+++ b/eventmesh-meta/eventmesh-meta-consul/src/test/java/org/apache/eventmesh/meta/consul/service/ConsulMetaServiceTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.eventmesh.meta.consul.service;
 
+import static org.apache.eventmesh.common.Constants.HTTP;
+
 import org.apache.eventmesh.api.exception.MetaException;
 import org.apache.eventmesh.api.meta.dto.EventMeshDataInfo;
 import org.apache.eventmesh.api.meta.dto.EventMeshRegisterInfo;
@@ -53,7 +55,7 @@ public class ConsulMetaServiceTest {
     public void registryTest() {
         consulMetaService = new ConsulMetaService();
         CommonConfiguration configuration = new CommonConfiguration();
-        ConfigurationContextUtil.putIfAbsent(ConfigurationContextUtil.HTTP, configuration);
+        ConfigurationContextUtil.putIfAbsent(HTTP, configuration);
         configuration.setMetaStorageAddr("127.0.0.1:8500");
         Mockito.when(eventMeshRegisterInfo.getEventMeshClusterName()).thenReturn("eventmesh");
         Mockito.when(eventMeshRegisterInfo.getEventMeshName()).thenReturn("eventmesh");

--- a/eventmesh-meta/eventmesh-meta-etcd/src/test/java/org/apache/eventmesh/registry/etcd/service/EtcdMetaServiceTest.java
+++ b/eventmesh-meta/eventmesh-meta-etcd/src/test/java/org/apache/eventmesh/registry/etcd/service/EtcdMetaServiceTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.eventmesh.registry.etcd.service;
 
+import static org.apache.eventmesh.common.Constants.HTTP;
+
 import org.apache.eventmesh.api.exception.MetaException;
 import org.apache.eventmesh.api.meta.dto.EventMeshDataInfo;
 import org.apache.eventmesh.api.meta.dto.EventMeshRegisterInfo;
@@ -51,7 +53,7 @@ public class EtcdMetaServiceTest {
         etcdMetaService = new EtcdMetaService();
         CommonConfiguration configuration = new CommonConfiguration();
         configuration.setMetaStorageAddr("127.0.0.1:2379");
-        ConfigurationContextUtil.putIfAbsent(ConfigurationContextUtil.HTTP, configuration);
+        ConfigurationContextUtil.putIfAbsent(HTTP, configuration);
 
         // Mockito.when(eventMeshRegisterInfo.getEventMeshClusterName()).thenReturn("eventmesh");
         // Mockito.when(eventMeshRegisterInfo.getEventMeshName()).thenReturn("eventmesh");

--- a/eventmesh-meta/eventmesh-meta-nacos/src/test/java/org/apache/eventmesh/registry/nacos/service/NacosMetaServiceTest.java
+++ b/eventmesh-meta/eventmesh-meta-nacos/src/test/java/org/apache/eventmesh/registry/nacos/service/NacosMetaServiceTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.eventmesh.registry.nacos.service;
 
+import static org.apache.eventmesh.common.Constants.HTTP;
+
 import org.apache.eventmesh.api.exception.MetaException;
 import org.apache.eventmesh.api.meta.dto.EventMeshRegisterInfo;
 import org.apache.eventmesh.api.meta.dto.EventMeshUnRegisterInfo;
@@ -55,7 +57,7 @@ public class NacosMetaServiceTest {
         configuration.setMetaStorageAddr("127.0.0.1");
         configuration.setEventMeshMetaStoragePluginPassword("nacos");
         configuration.setEventMeshMetaStoragePluginUsername("nacos");
-        ConfigurationContextUtil.putIfAbsent(ConfigurationContextUtil.HTTP, configuration);
+        ConfigurationContextUtil.putIfAbsent(HTTP, configuration);
 
         Mockito.when(eventMeshRegisterInfo.getEventMeshClusterName()).thenReturn("eventmesh");
         Mockito.when(eventMeshRegisterInfo.getEventMeshName()).thenReturn("eventmesh");

--- a/eventmesh-meta/eventmesh-meta-zookeeper/src/test/java/org/apache/eventmesh/registry/zookeeper/service/ZookeeperMetaServiceTest.java
+++ b/eventmesh-meta/eventmesh-meta-zookeeper/src/test/java/org/apache/eventmesh/registry/zookeeper/service/ZookeeperMetaServiceTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.eventmesh.registry.zookeeper.service;
 
+import static org.apache.eventmesh.common.Constants.HTTP;
+
 import org.apache.eventmesh.api.meta.dto.EventMeshDataInfo;
 import org.apache.eventmesh.api.meta.dto.EventMeshRegisterInfo;
 import org.apache.eventmesh.api.meta.dto.EventMeshUnRegisterInfo;
@@ -66,10 +68,10 @@ public class ZookeeperMetaServiceTest {
         CommonConfiguration configuration = new CommonConfiguration();
         configuration.setMetaStorageAddr("127.0.0.1:1500");
         configuration.setEventMeshName("eventmesh");
-        ConfigurationContextUtil.putIfAbsent(ConfigurationContextUtil.HTTP, configuration);
+        ConfigurationContextUtil.putIfAbsent(HTTP, configuration);
 
         Mockito.when(eventMeshRegisterInfo.getEventMeshClusterName()).thenReturn("eventmeshCluster");
-        Mockito.when(eventMeshRegisterInfo.getEventMeshName()).thenReturn("eventmesh-" + ConfigurationContextUtil.HTTP);
+        Mockito.when(eventMeshRegisterInfo.getEventMeshName()).thenReturn("eventmesh-" + HTTP);
         Mockito.when(eventMeshRegisterInfo.getEndPoint()).thenReturn("127.0.0.1:8848");
         Mockito.when(eventMeshRegisterInfo.getEventMeshInstanceNumMap()).thenReturn(Maps.newHashMap());
         HashMap<String, String> metaData = Maps.newHashMap();
@@ -77,7 +79,7 @@ public class ZookeeperMetaServiceTest {
         Mockito.when(eventMeshRegisterInfo.getMetadata()).thenReturn(metaData);
 
         Mockito.when(eventMeshUnRegisterInfo.getEventMeshClusterName()).thenReturn("eventmeshCluster");
-        Mockito.when(eventMeshUnRegisterInfo.getEventMeshName()).thenReturn("eventmesh-" + ConfigurationContextUtil.HTTP);
+        Mockito.when(eventMeshUnRegisterInfo.getEventMeshName()).thenReturn("eventmesh-" + HTTP);
         Mockito.when(eventMeshUnRegisterInfo.getEndPoint()).thenReturn("127.0.0.1:8848");
     }
 

--- a/eventmesh-metrics-plugin/eventmesh-metrics-prometheus/src/main/java/org/apache/eventmesh/metrics/prometheus/metrics/PrometheusGrpcExporter.java
+++ b/eventmesh-metrics-plugin/eventmesh-metrics-prometheus/src/main/java/org/apache/eventmesh/metrics/prometheus/metrics/PrometheusGrpcExporter.java
@@ -17,7 +17,7 @@
 
 package org.apache.eventmesh.metrics.prometheus.metrics;
 
-import static org.apache.eventmesh.metrics.prometheus.utils.PrometheusExporterConstants.GRPC;
+import static org.apache.eventmesh.common.Constants.GRPC;
 import static org.apache.eventmesh.metrics.prometheus.utils.PrometheusExporterConstants.METRICS_GRPC_PREFIX;
 import static org.apache.eventmesh.metrics.prometheus.utils.PrometheusExporterUtils.join;
 import static org.apache.eventmesh.metrics.prometheus.utils.PrometheusExporterUtils.observeOfValue;

--- a/eventmesh-metrics-plugin/eventmesh-metrics-prometheus/src/main/java/org/apache/eventmesh/metrics/prometheus/metrics/PrometheusHttpExporter.java
+++ b/eventmesh-metrics-plugin/eventmesh-metrics-prometheus/src/main/java/org/apache/eventmesh/metrics/prometheus/metrics/PrometheusHttpExporter.java
@@ -17,7 +17,7 @@
 
 package org.apache.eventmesh.metrics.prometheus.metrics;
 
-import static org.apache.eventmesh.metrics.prometheus.utils.PrometheusExporterConstants.HTTP;
+import static org.apache.eventmesh.common.Constants.HTTP;
 import static org.apache.eventmesh.metrics.prometheus.utils.PrometheusExporterUtils.join;
 import static org.apache.eventmesh.metrics.prometheus.utils.PrometheusExporterUtils.observeOfValue;
 

--- a/eventmesh-metrics-plugin/eventmesh-metrics-prometheus/src/main/java/org/apache/eventmesh/metrics/prometheus/metrics/PrometheusTcpExporter.java
+++ b/eventmesh-metrics-plugin/eventmesh-metrics-prometheus/src/main/java/org/apache/eventmesh/metrics/prometheus/metrics/PrometheusTcpExporter.java
@@ -17,8 +17,8 @@
 
 package org.apache.eventmesh.metrics.prometheus.metrics;
 
+import static org.apache.eventmesh.common.Constants.TCP;
 import static org.apache.eventmesh.metrics.prometheus.utils.PrometheusExporterConstants.METRICS_TCP_PREFIX;
-import static org.apache.eventmesh.metrics.prometheus.utils.PrometheusExporterConstants.TCP;
 import static org.apache.eventmesh.metrics.prometheus.utils.PrometheusExporterUtils.join;
 import static org.apache.eventmesh.metrics.prometheus.utils.PrometheusExporterUtils.observeOfValue;
 

--- a/eventmesh-metrics-plugin/eventmesh-metrics-prometheus/src/main/java/org/apache/eventmesh/metrics/prometheus/utils/PrometheusExporterConstants.java
+++ b/eventmesh-metrics-plugin/eventmesh-metrics-prometheus/src/main/java/org/apache/eventmesh/metrics/prometheus/utils/PrometheusExporterConstants.java
@@ -22,12 +22,6 @@ package org.apache.eventmesh.metrics.prometheus.utils;
  */
 public class PrometheusExporterConstants {
 
-    public static final String HTTP = "HTTP";
-
-    public static final String GRPC = "GRPC";
-
-    public static final String TCP = "TCP";
-
     public static final String METRICS_GRPC_PREFIX = "eventmesh.grpc.";
 
     public static final String METRICS_TCP_PREFIX = "eventmesh.tcp.";

--- a/eventmesh-openconnect/eventmesh-openconnect-java/src/main/java/org/apache/eventmesh/openconnect/SourceWorker.java
+++ b/eventmesh-openconnect/eventmesh-openconnect-java/src/main/java/org/apache/eventmesh/openconnect/SourceWorker.java
@@ -17,9 +17,10 @@
 
 package org.apache.eventmesh.openconnect;
 
+import static org.apache.eventmesh.common.Constants.CLOUD_EVENTS_PROTOCOL_NAME;
+
 import org.apache.eventmesh.client.tcp.EventMeshTCPClient;
 import org.apache.eventmesh.client.tcp.EventMeshTCPClientFactory;
-import org.apache.eventmesh.client.tcp.common.EventMeshCommon;
 import org.apache.eventmesh.client.tcp.common.MessageUtils;
 import org.apache.eventmesh.client.tcp.conf.EventMeshTCPClientConfig;
 import org.apache.eventmesh.common.protocol.tcp.Package;
@@ -230,7 +231,7 @@ public class SourceWorker implements ConnectorWorker {
             .withSubject(config.getPubSubConfig().getSubject())
             .withSource(URI.create("/"))
             .withDataContentType("application/cloudevents+json")
-            .withType(EventMeshCommon.CLOUD_EVENTS_PROTOCOL_NAME)
+            .withType(CLOUD_EVENTS_PROTOCOL_NAME)
             .withData(Objects.requireNonNull(JsonUtils.toJSONString(connectRecord.getData())).getBytes(StandardCharsets.UTF_8))
             .withExtension("ttl", 10000)
             .build();

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshGrpcBootstrap.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshGrpcBootstrap.java
@@ -17,6 +17,8 @@
 
 package org.apache.eventmesh.runtime.boot;
 
+import static org.apache.eventmesh.common.Constants.GRPC;
+
 import org.apache.eventmesh.common.config.ConfigService;
 import org.apache.eventmesh.common.utils.ConfigurationContextUtil;
 import org.apache.eventmesh.runtime.configuration.EventMeshGrpcConfiguration;
@@ -34,7 +36,7 @@ public class EventMeshGrpcBootstrap implements EventMeshBootstrap {
         ConfigService configService = ConfigService.getInstance();
         this.eventMeshGrpcConfiguration = configService.buildConfigInstance(EventMeshGrpcConfiguration.class);
 
-        ConfigurationContextUtil.putIfAbsent(ConfigurationContextUtil.GRPC, eventMeshGrpcConfiguration);
+        ConfigurationContextUtil.putIfAbsent(GRPC, eventMeshGrpcConfiguration);
     }
 
     @Override

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshGrpcServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshGrpcServer.java
@@ -17,11 +17,12 @@
 
 package org.apache.eventmesh.runtime.boot;
 
+import static org.apache.eventmesh.common.Constants.GRPC;
+
 import org.apache.eventmesh.api.meta.dto.EventMeshRegisterInfo;
 import org.apache.eventmesh.api.meta.dto.EventMeshUnRegisterInfo;
 import org.apache.eventmesh.common.ThreadPoolFactory;
 import org.apache.eventmesh.common.exception.EventMeshException;
-import org.apache.eventmesh.common.utils.ConfigurationContextUtil;
 import org.apache.eventmesh.common.utils.IPUtils;
 import org.apache.eventmesh.metrics.api.MetricsPluginFactory;
 import org.apache.eventmesh.metrics.api.MetricsRegistry;
@@ -178,9 +179,9 @@ public class EventMeshGrpcServer {
             EventMeshRegisterInfo eventMeshRegisterInfo = new EventMeshRegisterInfo();
             eventMeshRegisterInfo.setEventMeshClusterName(eventMeshGrpcConfiguration.getEventMeshCluster());
             eventMeshRegisterInfo.setEventMeshName(eventMeshGrpcConfiguration.getEventMeshName() + "-"
-                + ConfigurationContextUtil.GRPC);
+                + GRPC);
             eventMeshRegisterInfo.setEndPoint(endPoints);
-            eventMeshRegisterInfo.setProtocolType(ConfigurationContextUtil.GRPC);
+            eventMeshRegisterInfo.setProtocolType(GRPC);
             registerResult = metaStorage.register(eventMeshRegisterInfo);
         } catch (Exception e) {
             log.warn("eventMesh register to registry failed", e);
@@ -196,7 +197,7 @@ public class EventMeshGrpcServer {
         eventMeshUnRegisterInfo.setEventMeshClusterName(eventMeshGrpcConfiguration.getEventMeshCluster());
         eventMeshUnRegisterInfo.setEventMeshName(eventMeshGrpcConfiguration.getEventMeshName());
         eventMeshUnRegisterInfo.setEndPoint(endPoints);
-        eventMeshUnRegisterInfo.setProtocolType(ConfigurationContextUtil.GRPC);
+        eventMeshUnRegisterInfo.setProtocolType(GRPC);
         boolean registerResult = metaStorage.unRegister(eventMeshUnRegisterInfo);
         if (!registerResult) {
             throw new EventMeshException("eventMesh fail to unRegister");

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshHTTPServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshHTTPServer.java
@@ -17,11 +17,12 @@
 
 package org.apache.eventmesh.runtime.boot;
 
+import static org.apache.eventmesh.common.Constants.HTTP;
+
 import org.apache.eventmesh.api.meta.dto.EventMeshRegisterInfo;
 import org.apache.eventmesh.api.meta.dto.EventMeshUnRegisterInfo;
 import org.apache.eventmesh.common.exception.EventMeshException;
 import org.apache.eventmesh.common.protocol.http.common.RequestCode;
-import org.apache.eventmesh.common.utils.ConfigurationContextUtil;
 import org.apache.eventmesh.common.utils.IPUtils;
 import org.apache.eventmesh.metrics.api.MetricsPluginFactory;
 import org.apache.eventmesh.metrics.api.MetricsRegistry;
@@ -202,9 +203,9 @@ public class EventMeshHTTPServer extends AbstractHTTPServer {
             final EventMeshRegisterInfo eventMeshRegisterInfo = new EventMeshRegisterInfo();
             eventMeshRegisterInfo.setEventMeshClusterName(eventMeshHttpConfiguration.getEventMeshCluster());
             eventMeshRegisterInfo.setEventMeshName(eventMeshHttpConfiguration.getEventMeshName()
-                + "-" + ConfigurationContextUtil.HTTP);
+                + "-" + HTTP);
             eventMeshRegisterInfo.setEndPoint(endPoints);
-            eventMeshRegisterInfo.setProtocolType(ConfigurationContextUtil.HTTP);
+            eventMeshRegisterInfo.setProtocolType(HTTP);
             registerResult = metaStorage.register(eventMeshRegisterInfo);
         } catch (Exception e) {
             log.error("eventMesh register to registry failed", e);
@@ -223,7 +224,7 @@ public class EventMeshHTTPServer extends AbstractHTTPServer {
         eventMeshUnRegisterInfo.setEventMeshClusterName(eventMeshHttpConfiguration.getEventMeshCluster());
         eventMeshUnRegisterInfo.setEventMeshName(eventMeshHttpConfiguration.getEventMeshName());
         eventMeshUnRegisterInfo.setEndPoint(endPoints);
-        eventMeshUnRegisterInfo.setProtocolType(ConfigurationContextUtil.HTTP);
+        eventMeshUnRegisterInfo.setProtocolType(HTTP);
         final boolean registerResult = metaStorage.unRegister(eventMeshUnRegisterInfo);
         if (!registerResult) {
             throw new EventMeshException("eventMesh fail to unRegister");

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshHttpBootstrap.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshHttpBootstrap.java
@@ -17,6 +17,8 @@
 
 package org.apache.eventmesh.runtime.boot;
 
+import static org.apache.eventmesh.common.Constants.HTTP;
+
 import org.apache.eventmesh.common.config.ConfigService;
 import org.apache.eventmesh.common.utils.ConfigurationContextUtil;
 import org.apache.eventmesh.runtime.configuration.EventMeshHTTPConfiguration;
@@ -35,7 +37,7 @@ public class EventMeshHttpBootstrap implements EventMeshBootstrap {
         ConfigService configService = ConfigService.getInstance();
         this.eventMeshHttpConfiguration = configService.buildConfigInstance(EventMeshHTTPConfiguration.class);
 
-        ConfigurationContextUtil.putIfAbsent(ConfigurationContextUtil.HTTP, eventMeshHttpConfiguration);
+        ConfigurationContextUtil.putIfAbsent(HTTP, eventMeshHttpConfiguration);
     }
 
     @Override

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshServer.java
@@ -17,6 +17,10 @@
 
 package org.apache.eventmesh.runtime.boot;
 
+import static org.apache.eventmesh.common.Constants.GRPC;
+import static org.apache.eventmesh.common.Constants.HTTP;
+import static org.apache.eventmesh.common.Constants.TCP;
+
 import org.apache.eventmesh.common.config.CommonConfiguration;
 import org.apache.eventmesh.common.config.ConfigService;
 import org.apache.eventmesh.common.utils.AssertUtils;
@@ -77,13 +81,13 @@ public class EventMeshServer {
         final List<String> provideServerProtocols = configuration.getEventMeshProvideServerProtocols();
         for (String provideServerProtocol : provideServerProtocols) {
             switch (provideServerProtocol.toUpperCase()) {
-                case ConfigurationContextUtil.HTTP:
+                case HTTP:
                     BOOTSTRAP_LIST.add(new EventMeshHttpBootstrap(this));
                     break;
-                case ConfigurationContextUtil.TCP:
+                case TCP:
                     BOOTSTRAP_LIST.add(new EventMeshTcpBootstrap(this));
                     break;
-                case ConfigurationContextUtil.GRPC:
+                case GRPC:
                     BOOTSTRAP_LIST.add(new EventMeshGrpcBootstrap(this));
                     break;
                 default:

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshTCPServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshTCPServer.java
@@ -17,11 +17,12 @@
 
 package org.apache.eventmesh.runtime.boot;
 
+import static org.apache.eventmesh.common.Constants.TCP;
+
 import org.apache.eventmesh.api.meta.dto.EventMeshRegisterInfo;
 import org.apache.eventmesh.api.meta.dto.EventMeshUnRegisterInfo;
 import org.apache.eventmesh.common.exception.EventMeshException;
 import org.apache.eventmesh.common.protocol.tcp.Command;
-import org.apache.eventmesh.common.utils.ConfigurationContextUtil;
 import org.apache.eventmesh.common.utils.IPUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.metrics.api.MetricsPluginFactory;
@@ -177,10 +178,10 @@ public class EventMeshTCPServer extends AbstractTCPServer {
                 + EventMeshConstants.IP_PORT_SEPARATOR + eventMeshTCPConfiguration.getEventMeshTcpServerPort();
             EventMeshRegisterInfo eventMeshRegisterInfo = new EventMeshRegisterInfo();
             eventMeshRegisterInfo.setEventMeshClusterName(eventMeshTCPConfiguration.getEventMeshCluster());
-            eventMeshRegisterInfo.setEventMeshName(eventMeshTCPConfiguration.getEventMeshName() + "-" + ConfigurationContextUtil.TCP);
+            eventMeshRegisterInfo.setEventMeshName(eventMeshTCPConfiguration.getEventMeshName() + "-" + TCP);
             eventMeshRegisterInfo.setEndPoint(endPoints);
             eventMeshRegisterInfo.setEventMeshInstanceNumMap(clientSessionGroupMapping.prepareProxyClientDistributionData());
-            eventMeshRegisterInfo.setProtocolType(ConfigurationContextUtil.TCP);
+            eventMeshRegisterInfo.setProtocolType(TCP);
             registerResult = metaStorage.register(eventMeshRegisterInfo);
         } catch (Exception e) {
             log.error("eventMesh register to registry failed", e);
@@ -198,7 +199,7 @@ public class EventMeshTCPServer extends AbstractTCPServer {
         eventMeshUnRegisterInfo.setEventMeshClusterName(eventMeshTCPConfiguration.getEventMeshCluster());
         eventMeshUnRegisterInfo.setEventMeshName(eventMeshTCPConfiguration.getEventMeshName());
         eventMeshUnRegisterInfo.setEndPoint(endPoints);
-        eventMeshUnRegisterInfo.setProtocolType(ConfigurationContextUtil.TCP);
+        eventMeshUnRegisterInfo.setProtocolType(TCP);
         boolean registerResult = metaStorage.unRegister(eventMeshUnRegisterInfo);
         if (!registerResult) {
             throw new EventMeshException("eventMesh fail to unRegister");

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshTcpBootstrap.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshTcpBootstrap.java
@@ -17,6 +17,8 @@
 
 package org.apache.eventmesh.runtime.boot;
 
+import static org.apache.eventmesh.common.Constants.TCP;
+
 import org.apache.eventmesh.common.config.ConfigService;
 import org.apache.eventmesh.common.utils.ConfigurationContextUtil;
 import org.apache.eventmesh.runtime.configuration.EventMeshTCPConfiguration;
@@ -35,7 +37,7 @@ public class EventMeshTcpBootstrap implements EventMeshBootstrap {
         ConfigService configService = ConfigService.getInstance();
         this.eventMeshTcpConfiguration = configService.buildConfigInstance(EventMeshTCPConfiguration.class);
 
-        ConfigurationContextUtil.putIfAbsent(ConfigurationContextUtil.TCP, eventMeshTcpConfiguration);
+        ConfigurationContextUtil.putIfAbsent(TCP, eventMeshTcpConfiguration);
     }
 
     @Override

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/inf/AbstractEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/inf/AbstractEventProcessor.java
@@ -17,6 +17,7 @@
 
 package org.apache.eventmesh.runtime.core.protocol.http.processor.inf;
 
+import static org.apache.eventmesh.common.Constants.HTTP;
 import static org.apache.eventmesh.runtime.constants.EventMeshConstants.CONTENT_TYPE;
 
 import org.apache.eventmesh.api.meta.dto.EventMeshDataInfo;
@@ -26,7 +27,6 @@ import org.apache.eventmesh.common.protocol.SubscriptionItem;
 import org.apache.eventmesh.common.protocol.http.HttpEventWrapper;
 import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.utils.AssertUtils;
-import org.apache.eventmesh.common.utils.ConfigurationContextUtil;
 import org.apache.eventmesh.common.utils.IPUtils;
 import org.apache.eventmesh.common.utils.JsonUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
@@ -82,8 +82,8 @@ public abstract class AbstractEventProcessor implements AsyncHttpProcessor {
         MetaStorage metaStorage = eventMeshHTTPServer.getMetaStorage();
         List<EventMeshDataInfo> allEventMeshInfo = metaStorage.findAllEventMeshInfo();
         String httpServiceName =
-            ConfigurationContextUtil.HTTP + "-" + NacosConstant.GROUP + "@@" + httpConfiguration.getEventMeshName()
-                + "-" + ConfigurationContextUtil.HTTP;
+            HTTP + "-" + NacosConstant.GROUP + "@@" + httpConfiguration.getEventMeshName()
+                + "-" + HTTP;
         for (EventMeshDataInfo eventMeshDataInfo : allEventMeshInfo) {
             if (!eventMeshDataInfo.getEventMeshName().equals(httpServiceName)) {
                 continue;

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/http/ProtocolConstant.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/http/ProtocolConstant.java
@@ -19,7 +19,7 @@ package org.apache.eventmesh.client.http;
 
 public final class ProtocolConstant {
 
-    public static final String CE_PROTOCOL = "cloudevents";
+    public static final String CLOUD_EVENTS_PROTOCOL_NAME = "cloudevents";
     public static final String EM_MESSAGE_PROTOCOL = "eventmeshmessage";
     public static final String OP_MESSAGE_PROTOCOL = "openmessage";
     public static final String PROTOCOL_DESC = "http";

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/http/ProtocolConstant.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/http/ProtocolConstant.java
@@ -18,8 +18,6 @@
 package org.apache.eventmesh.client.http;
 
 public final class ProtocolConstant {
-
-    public static final String CLOUD_EVENTS_PROTOCOL_NAME = "cloudevents";
     public static final String EM_MESSAGE_PROTOCOL = "eventmeshmessage";
     public static final String OP_MESSAGE_PROTOCOL = "openmessage";
     public static final String PROTOCOL_DESC = "http";

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/http/ProtocolConstant.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/http/ProtocolConstant.java
@@ -18,6 +18,7 @@
 package org.apache.eventmesh.client.http;
 
 public final class ProtocolConstant {
+
     public static final String EM_MESSAGE_PROTOCOL = "eventmeshmessage";
     public static final String OP_MESSAGE_PROTOCOL = "openmessage";
     public static final String PROTOCOL_DESC = "http";

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/http/producer/CloudEventProducer.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/http/producer/CloudEventProducer.java
@@ -90,7 +90,7 @@ class CloudEventProducer extends AbstractProducerHttpClient<CloudEvent> {
             .addHeader(ProtocolKey.ClientInstanceKey.USERNAME.getKey(), eventMeshHttpClientConfig.getUserName())
             .addHeader(ProtocolKey.ClientInstanceKey.PASSWD.getKey(), eventMeshHttpClientConfig.getPassword())
             .addHeader(ProtocolKey.LANGUAGE, Constants.LANGUAGE_JAVA)
-            .addHeader(ProtocolKey.PROTOCOL_TYPE, ProtocolConstant.CE_PROTOCOL)
+            .addHeader(ProtocolKey.PROTOCOL_TYPE, Constants.CLOUD_EVENTS_PROTOCOL_NAME)
             .addHeader(ProtocolKey.PROTOCOL_DESC, ProtocolConstant.PROTOCOL_DESC)
             .addHeader(ProtocolKey.PROTOCOL_VERSION, cloudEvent.getSpecVersion().toString())
 

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/common/EventMeshCommon.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/common/EventMeshCommon.java
@@ -39,8 +39,6 @@ public class EventMeshCommon {
      */
     public static final String USER_AGENT_PURPOSE_SUB = "sub";
 
-    // protocol type
-    public static final String CLOUD_EVENTS_PROTOCOL_NAME = "cloudevents";
     public static final String EM_MESSAGE_PROTOCOL_NAME = "eventmeshmessage";
     public static final String OPEN_MESSAGE_PROTOCOL_NAME = "openmessage";
 }

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/common/MessageUtils.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/common/MessageUtils.java
@@ -17,6 +17,8 @@
 
 package org.apache.eventmesh.client.tcp.common;
 
+import static org.apache.eventmesh.common.Constants.CLOUD_EVENTS_PROTOCOL_NAME;
+
 import org.apache.eventmesh.common.Constants;
 import org.apache.eventmesh.common.protocol.SubscriptionItem;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
@@ -82,7 +84,7 @@ public class MessageUtils {
         if (message instanceof CloudEvent) {
             final CloudEvent cloudEvent = (CloudEvent) message;
             Preconditions.checkNotNull(cloudEvent.getDataContentType(), "DateContentType cannot be null");
-            msg.getHeader().putProperty(Constants.PROTOCOL_TYPE, EventMeshCommon.CLOUD_EVENTS_PROTOCOL_NAME);
+            msg.getHeader().putProperty(Constants.PROTOCOL_TYPE, CLOUD_EVENTS_PROTOCOL_NAME);
             msg.getHeader().putProperty(Constants.PROTOCOL_VERSION, cloudEvent.getSpecVersion().toString());
             msg.getHeader().putProperty(Constants.PROTOCOL_DESC, "tcp");
 


### PR DESCRIPTION
### Motivation

There were duplicate final static constants that could have been created in a single common file and could be reused anywhere in the project.


### Modifications
The common file which is suitable for hosting the static constants was found to be inside the package -> package org.apache.eventmesh.common. The file is the Constants.java file. There I added the following String constants ->
{  HTTP = "HTTP",  TCP = "TCP", GRPC = "GRPC"}
Other than this there is one more constant in the eventmesh-common.Constants file called ( CLOUD_EVENTS_PROTOCOL_NAME = "cloudevents" ) which I have added wherever applicable.
and changed the import statements accordingly.

### Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
- If a feature is not applicable for documentation, explain why? PR deals with only refactoring 
