### PR TITLE
[ISSUE#4549] Remove unnecessary transient modifiers. [HTTPMessageHandler]

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/push/HTTPMessageHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/push/HTTPMessageHandler.java
@@ -46,12 +46,12 @@ public class HTTPMessageHandler implements MessageHandler {
 
     private final transient EventMeshConsumer eventMeshConsumer;
 
-    private static final transient ScheduledExecutorService SCHEDULER =
+    private static final ScheduledExecutorService SCHEDULER =
         ThreadPoolFactory.createSingleScheduledExecutor("eventMesh-pushMsgTimeout");
 
     private static final Integer CONSUMER_GROUP_WAITING_REQUEST_THRESHOLD = 10000;
 
-    protected static final transient Map<String, Set<AbstractHTTPPushRequest>> waitingRequests = Maps.newConcurrentMap();
+    protected static final Map<String, Set<AbstractHTTPPushRequest>> waitingRequests = Maps.newConcurrentMap();
 
     private final transient ThreadPoolExecutor pushExecutor;
 


### PR DESCRIPTION
Fixes #4549 .

### Modifications
Remove unnecessary transient modifier, was located at file `HTTPMessageHandler.class`, line 49, 54.
