### PR TITLE
[ISSUE #4602] when wechat send message api response errcode is not zero, the wechat sink connector does not throw IllegalAccessException

### DIFF
--- a/eventmesh-connectors/README.md
+++ b/eventmesh-connectors/README.md
@@ -66,4 +66,6 @@ Add a new connector by implementing the source/sink interface using :
 |       [Spring](eventmesh-connector-spring)       |    Sink     |    ✅    |
 |                      WeCom                       |   Source    |    ⬜    |
 |        [WeCom](eventmesh-connector-wecom)        |    Sink     |    ✅    |
+|                      WeChat                      |   Source    |    ⬜    |
+|       [WeChat](eventmesh-connector-wechat)       |    Sink     |    ✅    |
 |         More connectors will be added...         | Source/Sink |   N/A   |

--- a/eventmesh-connectors/eventmesh-connector-wechat/src/main/java/org/apache/eventmesh/connector/wechat/sink/connector/TemplateMessageResponse.java
+++ b/eventmesh-connectors/eventmesh-connector-wechat/src/main/java/org/apache/eventmesh/connector/wechat/sink/connector/TemplateMessageResponse.java
@@ -22,7 +22,7 @@ import lombok.Data;
 @Data
 public class TemplateMessageResponse {
 
-    private int errocode;
+    private int errcode;
 
     private String errmsg;
 

--- a/eventmesh-connectors/eventmesh-connector-wechat/src/main/java/org/apache/eventmesh/connector/wechat/sink/connector/WeChatSinkConnector.java
+++ b/eventmesh-connectors/eventmesh-connector-wechat/src/main/java/org/apache/eventmesh/connector/wechat/sink/connector/WeChatSinkConnector.java
@@ -166,9 +166,9 @@ public class WeChatSinkConnector implements Sink {
                 throw new IOException("message response is null.");
             }
 
-            if (messageResponse.getErrocode() != 0) {
-                throw new IllegalAccessException(String.format("Send message to weCom error! errorCode=%s, errorMessage=%s",
-                    messageResponse.getErrocode(), messageResponse.getErrmsg()));
+            if (messageResponse.getErrcode() != 0) {
+                throw new IllegalAccessException(String.format("Send message to WeChat error! errorCode=%s, errorMessage=%s",
+                    messageResponse.getErrcode(), messageResponse.getErrmsg()));
             }
         }
 


### PR DESCRIPTION








<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
-->

Fixes #4602.

### Motivation

fix bug when wecaht api response fail



### Modifications

rename org.apache.eventmesh.connector.wechat.sink.connector.TemplateMessageResponse#errocode
to org.apache.eventmesh.connector.wechat.sink.connector.TemplateMessageResponse#errcode
add abnormal test case