### PR TITLE
[ISSUE #4688] Capture build scans on ge.apache.org to benefit from deep build insights

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,13 @@ jobs:
       # https://docs.gradle.org/current/userguide/performance.html
       - name: Build
         run: ./gradlew clean build jar dist jacocoTestReport -x spotlessJava -x generateGrammarSource --parallel --daemon
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
 
       - name: Install plugin
         run: ./gradlew installPlugin
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v2

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,33 @@
  * limitations under the License.
  */
 
+plugins {
+    id 'com.gradle.enterprise' version '3.15.1'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.12.1'
+}
+
+def isCiServer = System.getenv().containsKey("CI")
+
+gradleEnterprise {
+    server = "https://ge.apache.org"
+    buildScan {
+        capture { taskInputFiles = true }
+        uploadInBackground = !isCiServer
+        publishAlways()
+        publishIfAuthenticated()
+        obfuscation {
+            ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
+        }
+    }
+}
+
+buildCache {
+    remote(gradleEnterprise.buildCache) {
+        enabled = false
+    }
+}
+
+
 rootProject.name = 'eventmesh'
 String jdkVersion = "${jdk}"
 include 'eventmesh-runtime'


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

Closes #4688.

### Motivation

This PR publishes a build scan for every CI build on GitHub Actions and for every local build from an authenticated Apache committer. The build will not fail if publishing fails.

The build scans of the Apache EventMesh project will be published to the Develocity instance at [ge.apache.org](https://ge.apache.org/), hosted by the Apache Software Foundation and run in partnership between the ASF and Gradle. This Develocity instance has all features and extensions enabled and is freely available for use by the Apache EventMesh project and all other Apache projects. Currently, this is being used by other ASF projects such as [Beam](https://ge.apache.org/scans?search.rootProjectNames=beam&search.timeZoneId=America%2FChicago), [Kafka](https://ge.apache.org/scans?search.rootProjectNames=kafka&search.timeZoneId=America%2FChicago), [Solr](https://ge.apache.org/scans?search.rootProjectNames=solr*&search.timeZoneId=America%2FChicago), and [more](https://ge.apache.org/scans?search.buildToolType=gradle&search.rootProjectNames=not:beam,not:kafka,not:solr*&search.timeZoneId=America%2FChicago).

On this Develocity instance, Apache EventMesh will have access not only to all of the published build scans but other aggregate data features such as:

- Dashboards to view all historical build scans, along with performance trends over time
- Build failure analytics for enhanced investigation and diagnosis of build failures
- Test failure analytics to better understand trends and causes around slow, failing, and flaky tests

To see an example of the insights, see this [Build Scan](https://ge.solutions-team.gradle.com/s/ejzit5bjnx2v2). Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them.

### Modifications

- Added the Gradle Enterprise and Common Custom User Data Gradle Plugins
- Configured the Gradle Enterprise Gradle Plugin to publish Build Scans to ge.apache.org

### Documentation

- Does this pull request introduce a new feature? (no)