### PR TITLE
[ISSUE #1054] Build caching optimizations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ allprojects {
         enforceCheck false
         java {
             target project.fileTree(project.projectDir) {
-                include '**/*.java'
+                include 'src/*/java/**/*.java'
                 exclude '**/org/apache/eventmesh/**/protos**'
                 exclude '**/org/apache/eventmesh/connector/openfunction/client/EventMeshGrpcService**'
                 exclude '**/org/apache/eventmesh/connector/openfunction/client/CallbackServiceGrpc**'

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,6 @@ allprojects {
                   .exclude('**/org/apache/eventmesh/connector/openfunction/client/EventMeshGrpcService**')
                   .exclude('**/org/apache/eventmesh/connector/openfunction/client/CallbackServiceGrpc**')
                   .exclude('**/org/apache/eventmesh/connector/jdbc/antlr**')
-                  .dependsOn(spotlessApply)
 
     dependencies {
         repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,3 +33,4 @@ signEnabled=false
 
 org.gradle.warning.mode=none
 org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.caching=true


### PR DESCRIPTION
Fixes #1054.

### Motivation

The motivation of this PR is to improve the build time by resolving caching issues.

- build cache was not enabled.
- spotlessApply runs on every build, modifying source code and causing cache misses.
- spotless target included build directory, causing cache misses due to changing inputs.
- WatchFileManagerTest edits a properties file in place causing a cache miss in subsequent tasks.

### Modifications

- Enabled gradle build cache by setting org.gradle.caching = true in the gradle.properties file.
- Removed checkstyleMain dependency on spotlessApply (should run spotlessApply as a separate task or integrate into CI).
- Limited the target of spotlessJava to only the src java files.
- Copied configuration.properties into a TempDir for testing the onChange method.

These changes improved the build time for back-to-back builds with no changes from ~4 minutes 30 seconds down to ~15 seconds. 

build scan before modifications: https://ge.solutions-team.gradle.com/s/wl6q5fikzjhnq#performance
build scan after modifications: https://ge.solutions-team.gradle.com/s/cssmzbjx5v7js#performance

### Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) n/a
- If a feature is not applicable for documentation, explain why? n/a
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
