### PR TITLE
Deprecate `LogUtils` for removal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,10 @@ allprojects {
                   .exclude('**/org/apache/eventmesh/connector/jdbc/antlr**')
                   .dependsOn(spotlessApply)
 
+    configurations {
+        errorprone.extendsFrom(annotationProcessor)
+    }
+
     dependencies {
         repositories {
             mavenLocal()
@@ -104,6 +108,7 @@ allprojects {
             }
         }
         testImplementation "org.junit.jupiter:junit-jupiter:5.6.0"
+        errorprone "com.google.errorprone:error_prone_core:2.24.0"
     }
 
     spotless {
@@ -138,6 +143,7 @@ allprojects {
     test {
         useJUnitPlatform()
     }
+
 }
 
 task tar(type: Tar) {
@@ -389,6 +395,28 @@ subprojects {
     task packageSources(type: Jar) {
         from project.sourceSets.main.allSource
         archiveClassifier.set('sources')
+    }
+
+    task errorPronePatch(type: JavaCompile) {
+        classpath = sourceSets.main.compileClasspath
+        destinationDirectory = file('target/errorprone')
+        source(sourceSets.main.java)
+        options.annotationProcessorPath = configurations.errorprone
+        options.compilerArgs.addAll(
+                '-XDcompilePolicy=simple',
+                '-Xplugin:ErrorProne -XepPatchChecks:InlineMeInliner,RemoveUnusedImports -XepPatchLocation:IN_PLACE'
+        )
+    }
+
+    task errorPronePatchTest(type: JavaCompile) {
+        classpath = sourceSets.test.compileClasspath
+        destinationDirectory = file('target/testErrorprone')
+        source(sourceSets.test.java)
+        options.annotationProcessorPath = configurations.errorprone
+        options.compilerArgs.addAll(
+                '-XDcompilePolicy=simple',
+                '-Xplugin:ErrorProne -XepPatchChecks:InlineMeInliner,RemoveUnusedImports -XepPatchLocation:IN_PLACE'
+        )
     }
 
     artifacts {

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/file/WatchFileManager.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/file/WatchFileManager.java
@@ -17,8 +17,6 @@
 
 package org.apache.eventmesh.common.file;
 
-import org.apache.eventmesh.common.utils.LogUtils;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -62,10 +60,10 @@ public class WatchFileManager {
             return;
         }
 
-        LogUtils.info(log, "[WatchFileManager] start close");
+        log.info("[WatchFileManager] start close");
 
         for (Map.Entry<String, WatchFileTask> entry : WATCH_FILE_TASK_MAP.entrySet()) {
-            LogUtils.info(log, "[WatchFileManager] start to shutdown : {}", entry.getKey());
+            log.info("[WatchFileManager] start to shutdown : {}", entry.getKey());
 
             try {
                 entry.getValue().shutdown();

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/file/WatchFileTask.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/file/WatchFileTask.java
@@ -17,8 +17,6 @@
 
 package org.apache.eventmesh.common.file;
 
-import org.apache.eventmesh.common.utils.LogUtils;
-
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
@@ -89,7 +87,7 @@ public class WatchFileTask extends Thread {
                 for (WatchEvent<?> event : events) {
                     WatchEvent.Kind<?> kind = event.kind();
                     if (kind.equals(StandardWatchEventKinds.OVERFLOW)) {
-                        LogUtils.warn(log, "[WatchFileTask] file overflow: {}", event.context());
+                        log.warn("[WatchFileTask] file overflow: {}", event.context());
                         continue;
                     }
                     precessWatchEvent(event);
@@ -97,7 +95,7 @@ public class WatchFileTask extends Thread {
             } catch (InterruptedException ex) {
                 boolean interrupted = Thread.interrupted();
                 if (interrupted) {
-                    LogUtils.debug(log, "[WatchFileTask] file watch is interrupted");
+                    log.debug("[WatchFileTask] file watch is interrupted");
                 }
             } catch (Exception ex) {
                 log.error("[WatchFileTask] an exception occurred during file listening : ", ex);

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/tcp/codec/Codec.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/tcp/codec/Codec.java
@@ -25,7 +25,6 @@ import org.apache.eventmesh.common.protocol.tcp.RedirectInfo;
 import org.apache.eventmesh.common.protocol.tcp.Subscription;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -38,7 +37,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageCodec;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.handler.codec.ReplayingDecoder;
-
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Preconditions;
@@ -161,7 +159,7 @@ public class Codec extends ByteToMessageCodec<Package> {
             }
             final byte[] headerData = new byte[headerLength];
             in.readBytes(headerData);
-            LogUtils.debug(log, "Decode headerJson={}", deserializeBytes(headerData));
+            log.debug("Decode headerJson={}", deserializeBytes(headerData));
             return JsonUtils.parseObject(headerData, Header.class);
         }
 
@@ -171,7 +169,7 @@ public class Codec extends ByteToMessageCodec<Package> {
             }
             final byte[] bodyData = new byte[bodyLength];
             in.readBytes(bodyData);
-            LogUtils.debug(log, "Decode bodyJson={}", deserializeBytes(bodyData));
+            log.debug("Decode bodyJson={}", deserializeBytes(bodyData));
             return deserializeBody(deserializeBytes(bodyData), header);
         }
 
@@ -223,7 +221,7 @@ public class Codec extends ByteToMessageCodec<Package> {
             case REDIRECT_TO_CLIENT:
                 return JsonUtils.parseObject(bodyJsonString, RedirectInfo.class);
             default:
-                LogUtils.warn(log, "Invalidate TCP command: {}", command);
+                log.warn("Invalidate TCP command: {}", command);
                 return null;
         }
     }

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/LogUtils.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/LogUtils.java
@@ -20,191 +20,231 @@ package org.apache.eventmesh.common.utils;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 
+import com.google.errorprone.annotations.InlineMe;
+
 import lombok.experimental.UtilityClass;
 
+/**
+ * This class will be removed in the next major release.
+ * Use the {@link Logger} class directly.
+ */
+@Deprecated
 @UtilityClass
 public final class LogUtils {
 
+    @InlineMe(replacement = "logger.isTraceEnabled()")
     public static boolean isTraceEnabled(Logger logger) {
         return logger.isTraceEnabled();
     }
 
+    @InlineMe(replacement = "logger.isTraceEnabled(marker)")
     public static boolean isTraceEnabled(Logger logger, Marker marker) {
         return logger.isTraceEnabled(marker);
     }
 
+    @InlineMe(replacement = "logger.trace(msg)")
     public static void trace(Logger logger, String msg) {
         if (isTraceEnabled(logger)) {
             logger.trace(msg);
         }
     }
 
+    @InlineMe(replacement = "logger.trace(format, arg)")
     public static void trace(Logger logger, String format, Object arg) {
         if (isTraceEnabled(logger)) {
             logger.trace(format, arg);
         }
     }
 
+    @InlineMe(replacement = "logger.trace(msg, t)")
     public static void trace(Logger logger, String msg, Throwable t) {
         if (isTraceEnabled(logger)) {
             logger.trace(msg, t);
         }
     }
 
+    @InlineMe(replacement = "logger.trace(format, arguments)")
     public static void trace(Logger logger, String format, Object... arguments) {
         if (isTraceEnabled(logger)) {
             logger.trace(format, arguments);
         }
     }
 
+    @InlineMe(replacement = "logger.trace(format, arg1, arg2)")
     public static void trace(Logger logger, String format, Object arg1, Object arg2) {
         if (isTraceEnabled(logger)) {
             logger.trace(format, arg1, arg2);
         }
     }
 
+    @InlineMe(replacement = "logger.trace(marker, msg)")
     public static void trace(Logger logger, Marker marker, String msg) {
         if (isTraceEnabled(logger, marker)) {
             logger.trace(marker, msg);
         }
     }
 
+    @InlineMe(replacement = "logger.trace(marker, format, arg)")
     public static void trace(Logger logger, Marker marker, String format, Object arg) {
         if (isTraceEnabled(logger, marker)) {
             logger.trace(marker, format, arg);
         }
     }
 
+    @InlineMe(replacement = "logger.isDebugEnabled()")
     public static boolean isDebugEnabled(Logger logger) {
         return logger.isDebugEnabled();
     }
 
+    @InlineMe(replacement = "logger.debug(msg)")
     public static void debug(Logger logger, String msg) {
         if (isDebugEnabled(logger)) {
             logger.debug(msg);
         }
     }
 
+    @InlineMe(replacement = "logger.debug(format, arg)")
     public static void debug(Logger logger, String format, Object arg) {
         if (isDebugEnabled(logger)) {
             logger.debug(format, arg);
         }
     }
 
+    @InlineMe(replacement = "logger.debug(format, arg1, arg2)")
     public static void debug(Logger logger, String format, Object arg1, Object arg2) {
         if (isDebugEnabled(logger)) {
             logger.debug(format, arg1, arg2);
         }
     }
 
+    @InlineMe(replacement = "logger.debug(format, arguments)")
     public static void debug(Logger logger, String format, Object... arguments) {
         if (isDebugEnabled(logger)) {
             logger.debug(format, arguments);
         }
     }
 
+    @InlineMe(replacement = "logger.debug(msg, t)")
     public static void debug(Logger logger, String msg, Throwable t) {
         if (isDebugEnabled(logger)) {
             logger.debug(msg, t);
         }
     }
 
+    @InlineMe(replacement = "logger.isInfoEnabled()")
     public static boolean isInfoEnabled(Logger logger) {
         return logger.isInfoEnabled();
     }
 
+    @InlineMe(replacement = "logger.info(msg)")
     public static void info(Logger logger, String msg) {
         if (isInfoEnabled(logger)) {
             logger.info(msg);
         }
     }
 
+    @InlineMe(replacement = "logger.info(format, arg)")
     public static void info(Logger logger, String format, Object arg) {
         if (isInfoEnabled(logger)) {
             logger.info(format, arg);
         }
     }
 
+    @InlineMe(replacement = "logger.info(format, arg1, arg2)")
     public static void info(Logger logger, String format, Object arg1, Object arg2) {
         if (isInfoEnabled(logger)) {
             logger.info(format, arg1, arg2);
         }
     }
 
+    @InlineMe(replacement = "logger.info(format, arguments)")
     public static void info(Logger logger, String format, Object... arguments) {
         if (isInfoEnabled(logger)) {
             logger.info(format, arguments);
         }
     }
 
+    @InlineMe(replacement = "logger.info(msg, t)")
     public static void info(Logger logger, String msg, Throwable t) {
         if (isInfoEnabled(logger)) {
             logger.info(msg, t);
         }
     }
 
+    @InlineMe(replacement = "logger.isWarnEnabled()")
     public static boolean isWarnEnabled(Logger logger) {
         return logger.isWarnEnabled();
     }
 
+    @InlineMe(replacement = "logger.warn(msg)")
     public static void warn(Logger logger, String msg) {
         if (isWarnEnabled(logger)) {
             logger.warn(msg);
         }
     }
 
+    @InlineMe(replacement = "logger.warn(format, arg)")
     public static void warn(Logger logger, String format, Object arg) {
         if (isWarnEnabled(logger)) {
             logger.warn(format, arg);
         }
     }
 
+    @InlineMe(replacement = "logger.warn(format, arg1, arg2)")
     public static void warn(Logger logger, String format, Object arg1, Object arg2) {
         if (isWarnEnabled(logger)) {
             logger.warn(format, arg1, arg2);
         }
     }
 
+    @InlineMe(replacement = "logger.warn(format, arguments)")
     public static void warn(Logger logger, String format, Object... arguments) {
         if (isWarnEnabled(logger)) {
             logger.warn(format, arguments);
         }
     }
 
+    @InlineMe(replacement = "logger.warn(msg, t)")
     public static void warn(Logger logger, String msg, Throwable t) {
         if (isWarnEnabled(logger)) {
             logger.warn(msg, t);
         }
     }
 
+    @InlineMe(replacement = "logger.isErrorEnabled()")
     public static boolean isErrorEnabled(Logger logger) {
         return logger.isErrorEnabled();
     }
 
+    @InlineMe(replacement = "logger.error(msg)")
     public static void error(Logger logger, String msg) {
         if (isErrorEnabled(logger)) {
             logger.error(msg);
         }
     }
 
+    @InlineMe(replacement = "logger.error(format, arg)")
     public static void error(Logger logger, String format, Object arg) {
         if (isErrorEnabled(logger)) {
             logger.error(format, arg);
         }
     }
 
+    @InlineMe(replacement = "logger.error(format, arg1, arg2)")
     public static void error(Logger logger, String format, Object arg1, Object arg2) {
         if (isErrorEnabled(logger)) {
             logger.error(format, arg1, arg2);
         }
     }
 
+    @InlineMe(replacement = "logger.error(format, arguments)")
     public static void error(Logger logger, String format, Object... arguments) {
         if (isErrorEnabled(logger)) {
             logger.error(format, arguments);
         }
     }
 
+    @InlineMe(replacement = "logger.error(msg, t)")
     public static void error(Logger logger, String msg, Throwable t) {
         if (isErrorEnabled(logger)) {
             logger.error(msg, t);

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/LogUtils.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/LogUtils.java
@@ -44,49 +44,49 @@ public final class LogUtils {
 
     @InlineMe(replacement = "logger.trace(msg)")
     public static void trace(Logger logger, String msg) {
-        if (isTraceEnabled(logger)) {
+        if (logger.isTraceEnabled()) {
             logger.trace(msg);
         }
     }
 
     @InlineMe(replacement = "logger.trace(format, arg)")
     public static void trace(Logger logger, String format, Object arg) {
-        if (isTraceEnabled(logger)) {
+        if (logger.isTraceEnabled()) {
             logger.trace(format, arg);
         }
     }
 
     @InlineMe(replacement = "logger.trace(msg, t)")
     public static void trace(Logger logger, String msg, Throwable t) {
-        if (isTraceEnabled(logger)) {
+        if (logger.isTraceEnabled()) {
             logger.trace(msg, t);
         }
     }
 
     @InlineMe(replacement = "logger.trace(format, arguments)")
     public static void trace(Logger logger, String format, Object... arguments) {
-        if (isTraceEnabled(logger)) {
+        if (logger.isTraceEnabled()) {
             logger.trace(format, arguments);
         }
     }
 
     @InlineMe(replacement = "logger.trace(format, arg1, arg2)")
     public static void trace(Logger logger, String format, Object arg1, Object arg2) {
-        if (isTraceEnabled(logger)) {
+        if (logger.isTraceEnabled()) {
             logger.trace(format, arg1, arg2);
         }
     }
 
     @InlineMe(replacement = "logger.trace(marker, msg)")
     public static void trace(Logger logger, Marker marker, String msg) {
-        if (isTraceEnabled(logger, marker)) {
+        if (logger.isTraceEnabled(marker)) {
             logger.trace(marker, msg);
         }
     }
 
     @InlineMe(replacement = "logger.trace(marker, format, arg)")
     public static void trace(Logger logger, Marker marker, String format, Object arg) {
-        if (isTraceEnabled(logger, marker)) {
+        if (logger.isTraceEnabled(marker)) {
             logger.trace(marker, format, arg);
         }
     }
@@ -98,35 +98,35 @@ public final class LogUtils {
 
     @InlineMe(replacement = "logger.debug(msg)")
     public static void debug(Logger logger, String msg) {
-        if (isDebugEnabled(logger)) {
+        if (logger.isDebugEnabled()) {
             logger.debug(msg);
         }
     }
 
     @InlineMe(replacement = "logger.debug(format, arg)")
     public static void debug(Logger logger, String format, Object arg) {
-        if (isDebugEnabled(logger)) {
+        if (logger.isDebugEnabled()) {
             logger.debug(format, arg);
         }
     }
 
     @InlineMe(replacement = "logger.debug(format, arg1, arg2)")
     public static void debug(Logger logger, String format, Object arg1, Object arg2) {
-        if (isDebugEnabled(logger)) {
+        if (logger.isDebugEnabled()) {
             logger.debug(format, arg1, arg2);
         }
     }
 
     @InlineMe(replacement = "logger.debug(format, arguments)")
     public static void debug(Logger logger, String format, Object... arguments) {
-        if (isDebugEnabled(logger)) {
+        if (logger.isDebugEnabled()) {
             logger.debug(format, arguments);
         }
     }
 
     @InlineMe(replacement = "logger.debug(msg, t)")
     public static void debug(Logger logger, String msg, Throwable t) {
-        if (isDebugEnabled(logger)) {
+        if (logger.isDebugEnabled()) {
             logger.debug(msg, t);
         }
     }
@@ -138,35 +138,35 @@ public final class LogUtils {
 
     @InlineMe(replacement = "logger.info(msg)")
     public static void info(Logger logger, String msg) {
-        if (isInfoEnabled(logger)) {
+        if (logger.isInfoEnabled()) {
             logger.info(msg);
         }
     }
 
     @InlineMe(replacement = "logger.info(format, arg)")
     public static void info(Logger logger, String format, Object arg) {
-        if (isInfoEnabled(logger)) {
+        if (logger.isInfoEnabled()) {
             logger.info(format, arg);
         }
     }
 
     @InlineMe(replacement = "logger.info(format, arg1, arg2)")
     public static void info(Logger logger, String format, Object arg1, Object arg2) {
-        if (isInfoEnabled(logger)) {
+        if (logger.isInfoEnabled()) {
             logger.info(format, arg1, arg2);
         }
     }
 
     @InlineMe(replacement = "logger.info(format, arguments)")
     public static void info(Logger logger, String format, Object... arguments) {
-        if (isInfoEnabled(logger)) {
+        if (logger.isInfoEnabled()) {
             logger.info(format, arguments);
         }
     }
 
     @InlineMe(replacement = "logger.info(msg, t)")
     public static void info(Logger logger, String msg, Throwable t) {
-        if (isInfoEnabled(logger)) {
+        if (logger.isInfoEnabled()) {
             logger.info(msg, t);
         }
     }
@@ -178,35 +178,35 @@ public final class LogUtils {
 
     @InlineMe(replacement = "logger.warn(msg)")
     public static void warn(Logger logger, String msg) {
-        if (isWarnEnabled(logger)) {
+        if (logger.isWarnEnabled()) {
             logger.warn(msg);
         }
     }
 
     @InlineMe(replacement = "logger.warn(format, arg)")
     public static void warn(Logger logger, String format, Object arg) {
-        if (isWarnEnabled(logger)) {
+        if (logger.isWarnEnabled()) {
             logger.warn(format, arg);
         }
     }
 
     @InlineMe(replacement = "logger.warn(format, arg1, arg2)")
     public static void warn(Logger logger, String format, Object arg1, Object arg2) {
-        if (isWarnEnabled(logger)) {
+        if (logger.isWarnEnabled()) {
             logger.warn(format, arg1, arg2);
         }
     }
 
     @InlineMe(replacement = "logger.warn(format, arguments)")
     public static void warn(Logger logger, String format, Object... arguments) {
-        if (isWarnEnabled(logger)) {
+        if (logger.isWarnEnabled()) {
             logger.warn(format, arguments);
         }
     }
 
     @InlineMe(replacement = "logger.warn(msg, t)")
     public static void warn(Logger logger, String msg, Throwable t) {
-        if (isWarnEnabled(logger)) {
+        if (logger.isWarnEnabled()) {
             logger.warn(msg, t);
         }
     }
@@ -218,35 +218,35 @@ public final class LogUtils {
 
     @InlineMe(replacement = "logger.error(msg)")
     public static void error(Logger logger, String msg) {
-        if (isErrorEnabled(logger)) {
+        if (logger.isErrorEnabled()) {
             logger.error(msg);
         }
     }
 
     @InlineMe(replacement = "logger.error(format, arg)")
     public static void error(Logger logger, String format, Object arg) {
-        if (isErrorEnabled(logger)) {
+        if (logger.isErrorEnabled()) {
             logger.error(format, arg);
         }
     }
 
     @InlineMe(replacement = "logger.error(format, arg1, arg2)")
     public static void error(Logger logger, String format, Object arg1, Object arg2) {
-        if (isErrorEnabled(logger)) {
+        if (logger.isErrorEnabled()) {
             logger.error(format, arg1, arg2);
         }
     }
 
     @InlineMe(replacement = "logger.error(format, arguments)")
     public static void error(Logger logger, String format, Object... arguments) {
-        if (isErrorEnabled(logger)) {
+        if (logger.isErrorEnabled()) {
             logger.error(format, arguments);
         }
     }
 
     @InlineMe(replacement = "logger.error(msg, t)")
     public static void error(Logger logger, String msg, Throwable t) {
-        if (isErrorEnabled(logger)) {
+        if (logger.isErrorEnabled()) {
             logger.error(msg, t);
         }
     }

--- a/eventmesh-connectors/eventmesh-connector-jdbc/src/main/java/org/apache/eventmesh/connector/jdbc/connection/JdbcConnection.java
+++ b/eventmesh-connectors/eventmesh-connector-jdbc/src/main/java/org/apache/eventmesh/connector/jdbc/connection/JdbcConnection.java
@@ -17,7 +17,6 @@
 
 package org.apache.eventmesh.connector.jdbc.connection;
 
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.connector.jdbc.JdbcDriverMetaData;
 import org.apache.eventmesh.connector.jdbc.config.JdbcConfig;
 
@@ -182,7 +181,7 @@ public class JdbcConnection implements AutoCloseable {
         return execute(statement -> {
             for (String sqlStatement : sqlStatements) {
                 if (sqlStatement != null) {
-                    LogUtils.debug(log, "Executing '{}'", sqlStatement);
+                    log.debug("Executing '{}'", sqlStatement);
                     statement.execute(sqlStatement);
                 }
             }
@@ -220,7 +219,7 @@ public class JdbcConnection implements AutoCloseable {
 
         try (Statement statement = conn.createStatement()) {
             for (String sqlStatement : sqlStatements) {
-                LogUtils.debug(log, "Executing sql statement: {}", sqlStatement);
+                log.debug("Executing sql statement: {}", sqlStatement);
                 statement.execute(sqlStatement);
             }
         }
@@ -293,7 +292,7 @@ public class JdbcConnection implements AutoCloseable {
     public JdbcConnection query(String sql, StatementFactory statementFactory, JdbcResultSetConsumer resultConsumer) throws SQLException {
         Connection conn = connection();
         try (Statement statement = statementFactory.createStatement(conn)) {
-            LogUtils.debug(log, "Query sql '{}'", sql);
+            log.debug("Query sql '{}'", sql);
             try (ResultSet resultSet = statement.executeQuery(sql)) {
                 if (resultConsumer != null) {
                     resultConsumer.accept(resultSet);
@@ -331,7 +330,7 @@ public class JdbcConnection implements AutoCloseable {
     public <T> T query(String sql, StatementFactory statementFactory, ResultSetMapper<T> resultSetMapper) throws SQLException {
         Connection conn = connection();
         try (Statement statement = statementFactory.createStatement(conn)) {
-            LogUtils.debug(log, "Query sql '{}'", sql);
+            log.debug("Query sql '{}'", sql);
             try (ResultSet resultSet = statement.executeQuery(sql)) {
                 if (resultSetMapper != null) {
                     return resultSetMapper.map(resultSet);
@@ -374,7 +373,7 @@ public class JdbcConnection implements AutoCloseable {
 
         Connection conn = connection();
         try (PreparedStatement preparedStatement = preparedStatementFactory.createPreparedStatement(conn, sql)) {
-            LogUtils.debug(log, "Query sql '{}'", sql);
+            log.debug("Query sql '{}'", sql);
             if (preparedParameters != null) {
                 for (int index = 0; index < preparedParameters.length; ++index) {
                     final PreparedParameter preparedParameter = preparedParameters[index];
@@ -427,7 +426,7 @@ public class JdbcConnection implements AutoCloseable {
 
         Connection conn = connection();
         try (PreparedStatement preparedStatement = preparedStatementFactory.createPreparedStatement(conn, sql)) {
-            LogUtils.debug(log, "Query sql '{}'", sql);
+            log.debug("Query sql '{}'", sql);
             if (preparedParameters != null) {
                 for (int index = 0; index < preparedParameters.length; ++index) {
                     final PreparedParameter preparedParameter = preparedParameters[index];
@@ -568,9 +567,9 @@ public class JdbcConnection implements AutoCloseable {
             } else {
                 url = urlWithPlaceholder;
             }
-            LogUtils.debug(log, "URL: {}", url);
+            log.debug("URL: {}", url);
             Connection connection = DriverManager.getConnection(url, config.asProperties());
-            LogUtils.debug(log, "User [{}] Connected to {}", config.getUser(), url);
+            log.debug("User [{}] Connected to {}", config.getUser(), url);
             return connection;
         };
     }

--- a/eventmesh-connectors/eventmesh-connector-jdbc/src/main/java/org/apache/eventmesh/connector/jdbc/source/dialect/cdc/mysql/MysqlCdcEngine.java
+++ b/eventmesh-connectors/eventmesh-connector-jdbc/src/main/java/org/apache/eventmesh/connector/jdbc/source/dialect/cdc/mysql/MysqlCdcEngine.java
@@ -18,7 +18,6 @@
 package org.apache.eventmesh.connector.jdbc.source.dialect.cdc.mysql;
 
 import org.apache.eventmesh.common.EventMeshThreadFactory;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.connector.jdbc.DataChanges;
 import org.apache.eventmesh.connector.jdbc.DataChanges.Builder;
 import org.apache.eventmesh.connector.jdbc.Field;
@@ -424,7 +423,7 @@ public class MysqlCdcEngine extends AbstractCdcEngine<MysqlAntlr4DdlParser, Mysq
      * @param event   the event to be handled
      */
     protected void handleHeartbeatEvent(MysqlJdbcContext context, Event event) {
-        LogUtils.debug(log, "Replication client handle {}", event.getHeader().getEventType());
+        log.debug("Replication client handle {}", event.getHeader().getEventType());
     }
 
     /**
@@ -506,7 +505,7 @@ public class MysqlCdcEngine extends AbstractCdcEngine<MysqlAntlr4DdlParser, Mysq
         }
         String sqlBegin = sql.substring(0, 6).toUpperCase();
         if (StringUtils.startsWithAny(sqlBegin, "INSERT", "UPDATE", "DELETE")) {
-            LogUtils.warn(log, "Received DML '[SQL={}]' for processing, binlog probably contains events generated with statement", sql);
+            log.warn("Received DML '[SQL={}]' for processing, binlog probably contains events generated with statement", sql);
             return;
         }
 
@@ -732,7 +731,7 @@ public class MysqlCdcEngine extends AbstractCdcEngine<MysqlAntlr4DdlParser, Mysq
     protected void handleGtidEvent(MysqlJdbcContext context, Event event) {
         GtidEventData gtidEvent = unwrapData(event);
         String gtid = gtidEvent.getMySqlGtid().toString();
-        LogUtils.debug(log, "Received GTID event: {}", gtid);
+        log.debug("Received GTID event: {}", gtid);
         localGtidSet.add(gtid);
         context.beginGtid(gtid);
     }

--- a/eventmesh-connectors/eventmesh-connector-jdbc/src/main/java/org/apache/eventmesh/connector/jdbc/source/dialect/mysql/MysqlDatabaseDialect.java
+++ b/eventmesh-connectors/eventmesh-connector-jdbc/src/main/java/org/apache/eventmesh/connector/jdbc/source/dialect/mysql/MysqlDatabaseDialect.java
@@ -17,7 +17,6 @@
 
 package org.apache.eventmesh.connector.jdbc.source.dialect.mysql;
 
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.connector.jdbc.DataTypeConvertor;
 import org.apache.eventmesh.connector.jdbc.JdbcDriverMetaData;
 import org.apache.eventmesh.connector.jdbc.connection.mysql.MysqlJdbcConnection;
@@ -138,7 +137,7 @@ public class MysqlDatabaseDialect extends AbstractGeneralDatabaseDialect<MysqlJd
 
         // Build the SQL query to return a list of tables for the given database
         String sql = MysqlDialectSql.SHOW_DATABASE_TABLE.ofWrapperSQL("`" + databaseName + "`");
-        LogUtils.debug(log, "List tables SQL:{}", sql);
+        log.debug("List tables SQL:{}", sql);
         this.connection.query(sql, resultSet -> {
             // Execute the query and add each table ID to the list
             while (resultSet.next()) {
@@ -173,7 +172,7 @@ public class MysqlDatabaseDialect extends AbstractGeneralDatabaseDialect<MysqlJd
 
         // Get table creation SQL
         final String createTableSql = MysqlDialectSql.SHOW_CREATE_TABLE.ofWrapperSQL(tableId.getId());
-        LogUtils.debug(log, "Show create table SQL:{}", createTableSql);
+        log.debug("Show create table SQL:{}", createTableSql);
 
         this.connection.query(createTableSql, resultSet -> {
             boolean hasNext = resultSet.next();
@@ -186,7 +185,7 @@ public class MysqlDatabaseDialect extends AbstractGeneralDatabaseDialect<MysqlJd
 
         // Get table columns SQL
         final String selectTableSql = MysqlDialectSql.SELECT_TABLE_COLUMNS.ofWrapperSQL(tableId.getId());
-        LogUtils.debug(log, "Select table SQL:{}", selectTableSql);
+        log.debug("Select table SQL:{}", selectTableSql);
         Map<String, DefaultColumn> columns = new HashMap<>(16);
         // Execute query to get table columns
         this.connection.query(selectTableSql, resultSet -> {
@@ -210,7 +209,7 @@ public class MysqlDatabaseDialect extends AbstractGeneralDatabaseDialect<MysqlJd
 
         // Get table columns details SQL
         final String showTableSql = MysqlDialectSql.SHOW_TABLE_COLUMNS.ofWrapperSQL(tableId.getTableName(), tableId.getCatalogName());
-        LogUtils.debug(log, "Show table columns SQL:{}", showTableSql);
+        log.debug("Show table columns SQL:{}", showTableSql);
         // Execute query to get table columns details
         List<DefaultColumn> columnList = new ArrayList<>(columns.size());
         this.connection.query(showTableSql, resultSet -> {

--- a/eventmesh-connectors/eventmesh-connector-lark/src/main/java/org/apache/eventmesh/connector/lark/server/LarkConnectServer.java
+++ b/eventmesh-connectors/eventmesh-connector-lark/src/main/java/org/apache/eventmesh/connector/lark/server/LarkConnectServer.java
@@ -28,7 +28,7 @@ public class LarkConnectServer {
     public static void main(String[] args) throws Exception {
 
         LarkConnectServerConfig larkConnectServerConfig = ConfigUtil.parse(LarkConnectServerConfig.class,
-                Constants.CONNECT_SERVER_CONFIG_FILE_NAME);
+            Constants.CONNECT_SERVER_CONFIG_FILE_NAME);
 
         if (larkConnectServerConfig.isSinkEnable()) {
             Application application = new Application();

--- a/eventmesh-connectors/eventmesh-connector-lark/src/main/java/org/apache/eventmesh/connector/lark/sink/ImServiceHandler.java
+++ b/eventmesh-connectors/eventmesh-connector-lark/src/main/java/org/apache/eventmesh/connector/lark/sink/ImServiceHandler.java
@@ -93,14 +93,13 @@ public class ImServiceHandler {
         ImServiceHandler imServiceHandler = new ImServiceHandler();
         imServiceHandler.sinkConnectorConfig = sinkConnectorConfig;
         imServiceHandler.imService = Client.newBuilder(sinkConnectorConfig.getAppId(), sinkConnectorConfig.getAppSecret())
-                .httpTransport(new OkHttpTransport(new OkHttpClient().newBuilder()
-                        .callTimeout(3L, TimeUnit.SECONDS)
-                        .build())
-                )
-                .disableTokenCache()
-                .requestTimeout(3, TimeUnit.SECONDS)
-                .build()
-                .im();
+            .httpTransport(new OkHttpTransport(new OkHttpClient().newBuilder()
+                .callTimeout(3L, TimeUnit.SECONDS)
+                .build()))
+            .disableTokenCache()
+            .requestTimeout(3, TimeUnit.SECONDS)
+            .build()
+            .im();
 
         long fixedWait = Long.parseLong(sinkConnectorConfig.getRetryDelayInMills());
         int maxRetryTimes = Integer.parseInt(sinkConnectorConfig.getMaxRetryTimes()) + 1;
@@ -128,24 +127,25 @@ public class ImServiceHandler {
             });
         } else {
             imServiceHandler.retryer = RetryerBuilder.<ConnectRecord>newBuilder()
-                    .retryIfException()
-                    .retryIfResult(Objects::nonNull)
-                    .withWaitStrategy(WaitStrategies.fixedWait(fixedWait, TimeUnit.MILLISECONDS))
-                    .withStopStrategy(StopStrategies.stopAfterAttempt(maxRetryTimes))
-                    .withRetryListener(new RetryListener() {
-                        @SneakyThrows
-                        @Override
-                        public <V> void onRetry(Attempt<V> attempt) {
+                .retryIfException()
+                .retryIfResult(Objects::nonNull)
+                .withWaitStrategy(WaitStrategies.fixedWait(fixedWait, TimeUnit.MILLISECONDS))
+                .withStopStrategy(StopStrategies.stopAfterAttempt(maxRetryTimes))
+                .withRetryListener(new RetryListener() {
 
-                            long times = attempt.getAttemptNumber();
-                            if (times > 1) {
-                                redoSinkNum.increment();
-                                log.info("Total redo sink task num : [{}]", redoSinkNum.sum());
-                                log.warn("Retry sink event to lark | times=[{}]", attempt.getAttemptNumber() - 1);
-                            }
+                    @SneakyThrows
+                    @Override
+                    public <V> void onRetry(Attempt<V> attempt) {
+
+                        long times = attempt.getAttemptNumber();
+                        if (times > 1) {
+                            redoSinkNum.increment();
+                            log.info("Total redo sink task num : [{}]", redoSinkNum.sum());
+                            log.warn("Retry sink event to lark | times=[{}]", attempt.getAttemptNumber() - 1);
                         }
-                    })
-                    .build();
+                    }
+                })
+                .build();
         }
 
         return imServiceHandler;
@@ -156,9 +156,9 @@ public class ImServiceHandler {
         headers.put("Content-Type", Lists.newArrayList("application/json; charset=utf-8"));
 
         RequestOptions requestOptions = RequestOptions.newBuilder()
-                .tenantAccessToken(getTenantAccessToken(sinkConnectorConfig.getAppId(), sinkConnectorConfig.getAppSecret()))
-                .headers(headers)
-                .build();
+            .tenantAccessToken(getTenantAccessToken(sinkConnectorConfig.getAppId(), sinkConnectorConfig.getAppSecret()))
+            .headers(headers)
+            .build();
 
         retryer.call(() -> {
             CreateMessageReq createMessageReq = convertCreateMessageReq(connectRecord);
@@ -176,9 +176,9 @@ public class ImServiceHandler {
         headers.put("Content-Type", Lists.newArrayList("application/json; charset=utf-8"));
 
         RequestOptions requestOptions = RequestOptions.newBuilder()
-                .tenantAccessToken(getTenantAccessToken(sinkConnectorConfig.getAppId(), sinkConnectorConfig.getAppSecret()))
-                .headers(headers)
-                .build();
+            .tenantAccessToken(getTenantAccessToken(sinkConnectorConfig.getAppId(), sinkConnectorConfig.getAppSecret()))
+            .headers(headers)
+            .build();
 
         CreateMessageReq createMessageReq = convertCreateMessageReq(connectRecord);
 
@@ -187,30 +187,30 @@ public class ImServiceHandler {
         LongAdder cnt = new LongAdder();
         AtomicBoolean isAck = new AtomicBoolean(false);
         Runnable task = () -> CompletableFuture
-                .supplyAsync(() -> {
-                    try {
-                        cnt.increment();
-                        return imService.message().create(createMessageReq, requestOptions);
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-                }, sinkAsyncWorker)
-                .whenCompleteAsync((resp, e) -> {
-                    if (cnt.sum() > 1) {
-                        redoSinkNum.increment();
-                        log.info("Total redo sink task num : [{}]", redoSinkNum.sum());
-                        log.warn("Retry sink event to lark | times=[{}]", cnt.sum() - 1);
-                    }
-                    if (Objects.nonNull(e)) {
-                        log.error("eventmesh-connector-lark internal exception.", e);
-                        return;
-                    }
-                    if (resp.getCode() != 0) {
-                        log.warn("Sinking event to lark failure | code:[{}] | msg:[{}] | err:[{}]", resp.getCode(), resp.getMsg(), resp.getError());
-                        return;
-                    }
-                    isAck.set(true);
-                });
+            .supplyAsync(() -> {
+                try {
+                    cnt.increment();
+                    return imService.message().create(createMessageReq, requestOptions);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }, sinkAsyncWorker)
+            .whenCompleteAsync((resp, e) -> {
+                if (cnt.sum() > 1) {
+                    redoSinkNum.increment();
+                    log.info("Total redo sink task num : [{}]", redoSinkNum.sum());
+                    log.warn("Retry sink event to lark | times=[{}]", cnt.sum() - 1);
+                }
+                if (Objects.nonNull(e)) {
+                    log.error("eventmesh-connector-lark internal exception.", e);
+                    return;
+                }
+                if (resp.getCode() != 0) {
+                    log.warn("Sinking event to lark failure | code:[{}] | msg:[{}] | err:[{}]", resp.getCode(), resp.getMsg(), resp.getError());
+                    return;
+                }
+                isAck.set(true);
+            });
 
         ScheduledFuture<?> future = retryWorker.scheduleAtFixedRate(task, 0L, fixedWait, TimeUnit.MILLISECONDS);
         cleanerWorker.submit(() -> {
@@ -226,8 +226,8 @@ public class ImServiceHandler {
 
     private CreateMessageReq convertCreateMessageReq(ConnectRecord connectRecord) {
         CreateMessageReqBody.Builder bodyBuilder = CreateMessageReqBody.newBuilder()
-                .receiveId(sinkConnectorConfig.getReceiveId())
-                .uuid(UUID.randomUUID().toString());
+            .receiveId(sinkConnectorConfig.getReceiveId())
+            .uuid(UUID.randomUUID().toString());
 
         String templateTypeKey = connectRecord.getExtension(ConnectRecordExtensionKeys.TEMPLATE_TYPE_4_LARK);
         if (null == templateTypeKey || "null".equals(templateTypeKey)) {
@@ -236,18 +236,18 @@ public class ImServiceHandler {
         LarkMessageTemplateType templateType = LarkMessageTemplateType.of(templateTypeKey);
         if (LarkMessageTemplateType.PLAIN_TEXT == templateType) {
             bodyBuilder.content(createTextContent(connectRecord))
-                    .msgType(MsgTypeEnum.MSG_TYPE_TEXT.getValue());
+                .msgType(MsgTypeEnum.MSG_TYPE_TEXT.getValue());
         } else if (LarkMessageTemplateType.MARKDOWN == templateType) {
             String title = Optional.ofNullable(connectRecord.getExtension(ConnectRecordExtensionKeys.MARKDOWN_MESSAGE_TITLE_4_LARK))
-                    .orElse("EventMesh-Message");
+                .orElse("EventMesh-Message");
             bodyBuilder.content(createInteractiveContent(connectRecord, title))
-                    .msgType(MsgTypeEnum.MSG_TYPE_INTERACTIVE.getValue());
+                .msgType(MsgTypeEnum.MSG_TYPE_INTERACTIVE.getValue());
         }
 
         return CreateMessageReq.newBuilder()
-                .receiveIdType(sinkConnectorConfig.getReceiveIdType())
-                .createMessageReqBody(bodyBuilder.build())
-                .build();
+            .receiveIdType(sinkConnectorConfig.getReceiveIdType())
+            .createMessageReqBody(bodyBuilder.build())
+            .build();
     }
 
     private String createTextContent(ConnectRecord connectRecord) {
@@ -287,26 +287,26 @@ public class ImServiceHandler {
         sb.append(new String((byte[]) connectRecord.getData()));
 
         MessageCardConfig config = MessageCardConfig.newBuilder()
-                .enableForward(true)
-                .wideScreenMode(true)
-                .updateMulti(true)
-                .build();
+            .enableForward(true)
+            .wideScreenMode(true)
+            .updateMulti(true)
+            .build();
 
         // header
         MessageCardHeader header = MessageCardHeader.newBuilder()
-                .template(MessageCardHeaderTemplateEnum.BLUE)
-                .title(MessageCardPlainText.newBuilder()
-                        .content(title)
-                        .build())
-                .build();
+            .template(MessageCardHeaderTemplateEnum.BLUE)
+            .title(MessageCardPlainText.newBuilder()
+                .content(title)
+                .build())
+            .build();
 
         MessageCard content = MessageCard.newBuilder()
-                .config(config)
-                .header(header)
-                .elements(new MessageCardElement[]{
-                        MessageCardMarkdown.newBuilder().content(sb.toString()).build()
-                })
-                .build();
+            .config(config)
+            .header(header)
+            .elements(new MessageCardElement[]{
+                    MessageCardMarkdown.newBuilder().content(sb.toString()).build()
+            })
+            .build();
 
         return content.String();
     }
@@ -328,7 +328,7 @@ public class ImServiceHandler {
      */
     private void atAll(StringBuilder sb) {
         sb.append("<at id=all>")
-                .append("</at>");
+            .append("</at>");
     }
 
     /**
@@ -339,8 +339,8 @@ public class ImServiceHandler {
      */
     private void atUser(StringBuilder sb, String userId) {
         sb.append("<at id=")
-                .append(userId)
-                .append(">")
-                .append("</at>");
+            .append(userId)
+            .append(">")
+            .append("</at>");
     }
 }

--- a/eventmesh-connectors/eventmesh-connector-lark/src/main/java/org/apache/eventmesh/connector/lark/sink/config/SinkConnectorConfig.java
+++ b/eventmesh-connectors/eventmesh-connector-lark/src/main/java/org/apache/eventmesh/connector/lark/sink/config/SinkConnectorConfig.java
@@ -70,12 +70,12 @@ public class SinkConnectorConfig {
 
         // validate receiveIdType
         if (!StringUtils.containsAny(receiveIdType, ReceiveIdTypeEnum.CHAT_ID.getValue(),
-                ReceiveIdTypeEnum.EMAIL.getValue(),
-                ReceiveIdTypeEnum.OPEN_ID.getValue(),
-                ReceiveIdTypeEnum.USER_ID.getValue(),
-                ReceiveIdTypeEnum.UNION_ID.getValue())) {
+            ReceiveIdTypeEnum.EMAIL.getValue(),
+            ReceiveIdTypeEnum.OPEN_ID.getValue(),
+            ReceiveIdTypeEnum.USER_ID.getValue(),
+            ReceiveIdTypeEnum.UNION_ID.getValue())) {
             throw new IllegalArgumentException(
-                    String.format("sinkConnectorConfig.receiveIdType=[%s], Invalid.", receiveIdType));
+                String.format("sinkConnectorConfig.receiveIdType=[%s], Invalid.", receiveIdType));
         }
     }
 }

--- a/eventmesh-connectors/eventmesh-connector-lark/src/main/java/org/apache/eventmesh/connector/lark/sink/connector/LarkSinkConnector.java
+++ b/eventmesh-connectors/eventmesh-connector-lark/src/main/java/org/apache/eventmesh/connector/lark/sink/connector/LarkSinkConnector.java
@@ -44,7 +44,6 @@ import com.lark.oapi.core.response.TenantAccessTokenResp;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
-
 @Slf4j
 public class LarkSinkConnector implements Sink {
 
@@ -60,11 +59,11 @@ public class LarkSinkConnector implements Sink {
      * you can try to modify it.
      */
     public static final Cache<String, String> AUTH_CACHE = CacheBuilder.newBuilder()
-            .initialCapacity(12)
-            .maximumSize(10)
-            .concurrencyLevel(5)
-            .expireAfterWrite(30, TimeUnit.MINUTES)
-            .build();
+        .initialCapacity(12)
+        .maximumSize(10)
+        .concurrencyLevel(5)
+        .expireAfterWrite(30, TimeUnit.MINUTES)
+        .build();
 
     private LarkSinkConfig sinkConfig;
 
@@ -78,7 +77,8 @@ public class LarkSinkConnector implements Sink {
     }
 
     @Override
-    public void init(Config config) {}
+    public void init(Config config) {
+    }
 
     @Override
     public void init(ConnectorContext connectorContext) {
@@ -136,15 +136,15 @@ public class LarkSinkConnector implements Sink {
         return AUTH_CACHE.get(TENANT_ACCESS_TOKEN, () -> {
 
             Client client = Client.newBuilder(appId, appSecret)
-                    .appType(AppType.SELF_BUILT)
-                    .logReqAtDebug(true)
-                    .build();
+                .appType(AppType.SELF_BUILT)
+                .logReqAtDebug(true)
+                .build();
 
             TenantAccessTokenResp resp = client.ext().getTenantAccessTokenBySelfBuiltApp(
-                    SelfBuiltTenantAccessTokenReq.newBuilder()
-                            .appSecret(appSecret)
-                            .appId(appId)
-                            .build());
+                SelfBuiltTenantAccessTokenReq.newBuilder()
+                    .appSecret(appSecret)
+                    .appId(appId)
+                    .build());
             return resp.getTenantAccessToken();
         });
     }

--- a/eventmesh-connectors/eventmesh-connector-lark/src/test/java/org/apache/eventmesh/connector/lark/sink/ImServiceHandlerTest.java
+++ b/eventmesh-connectors/eventmesh-connector-lark/src/test/java/org/apache/eventmesh/connector/lark/sink/ImServiceHandlerTest.java
@@ -80,8 +80,8 @@ public class ImServiceHandlerTest {
         when(message.create(any(), any())).thenReturn(new CreateMessageResp());
         when(imService.message()).thenReturn(message);
         Field imServiceField = ReflectionSupport.findFields(imServiceHandler.getClass(),
-                (f) -> f.getName().equals("imService"),
-                HierarchyTraversalMode.BOTTOM_UP).get(0);
+            (f) -> f.getName().equals("imService"),
+            HierarchyTraversalMode.BOTTOM_UP).get(0);
         imServiceField.setAccessible(true);
         imServiceField.set(imServiceHandler, imService);
     }
@@ -106,7 +106,7 @@ public class ImServiceHandlerTest {
             RecordPartition partition = new RecordPartition();
             RecordOffset offset = new RecordOffset();
             ConnectRecord connectRecord = new ConnectRecord(partition, offset,
-                    System.currentTimeMillis(), "test-lark".getBytes(StandardCharsets.UTF_8));
+                System.currentTimeMillis(), "test-lark".getBytes(StandardCharsets.UTF_8));
             if (Boolean.parseBoolean(sinkConnectorConfig.getSinkAsync())) {
                 imServiceHandler.sinkAsync(connectRecord);
                 long retryDelayInMills = Long.parseLong(sinkConnectorConfig.getRetryDelayInMills());
@@ -148,7 +148,7 @@ public class ImServiceHandlerTest {
             RecordPartition partition = new RecordPartition();
             RecordOffset offset = new RecordOffset();
             ConnectRecord connectRecord = new ConnectRecord(partition, offset,
-                    System.currentTimeMillis(), "test-lark".getBytes(StandardCharsets.UTF_8));
+                System.currentTimeMillis(), "test-lark".getBytes(StandardCharsets.UTF_8));
             if (Boolean.parseBoolean(sinkConnectorConfig.getSinkAsync())) {
                 imServiceHandler.sinkAsync(connectRecord);
 

--- a/eventmesh-connectors/eventmesh-connector-lark/src/test/java/org/apache/eventmesh/connector/lark/sink/LarkSinkConnectorTest.java
+++ b/eventmesh-connectors/eventmesh-connector-lark/src/test/java/org/apache/eventmesh/connector/lark/sink/LarkSinkConnectorTest.java
@@ -85,7 +85,7 @@ public class LarkSinkConnectorTest {
             RecordPartition partition = new RecordPartition();
             RecordOffset offset = new RecordOffset();
             ConnectRecord connectRecord = new ConnectRecord(partition, offset,
-                    System.currentTimeMillis(), "test-lark".getBytes(StandardCharsets.UTF_8));
+                System.currentTimeMillis(), "test-lark".getBytes(StandardCharsets.UTF_8));
             connectRecords.add(connectRecord);
         }
         larkSinkConnector.put(connectRecords);

--- a/eventmesh-connectors/eventmesh-connector-wechat/src/test/java/org/apache/eventmesh/connector/wechat/sink/connector/WeChatSinkConnectorTest.java
+++ b/eventmesh-connectors/eventmesh-connector-wechat/src/test/java/org/apache/eventmesh/connector/wechat/sink/connector/WeChatSinkConnectorTest.java
@@ -55,8 +55,6 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
-
-
 @ExtendWith(MockitoExtension.class)
 public class WeChatSinkConnectorTest {
 
@@ -106,8 +104,8 @@ public class WeChatSinkConnectorTest {
             .body(sendMessageBody)
             .message("ok")
             .build();
-        ArgumentMatcher<Request> sendMessageMatcher = (anyRequest) ->
-            sendMessageRequest.url().encodedPath().startsWith(anyRequest.url().encodedPath());
+        ArgumentMatcher<Request> sendMessageMatcher =
+            (anyRequest) -> sendMessageRequest.url().encodedPath().startsWith(anyRequest.url().encodedPath());
         Call sendMessageRequestCall = Mockito.mock(Call.class);
         Mockito.doReturn(sendMessageRequestCall).when(okHttpClient).newCall(Mockito.argThat(sendMessageMatcher));
         Mockito.doReturn(sendMessageResponse).when(sendMessageRequestCall).execute();
@@ -137,8 +135,8 @@ public class WeChatSinkConnectorTest {
             .body(sendMessageBody)
             .message("ok")
             .build();
-        ArgumentMatcher<Request> sendMessageMatcher = (anyRequest) ->
-            sendMessageRequest.url().encodedPath().startsWith(anyRequest.url().encodedPath());
+        ArgumentMatcher<Request> sendMessageMatcher =
+            (anyRequest) -> sendMessageRequest.url().encodedPath().startsWith(anyRequest.url().encodedPath());
         Call sendMessageRequestCall = Mockito.mock(Call.class);
         Mockito.doReturn(sendMessageRequestCall).when(okHttpClient).newCall(Mockito.argThat(sendMessageMatcher));
         Mockito.doReturn(sendMessageResponse).when(sendMessageRequestCall).execute();

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/pub/eventmeshmessage/WorkflowAsyncPublishInstance.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/pub/eventmeshmessage/WorkflowAsyncPublishInstance.java
@@ -24,7 +24,6 @@ import org.apache.eventmesh.client.workflow.config.EventMeshWorkflowClientConfig
 import org.apache.eventmesh.common.ExampleConstants;
 import org.apache.eventmesh.common.protocol.workflow.protos.ExecuteRequest;
 import org.apache.eventmesh.common.protocol.workflow.protos.ExecuteResponse;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.grpc.GrpcAbstractDemo;
 import org.apache.eventmesh.selector.NacosSelector;
@@ -66,7 +65,7 @@ public class WorkflowAsyncPublishInstance extends GrpcAbstractDemo {
             EventMeshWorkflowClient eventMeshWorkflowClient = new EventMeshWorkflowClient(eventMeshWorkflowClientConfig);
             ExecuteResponse response = eventMeshWorkflowClient.getWorkflowClient().execute(executeRequest.build());
 
-            LogUtils.info(log, "received response: {}", response.toString());
+            log.info("received response: {}", response.toString());
 
             ThreadUtils.sleep(1, TimeUnit.MINUTES);
 

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/CloudEventsAsyncSubscribe.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/CloudEventsAsyncSubscribe.java
@@ -24,7 +24,6 @@ import org.apache.eventmesh.common.enums.EventMeshProtocolType;
 import org.apache.eventmesh.common.protocol.SubscriptionItem;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.grpc.GrpcAbstractDemo;
 
@@ -62,7 +61,7 @@ public class CloudEventsAsyncSubscribe extends GrpcAbstractDemo implements Recei
 
     @Override
     public Optional<CloudEvent> handle(final CloudEvent msg) {
-        LogUtils.info(log, "receive async msg: {}", msg);
+        log.info("receive async msg: {}", msg);
         return Optional.empty();
     }
 

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/CloudEventsSubscribeReply.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/CloudEventsSubscribeReply.java
@@ -24,7 +24,6 @@ import org.apache.eventmesh.common.enums.EventMeshProtocolType;
 import org.apache.eventmesh.common.protocol.SubscriptionItem;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.grpc.GrpcAbstractDemo;
 
@@ -63,7 +62,7 @@ public class CloudEventsSubscribeReply extends GrpcAbstractDemo implements Recei
 
     @Override
     public Optional<CloudEvent> handle(final CloudEvent msg) {
-        LogUtils.info(log, "receive request-reply msg: {}", msg);
+        log.info("receive request-reply msg: {}", msg);
 
         if (msg != null) {
             return Optional.of(msg);

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/EventMeshAsyncSubscribe.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/EventMeshAsyncSubscribe.java
@@ -25,7 +25,6 @@ import org.apache.eventmesh.common.enums.EventMeshProtocolType;
 import org.apache.eventmesh.common.protocol.SubscriptionItem;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.grpc.GrpcAbstractDemo;
 
@@ -61,7 +60,7 @@ public class EventMeshAsyncSubscribe extends GrpcAbstractDemo implements Receive
 
     @Override
     public Optional<EventMeshMessage> handle(final EventMeshMessage msg) {
-        LogUtils.info(log, "receive async msg: {}", msg);
+        log.info("receive async msg: {}", msg);
         return Optional.empty();
     }
 

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/EventMeshSubscribeBroadcast.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/EventMeshSubscribeBroadcast.java
@@ -25,7 +25,6 @@ import org.apache.eventmesh.common.enums.EventMeshProtocolType;
 import org.apache.eventmesh.common.protocol.SubscriptionItem;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.grpc.GrpcAbstractDemo;
 
@@ -62,7 +61,7 @@ public class EventMeshSubscribeBroadcast extends GrpcAbstractDemo implements Rec
 
     @Override
     public Optional<EventMeshMessage> handle(final EventMeshMessage msg) {
-        LogUtils.info(log, "receive async broadcast msg: {}", msg);
+        log.info("receive async broadcast msg: {}", msg);
         return Optional.empty();
     }
 

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/EventMeshSubscribeReply.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/EventMeshSubscribeReply.java
@@ -25,7 +25,6 @@ import org.apache.eventmesh.common.enums.EventMeshProtocolType;
 import org.apache.eventmesh.common.protocol.SubscriptionItem;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.grpc.GrpcAbstractDemo;
 
@@ -61,7 +60,7 @@ public class EventMeshSubscribeReply extends GrpcAbstractDemo implements Receive
 
     @Override
     public Optional<EventMeshMessage> handle(final EventMeshMessage msg) {
-        LogUtils.info(log, "receive request-reply msg: {}", msg);
+        log.info("receive request-reply msg: {}", msg);
         if (msg != null) {
             return Optional.of(msg);
         } else {

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/WorkflowExpressAsyncSubscribe.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/WorkflowExpressAsyncSubscribe.java
@@ -29,7 +29,6 @@ import org.apache.eventmesh.common.ExampleConstants;
 import org.apache.eventmesh.common.enums.EventMeshProtocolType;
 import org.apache.eventmesh.common.protocol.workflow.protos.ExecuteRequest;
 import org.apache.eventmesh.common.protocol.workflow.protos.ExecuteResponse;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.grpc.GrpcAbstractDemo;
 import org.apache.eventmesh.selector.NacosSelector;
@@ -81,7 +80,7 @@ public class WorkflowExpressAsyncSubscribe extends GrpcAbstractDemo implements R
 
     @Override
     public Optional<EventMeshMessage> handle(final EventMeshMessage msg) throws Exception {
-        LogUtils.info(log, "receive async msg: {}", msg);
+        log.info("receive async msg: {}", msg);
         if (msg == null) {
             log.info("async msg is null, workflow end.");
             return Optional.empty();
@@ -95,7 +94,7 @@ public class WorkflowExpressAsyncSubscribe extends GrpcAbstractDemo implements R
             .setTaskInstanceId(taskInstanceId)
             .setInstanceId(workflowInstanceId).build();
         final ExecuteResponse response = workflowClient.getWorkflowClient().execute(executeRequest);
-        LogUtils.info(log, "receive workflow msg: {}", response.getInstanceId());
+        log.info("receive workflow msg: {}", response.getInstanceId());
         return Optional.empty();
     }
 

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/WorkflowOrderAsyncSubscribe.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/WorkflowOrderAsyncSubscribe.java
@@ -29,7 +29,6 @@ import org.apache.eventmesh.common.ExampleConstants;
 import org.apache.eventmesh.common.enums.EventMeshProtocolType;
 import org.apache.eventmesh.common.protocol.workflow.protos.ExecuteRequest;
 import org.apache.eventmesh.common.protocol.workflow.protos.ExecuteResponse;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.grpc.GrpcAbstractDemo;
 import org.apache.eventmesh.selector.NacosSelector;
@@ -81,7 +80,7 @@ public class WorkflowOrderAsyncSubscribe extends GrpcAbstractDemo implements Rec
 
     @Override
     public Optional<EventMeshMessage> handle(final EventMeshMessage msg) throws Exception {
-        LogUtils.info(log, "receive async msg: {}", msg);
+        log.info("receive async msg: {}", msg);
 
         final Map<String, String> props = msg.getProp();
         final String workflowInstanceId = props.get("workflowinstanceid");
@@ -91,7 +90,7 @@ public class WorkflowOrderAsyncSubscribe extends GrpcAbstractDemo implements Rec
             .setTaskInstanceId(taskInstanceId)
             .setInstanceId(workflowInstanceId).build();
         final ExecuteResponse response = workflowClient.getWorkflowClient().execute(executeRequest);
-        LogUtils.info(log, "receive workflow msg: {}", response.getInstanceId());
+        log.info("receive workflow msg: {}", response.getInstanceId());
         return Optional.empty();
     }
 

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/WorkflowPaymentAsyncSubscribe.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/WorkflowPaymentAsyncSubscribe.java
@@ -29,7 +29,6 @@ import org.apache.eventmesh.common.ExampleConstants;
 import org.apache.eventmesh.common.enums.EventMeshProtocolType;
 import org.apache.eventmesh.common.protocol.workflow.protos.ExecuteRequest;
 import org.apache.eventmesh.common.protocol.workflow.protos.ExecuteResponse;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.grpc.GrpcAbstractDemo;
 import org.apache.eventmesh.selector.NacosSelector;
@@ -81,7 +80,7 @@ public class WorkflowPaymentAsyncSubscribe extends GrpcAbstractDemo implements R
 
     @Override
     public Optional<EventMeshMessage> handle(final EventMeshMessage msg) throws Exception {
-        LogUtils.info(log, "receive async msg: {}", msg);
+        log.info("receive async msg: {}", msg);
         if (msg == null) {
             log.info("async msg is null, workflow end.");
             return Optional.empty();
@@ -95,7 +94,7 @@ public class WorkflowPaymentAsyncSubscribe extends GrpcAbstractDemo implements R
             .setTaskInstanceId(taskInstanceId)
             .setInstanceId(workflowInstanceId).build();
         final ExecuteResponse response = workflowClient.getWorkflowClient().execute(executeRequest);
-        LogUtils.info(log, "receive workflow msg: {}", response.getInstanceId());
+        log.info("receive workflow msg: {}", response.getInstanceId());
         return Optional.empty();
     }
 

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/app/controller/SubController.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/app/controller/SubController.java
@@ -18,7 +18,6 @@
 package org.apache.eventmesh.grpc.sub.app.controller;
 
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.grpc.sub.app.service.SubService;
 
 import java.util.HashMap;
@@ -44,7 +43,7 @@ public class SubController {
     @RequestMapping(value = "/test", method = RequestMethod.POST)
     public String subTest(final HttpServletRequest request) {
         final String content = request.getParameter("content");
-        LogUtils.info(log, "=======receive message======= {}", content);
+        log.info("=======receive message======= {}", content);
 
         subService.consumeMessage(content);
 

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/app/service/SubService.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/grpc/sub/app/service/SubService.java
@@ -29,7 +29,6 @@ import org.apache.eventmesh.common.ExampleConstants;
 import org.apache.eventmesh.common.protocol.SubscriptionItem;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.grpc.pub.eventmeshmessage.AsyncPublishInstance;
 import org.apache.eventmesh.util.Utils;
 
@@ -96,11 +95,11 @@ public class SubService implements InitializingBean {
             try {
                 countDownLatch.await();
             } catch (InterruptedException e) {
-                LogUtils.warn(log, "exception occurred when countDownLatch.await ", e);
+                log.warn("exception occurred when countDownLatch.await ", e);
                 Thread.currentThread().interrupt();
             }
 
-            LogUtils.info(log, "stopThread start....");
+            log.info("stopThread start....");
 
         });
 
@@ -109,7 +108,7 @@ public class SubService implements InitializingBean {
 
     @PreDestroy
     public void cleanup() {
-        LogUtils.info(log, "start destroy....");
+        log.info("start destroy....");
 
         try {
             eventMeshGrpcConsumer.unsubscribe(Collections.singletonList(subscriptionItem), url);
@@ -122,15 +121,15 @@ public class SubService implements InitializingBean {
             log.error("exception occurred when close consumer ", e);
         }
 
-        LogUtils.info(log, "end destroy....");
+        log.info("end destroy....");
     }
 
     /**
      * Count the message already consumed
      */
     public void consumeMessage(final String msg) {
-        LogUtils.info(log, "consume message: {}", msg);
+        log.info("consume message: {}", msg);
         countDownLatch.countDown();
-        LogUtils.info(log, "remaining number of messages to be consumed: {}", countDownLatch.getCount());
+        log.info("remaining number of messages to be consumed: {}", countDownLatch.getCount());
     }
 }

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/http/demo/pub/eventmeshmessage/AsyncSyncRequestInstance.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/http/demo/pub/eventmeshmessage/AsyncSyncRequestInstance.java
@@ -21,7 +21,6 @@ import org.apache.eventmesh.client.http.producer.EventMeshHttpProducer;
 import org.apache.eventmesh.client.http.producer.RRCallback;
 import org.apache.eventmesh.common.EventMeshMessage;
 import org.apache.eventmesh.common.ExampleConstants;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.RandomStringUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.http.demo.HttpAbstractDemo;
@@ -48,13 +47,13 @@ public class AsyncSyncRequestInstance extends HttpAbstractDemo {
 
                 @Override
                 public void onSuccess(final EventMeshMessage o) {
-                    LogUtils.debug(log, "sendmsg: {}, return: {}, cost: {} ms", eventMeshMessage.getContent(), o.getContent(),
+                    log.debug("sendmsg: {}, return: {}, cost: {} ms", eventMeshMessage.getContent(), o.getContent(),
                         System.currentTimeMillis() - startTime);
                 }
 
                 @Override
                 public void onException(Throwable e) {
-                    LogUtils.debug(log, "send msg failed", e);
+                    log.debug("send msg failed", e);
                 }
             }, 3_000);
 

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/http/demo/pub/eventmeshmessage/SyncRequestInstance.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/http/demo/pub/eventmeshmessage/SyncRequestInstance.java
@@ -20,7 +20,6 @@ package org.apache.eventmesh.http.demo.pub.eventmeshmessage;
 import org.apache.eventmesh.client.http.producer.EventMeshHttpProducer;
 import org.apache.eventmesh.common.EventMeshMessage;
 import org.apache.eventmesh.common.ExampleConstants;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.RandomStringUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.http.demo.HttpAbstractDemo;
@@ -48,7 +47,7 @@ public class SyncRequestInstance extends HttpAbstractDemo {
                 .build();
 
             final EventMeshMessage rsp = eventMeshHttpProducer.request(eventMeshMessage, 10_000);
-            LogUtils.debug(log, "send msg: {}, return: {}, cost:{} ms", eventMeshMessage.getContent(), rsp.getContent(),
+            log.debug("send msg: {}, return: {}, cost:{} ms", eventMeshMessage.getContent(), rsp.getContent(),
                 System.currentTimeMillis() - startTime);
         } catch (Exception e) {
             log.error("send msg failed, ", e);

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/http/demo/sub/controller/SubController.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/http/demo/sub/controller/SubController.java
@@ -21,7 +21,6 @@ import static org.apache.eventmesh.common.Constants.CLOUD_EVENTS_PROTOCOL_NAME;
 
 import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.http.demo.sub.service.SubService;
 
 import org.apache.commons.lang3.StringUtils;
@@ -56,7 +55,7 @@ public class SubController {
     @RequestMapping(value = "/test", method = RequestMethod.POST)
     public String subTest(final HttpServletRequest request) {
         final String content = request.getParameter("content");
-        LogUtils.info(log, "receive message: {}", content);
+        log.info("receive message: {}", content);
         @SuppressWarnings("unchecked")
         final Map<String, String> contentMap = JsonUtils.parseObject(content, HashMap.class);
         if (StringUtils.equals(CLOUD_EVENTS_PROTOCOL_NAME, contentMap.get(ProtocolKey.PROTOCOL_TYPE))) {
@@ -66,7 +65,7 @@ public class SubController {
                 final CloudEventData eventData = event.getData();
                 if (eventData != null) {
                     final String data = new String(eventData.toBytes(), StandardCharsets.UTF_8);
-                    LogUtils.info(log, "receive data: {}", data);
+                    log.info("receive data: {}", data);
                 }
             }
         }

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/http/demo/sub/service/SubService.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/http/demo/sub/service/SubService.java
@@ -30,7 +30,6 @@ import org.apache.eventmesh.common.protocol.SubscriptionItem;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
 import org.apache.eventmesh.common.utils.IPUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.http.demo.pub.eventmeshmessage.AsyncPublishInstance;
 import org.apache.eventmesh.util.Utils;
@@ -102,14 +101,14 @@ public class SubService implements InitializingBean {
                 log.error("interrupted exception", e);
                 Thread.currentThread().interrupt();
             }
-            LogUtils.info(log, "stopThread start....");
+            log.info("stopThread start....");
         });
         stopThread.start();
     }
 
     @PreDestroy
     public void cleanup() {
-        LogUtils.info(log, "start destroy....");
+        log.info("start destroy....");
 
         try {
             final List<String> unSubList = new ArrayList<>();
@@ -125,15 +124,15 @@ public class SubService implements InitializingBean {
             eventMeshHttpConsumer.close();
         }
 
-        LogUtils.info(log, "end destroy....");
+        log.info("end destroy....");
     }
 
     /**
      * Count the message already consumed
      */
     public void consumeMessage(final String msg) {
-        LogUtils.info(log, "consume message: {}", msg);
+        log.info("consume message: {}", msg);
         countDownLatch.countDown();
-        LogUtils.info(log, "remaining number: {} of messages to be consumed", countDownLatch.getCount());
+        log.info("remaining number: {} of messages to be consumed", countDownLatch.getCount());
     }
 }

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/pub/cloudevents/AsyncPublish.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/pub/cloudevents/AsyncPublish.java
@@ -23,7 +23,6 @@ import org.apache.eventmesh.client.tcp.common.EventMeshCommon;
 import org.apache.eventmesh.client.tcp.conf.EventMeshTCPClientConfig;
 import org.apache.eventmesh.common.ExampleConstants;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.tcp.common.EventMeshTestUtils;
 import org.apache.eventmesh.util.Utils;
@@ -55,7 +54,7 @@ public class AsyncPublish {
 
             for (int i = 0; i < 2; i++) {
                 CloudEvent event = EventMeshTestUtils.generateCloudEventV1Async();
-                LogUtils.info(log, "begin send async msg[{}]: {}", i, event);
+                log.info("begin send async msg[{}]: {}", i, event);
                 client.publish(event, EventMeshCommon.DEFAULT_TIME_OUT_MILLS);
 
                 ThreadUtils.sleep(1, TimeUnit.SECONDS);

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/pub/cloudevents/SyncRequest.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/pub/cloudevents/SyncRequest.java
@@ -24,7 +24,6 @@ import org.apache.eventmesh.client.tcp.conf.EventMeshTCPClientConfig;
 import org.apache.eventmesh.common.ExampleConstants;
 import org.apache.eventmesh.common.protocol.tcp.Package;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.tcp.common.EventMeshTestUtils;
 import org.apache.eventmesh.util.Utils;
 
@@ -61,7 +60,7 @@ public class SyncRequest {
 
             final CloudEvent event = EventMeshTestUtils.generateCloudEventV1SyncRR();
 
-            LogUtils.info(log, "begin send rr msg: {}", event);
+            log.info("begin send rr msg: {}", event);
 
             final Package response = client.rr(event, EventMeshCommon.DEFAULT_TIME_OUT_MILLS);
             // check-NPE EventFormat
@@ -82,7 +81,7 @@ public class SyncRequest {
             }
 
             final String content = new String(cloudEventData.toBytes(), StandardCharsets.UTF_8);
-            LogUtils.info(log, "receive rr reply: {}|{}", response, content);
+            log.info("receive rr reply: {}|{}", response, content);
 
         } catch (Exception e) {
             log.error("SyncRequest failed", e);

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/pub/eventmeshmessage/AsyncPublish.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/pub/eventmeshmessage/AsyncPublish.java
@@ -24,7 +24,6 @@ import org.apache.eventmesh.client.tcp.conf.EventMeshTCPClientConfig;
 import org.apache.eventmesh.common.ExampleConstants;
 import org.apache.eventmesh.common.protocol.tcp.EventMeshMessage;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.tcp.common.EventMeshTestUtils;
 import org.apache.eventmesh.util.Utils;
@@ -55,7 +54,7 @@ public class AsyncPublish {
             for (int i = 0; i < 5; i++) {
                 final EventMeshMessage eventMeshMessage = EventMeshTestUtils.generateAsyncEventMqMsg();
 
-                LogUtils.info(log, "begin send async msg[{}]: {}", i, eventMeshMessage);
+                log.info("begin send async msg[{}]: {}", i, eventMeshMessage);
                 client.publish(eventMeshMessage, EventMeshCommon.DEFAULT_TIME_OUT_MILLS);
 
                 ThreadUtils.sleep(1, TimeUnit.SECONDS);

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/pub/eventmeshmessage/AsyncPublishBroadcast.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/pub/eventmeshmessage/AsyncPublishBroadcast.java
@@ -24,7 +24,6 @@ import org.apache.eventmesh.client.tcp.conf.EventMeshTCPClientConfig;
 import org.apache.eventmesh.common.ExampleConstants;
 import org.apache.eventmesh.common.protocol.tcp.EventMeshMessage;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.tcp.common.EventMeshTestUtils;
 import org.apache.eventmesh.util.Utils;
@@ -54,7 +53,7 @@ public class AsyncPublishBroadcast {
 
             final EventMeshMessage eventMeshMessage = EventMeshTestUtils.generateBroadcastMqMsg();
 
-            LogUtils.info(log, "begin send broadcast msg: {}", eventMeshMessage);
+            log.info("begin send broadcast msg: {}", eventMeshMessage);
             client.broadcast(eventMeshMessage, EventMeshCommon.DEFAULT_TIME_OUT_MILLS);
 
             ThreadUtils.sleep(2, TimeUnit.SECONDS);

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/pub/eventmeshmessage/SyncRequest.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/pub/eventmeshmessage/SyncRequest.java
@@ -25,7 +25,6 @@ import org.apache.eventmesh.common.ExampleConstants;
 import org.apache.eventmesh.common.protocol.tcp.EventMeshMessage;
 import org.apache.eventmesh.common.protocol.tcp.Package;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.tcp.common.EventMeshTestUtils;
 import org.apache.eventmesh.util.Utils;
 
@@ -53,10 +52,10 @@ public class SyncRequest {
 
             final EventMeshMessage eventMeshMessage = EventMeshTestUtils.generateSyncRRMqMsg();
 
-            LogUtils.info(log, "begin send rr msg: {}", eventMeshMessage);
+            log.info("begin send rr msg: {}", eventMeshMessage);
 
             final Package response = client.rr(eventMeshMessage, EventMeshCommon.DEFAULT_TIME_OUT_MILLS);
-            LogUtils.info(log, "receive rr reply: {}", response);
+            log.info("receive rr reply: {}", response);
 
         } catch (Exception e) {
             log.error("SyncRequest failed", e);

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/sub/cloudevents/AsyncSubscribe.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/sub/cloudevents/AsyncSubscribe.java
@@ -25,7 +25,6 @@ import org.apache.eventmesh.common.ExampleConstants;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.tcp.common.EventMeshTestUtils;
 import org.apache.eventmesh.util.Utils;
 
@@ -73,7 +72,7 @@ public class AsyncSubscribe implements ReceiveMsgHook<CloudEvent> {
         }
 
         final String content = new String(msg.getData().toBytes(), StandardCharsets.UTF_8);
-        LogUtils.info(log, "receive async msg: {}|{}", msg, content);
+        log.info("receive async msg: {}|{}", msg, content);
         return Optional.empty();
     }
 }

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/sub/cloudevents/SyncResponse.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/sub/cloudevents/SyncResponse.java
@@ -25,7 +25,6 @@ import org.apache.eventmesh.common.ExampleConstants;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.tcp.common.EventMeshTestUtils;
 import org.apache.eventmesh.util.Utils;
 
@@ -74,7 +73,7 @@ public class SyncResponse implements ReceiveMsgHook<CloudEvent> {
         }
 
         final String content = new String(event.getData().toBytes(), StandardCharsets.UTF_8);
-        LogUtils.info(log, "receive sync rr msg: {}|{}", event, content);
+        log.info("receive sync rr msg: {}|{}", event, content);
         return Optional.of(event);
     }
 

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/sub/eventmeshmessage/AsyncSubscribe.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/sub/eventmeshmessage/AsyncSubscribe.java
@@ -26,7 +26,6 @@ import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
 import org.apache.eventmesh.common.protocol.tcp.EventMeshMessage;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.tcp.common.EventMeshTestUtils;
 import org.apache.eventmesh.util.Utils;
 
@@ -66,7 +65,7 @@ public class AsyncSubscribe implements ReceiveMsgHook<EventMeshMessage> {
 
     @Override
     public Optional<EventMeshMessage> handle(final EventMeshMessage msg) {
-        LogUtils.info(log, "receive async msg: {}", msg);
+        log.info("receive async msg: {}", msg);
         return Optional.empty();
     }
 }

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/sub/eventmeshmessage/AsyncSubscribeBroadcast.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/sub/eventmeshmessage/AsyncSubscribeBroadcast.java
@@ -26,7 +26,6 @@ import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
 import org.apache.eventmesh.common.protocol.tcp.EventMeshMessage;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.tcp.common.EventMeshTestUtils;
 import org.apache.eventmesh.util.Utils;
 
@@ -68,7 +67,7 @@ public class AsyncSubscribeBroadcast implements ReceiveMsgHook<EventMeshMessage>
 
     @Override
     public Optional<EventMeshMessage> handle(final EventMeshMessage msg) {
-        LogUtils.info(log, "receive broadcast msg: {}", msg);
+        log.info("receive broadcast msg: {}", msg);
         return Optional.empty();
     }
 

--- a/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/sub/eventmeshmessage/SyncResponse.java
+++ b/eventmesh-examples/src/main/java/org/apache/eventmesh/tcp/demo/sub/eventmeshmessage/SyncResponse.java
@@ -26,7 +26,6 @@ import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
 import org.apache.eventmesh.common.protocol.tcp.EventMeshMessage;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.tcp.common.EventMeshTestUtils;
 import org.apache.eventmesh.util.Utils;
 
@@ -67,7 +66,7 @@ public class SyncResponse implements ReceiveMsgHook<EventMeshMessage> {
 
     @Override
     public Optional<EventMeshMessage> handle(final EventMeshMessage msg) {
-        LogUtils.info(log, "receive sync rr msg: {}", msg);
+        log.info("receive sync rr msg: {}", msg);
         return Optional.ofNullable(msg);
     }
 

--- a/eventmesh-openconnect/eventmesh-openconnect-java/src/main/java/org/apache/eventmesh/openconnect/SourceWorker.java
+++ b/eventmesh-openconnect/eventmesh-openconnect-java/src/main/java/org/apache/eventmesh/openconnect/SourceWorker.java
@@ -330,7 +330,7 @@ public class SourceWorker implements ConnectorWorker {
             log.info("{} Committing offsets for {} acknowledged messages", this, committableOffsets.numCommittableMessages());
             if (committableOffsets.hasPending()) {
                 log.debug("{} There are currently {} pending messages spread across {} source partitions whose offsets will not be committed. "
-                        + "The source partition with the most pending messages is {}, with {} pending messages",
+                    + "The source partition with the most pending messages is {}, with {} pending messages",
                     this,
                     committableOffsets.numUncommittableMessages(),
                     committableOffsets.numDeques(),
@@ -338,7 +338,7 @@ public class SourceWorker implements ConnectorWorker {
                     committableOffsets.largestDequeSize());
             } else {
                 log.debug("{} There are currently no pending messages for this offset commit; "
-                        + "all messages dispatched to the task's producer since the last commit have been acknowledged",
+                    + "all messages dispatched to the task's producer since the last commit have been acknowledged",
                     this);
             }
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/RedirectClientBySubSystemHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/RedirectClientBySubSystemHandler.java
@@ -18,7 +18,6 @@
 package org.apache.eventmesh.runtime.admin.handler;
 
 import org.apache.eventmesh.common.Constants;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.NetUtils;
 import org.apache.eventmesh.runtime.admin.controller.HttpHandlerManager;
 import org.apache.eventmesh.runtime.boot.EventMeshTCPServer;
@@ -102,8 +101,8 @@ public class RedirectClientBySubSystemHandler extends AbstractHttpHandler {
                 out.write("params illegal!".getBytes(Constants.DEFAULT_CHARSET));
                 return;
             }
-            LogUtils.info(log, "redirectClientBySubSystem in admin,subsys:{},destIp:{},destPort:{}====================",
-                subSystem, destEventMeshIp, destEventMeshPort);
+            log.info("redirectClientBySubSystem in admin,subsys:{},destIp:{},destPort:{}====================", subSystem, destEventMeshIp,
+                destEventMeshPort);
 
             // Retrieve the mapping between Sessions and their corresponding client address
             final ClientSessionGroupMapping clientSessionGroupMapping = eventMeshTCPServer.getClientSessionGroupMapping();

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/RejectAllClientHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/RejectAllClientHandler.java
@@ -18,7 +18,6 @@
 package org.apache.eventmesh.runtime.admin.handler;
 
 import org.apache.eventmesh.common.Constants;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.NetUtils;
 import org.apache.eventmesh.runtime.admin.controller.HttpHandlerManager;
 import org.apache.eventmesh.runtime.boot.EventMeshTCPServer;
@@ -83,7 +82,7 @@ public class RejectAllClientHandler extends AbstractHttpHandler {
             final ConcurrentHashMap<InetSocketAddress, Session> sessionMap = clientSessionGroupMapping.getSessionMap();
             final List<InetSocketAddress> successRemoteAddrs = new ArrayList<>();
             try {
-                LogUtils.info(log, "rejectAllClient in admin====================");
+                log.info("rejectAllClient in admin====================");
                 if (!sessionMap.isEmpty()) {
                     // Iterate through the sessionMap and close each client connection
                     for (final Map.Entry<InetSocketAddress, Session> entry : sessionMap.entrySet()) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/ShowClientBySystemHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/ShowClientBySystemHandler.java
@@ -19,7 +19,6 @@ package org.apache.eventmesh.runtime.admin.handler;
 
 import org.apache.eventmesh.common.Constants;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.NetUtils;
 import org.apache.eventmesh.runtime.admin.controller.HttpHandlerManager;
 import org.apache.eventmesh.runtime.boot.EventMeshTCPServer;
@@ -85,7 +84,7 @@ public class ShowClientBySystemHandler extends AbstractHttpHandler {
             String subSystem = queryStringInfo.get(EventMeshConstants.MANAGE_SUBSYSTEM);
 
             String newLine = System.getProperty("line.separator");
-            LogUtils.info(log, "showClientBySubsys,subsys:{}", subSystem);
+            log.info("showClientBySubsys,subsys:{}", subSystem);
             // Retrieve the mapping between Sessions and their corresponding client address
             ClientSessionGroupMapping clientSessionGroupMapping = eventMeshTCPServer.getClientSessionGroupMapping();
             ConcurrentHashMap<InetSocketAddress, Session> sessionMap = clientSessionGroupMapping.getSessionMap();

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/AbstractHTTPServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/AbstractHTTPServer.java
@@ -27,7 +27,6 @@ import org.apache.eventmesh.common.protocol.http.common.ProtocolVersion;
 import org.apache.eventmesh.common.protocol.http.common.RequestCode;
 import org.apache.eventmesh.common.protocol.http.header.Header;
 import org.apache.eventmesh.common.utils.AssertUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.common.Pair;
 import org.apache.eventmesh.runtime.configuration.EventMeshHTTPConfiguration;
 import org.apache.eventmesh.runtime.constants.EventMeshConstants;
@@ -168,7 +167,7 @@ public abstract class AbstractHTTPServer extends AbstractRemotingServer {
                     .childHandler(new HttpsServerInitializer(useTLS ? SSLContextFactory.getSslContext(eventMeshHttpConfiguration) : null))
                     .childOption(ChannelOption.SO_KEEPALIVE, Boolean.TRUE);
 
-                LogUtils.info(log, "HTTPServer[port={}] started.", this.getPort());
+                log.info("HTTPServer[port={}] started.", this.getPort());
 
                 bootstrap.bind(this.getPort())
                     .channel()
@@ -246,8 +245,7 @@ public abstract class AbstractHTTPServer extends AbstractRemotingServer {
     public void sendResponse(final ChannelHandlerContext ctx, final DefaultFullHttpResponse response) {
         ctx.writeAndFlush(response).addListener((ChannelFutureListener) f -> {
             if (!f.isSuccess()) {
-                LogUtils.warn(log, "send response to [{}] fail, will close this channel",
-                    RemotingHelper.parseChannelRemoteAddr(f.channel()));
+                log.warn("send response to [{}] fail, will close this channel", RemotingHelper.parseChannelRemoteAddr(f.channel()));
                 f.channel().close();
             }
         });
@@ -366,7 +364,7 @@ public abstract class AbstractHTTPServer extends AbstractRemotingServer {
                     return;
                 }
 
-                LogUtils.debug(log, "{}", requestCommand);
+                log.debug("{}", requestCommand);
 
                 final AsyncContext<HttpCommand> asyncContext =
                     new AsyncContext<>(requestCommand, responseCommand, asyncContextCompleteHandler);
@@ -414,7 +412,7 @@ public abstract class AbstractHTTPServer extends AbstractRemotingServer {
 
                             if (asyncContext.isComplete()) {
                                 sendResponse(ctx, responseCommand.httpResponse());
-                                LogUtils.debug(log, "{}", asyncContext.getResponse());
+                                log.debug("{}", asyncContext.getResponse());
                                 final Map<String, Object> traceMap = asyncContext.getRequest().getHeader().toMap();
                                 TraceUtils.finishSpanWithException(TraceUtils.prepareServerSpan(traceMap,
                                     EventMeshTraceConstants.TRACE_UPSTREAM_EVENTMESH_SERVER_SPAN,
@@ -434,7 +432,7 @@ public abstract class AbstractHTTPServer extends AbstractRemotingServer {
                         metrics.getSummaryMetrics()
                             .recordHTTPReqResTimeCost(System.currentTimeMillis() - request.getReqTime());
 
-                        LogUtils.debug(log, "{}", asyncContext.getResponse());
+                        log.debug("{}", asyncContext.getResponse());
 
                         sendResponse(ctx, asyncContext.getResponse().httpResponse());
 
@@ -490,7 +488,7 @@ public abstract class AbstractHTTPServer extends AbstractRemotingServer {
         @Override
         public void channelActive(final ChannelHandlerContext ctx) throws Exception {
             if (connections.incrementAndGet() > MAX_CONNECTIONS) {
-                LogUtils.warn(log, "client|http|channelActive|remoteAddress={}|msg=too many client({}) connect this eventMesh server",
+                log.warn("client|http|channelActive|remoteAddress={}|msg=too many client({}) connect this eventMesh server",
                     RemotingHelper.parseChannelRemoteAddr(ctx.channel()), MAX_CONNECTIONS);
                 ctx.close();
                 return;
@@ -510,8 +508,7 @@ public abstract class AbstractHTTPServer extends AbstractRemotingServer {
                 final IdleStateEvent event = (IdleStateEvent) evt;
                 if (event.state().equals(IdleState.ALL_IDLE)) {
                     final String remoteAddress = RemotingHelper.parseChannelRemoteAddr(ctx.channel());
-                    LogUtils.info(log, "client|http|userEventTriggered|remoteAddress={}|msg={}",
-                        remoteAddress, evt.getClass().getName());
+                    log.info("client|http|userEventTriggered|remoteAddress={}|msg={}", remoteAddress, evt.getClass().getName());
                     ctx.close();
                 }
             }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/AbstractRemotingServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/AbstractRemotingServer.java
@@ -18,7 +18,6 @@
 package org.apache.eventmesh.runtime.boot;
 
 import org.apache.eventmesh.common.EventMeshThreadFactory;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.SystemUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.runtime.core.protocol.producer.ProducerManager;
@@ -93,7 +92,7 @@ public abstract class AbstractRemotingServer implements RemotingServer {
     public void shutdown() throws Exception {
         if (bossGroup != null) {
             bossGroup.shutdownGracefully();
-            LogUtils.info(log, "shutdown bossGroup");
+            log.info("shutdown bossGroup");
         }
         producerManager.shutdown();
 
@@ -101,13 +100,13 @@ public abstract class AbstractRemotingServer implements RemotingServer {
 
         if (ioGroup != null) {
             ioGroup.shutdownGracefully();
-            LogUtils.info(log, "shutdown ioGroup");
+            log.info("shutdown ioGroup");
         }
 
         if (workerGroup != null) {
             workerGroup.shutdownGracefully();
 
-            LogUtils.info(log, "shutdown workerGroup");
+            log.info("shutdown workerGroup");
         }
     }
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/AbstractTCPServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/AbstractTCPServer.java
@@ -26,7 +26,6 @@ import org.apache.eventmesh.common.protocol.tcp.Package;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
 import org.apache.eventmesh.common.protocol.tcp.codec.Codec;
 import org.apache.eventmesh.common.utils.AssertUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.common.Pair;
 import org.apache.eventmesh.runtime.configuration.EventMeshTCPConfiguration;
 import org.apache.eventmesh.runtime.constants.EventMeshConstants;
@@ -254,13 +253,13 @@ public class AbstractTCPServer extends AbstractRemotingServer {
                 }
 
                 if (Command.HELLO_REQUEST == cmd || Command.RECOMMEND_REQUEST == cmd) {
-                    LogUtils.info(messageLogger, "pkg|c2eventMesh|cmd={}|pkg={}", cmd, pkg);
+                    messageLogger.info("pkg|c2eventMesh|cmd={}|pkg={}", cmd, pkg);
                     processTcpCommandRequest(pkg, ctx, startTime, cmd);
                     return;
                 }
 
                 if (clientSessionGroupMapping.getSession(ctx) == null) {
-                    LogUtils.info(messageLogger, "pkg|c2eventMesh|cmd={}|pkg={},no session is found", cmd, pkg);
+                    messageLogger.info("pkg|c2eventMesh|cmd={}|pkg={},no session is found", cmd, pkg);
                     throw new Exception("no session is found");
                 }
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshHTTPServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshHTTPServer.java
@@ -24,7 +24,6 @@ import org.apache.eventmesh.api.meta.dto.EventMeshUnRegisterInfo;
 import org.apache.eventmesh.common.exception.EventMeshException;
 import org.apache.eventmesh.common.protocol.http.common.RequestCode;
 import org.apache.eventmesh.common.utils.IPUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.metrics.api.MetricsPluginFactory;
 import org.apache.eventmesh.metrics.api.MetricsRegistry;
 import org.apache.eventmesh.runtime.acl.Acl;
@@ -114,7 +113,7 @@ public class EventMeshHTTPServer extends AbstractHTTPServer {
     }
 
     public void init() throws Exception {
-        LogUtils.info(log, "==================EventMeshHTTPServer Initialing==================");
+        log.info("==================EventMeshHTTPServer Initialing==================");
         super.init();
 
         msgRateLimiter = RateLimiter.create(eventMeshHttpConfiguration.getEventMeshHttpMsgReqNumPerSecond());
@@ -153,7 +152,7 @@ public class EventMeshHTTPServer extends AbstractHTTPServer {
 
         registerHTTPRequestProcessor();
 
-        LogUtils.info(log, "==================EventMeshHTTPServer initialized==================");
+        log.info("==================EventMeshHTTPServer initialized==================");
     }
 
     @Override
@@ -172,7 +171,7 @@ public class EventMeshHTTPServer extends AbstractHTTPServer {
         if (eventMeshHttpConfiguration.isEventMeshServerMetaStorageEnable()) {
             this.register();
         }
-        LogUtils.info(log, "==================EventMeshHTTPServer started==================");
+        log.info("==================EventMeshHTTPServer started==================");
     }
 
     @Override
@@ -197,7 +196,7 @@ public class EventMeshHTTPServer extends AbstractHTTPServer {
         if (eventMeshHttpConfiguration.isEventMeshServerMetaStorageEnable()) {
             this.unRegister();
         }
-        LogUtils.info(log, "==================EventMeshHTTPServer shutdown==================");
+        log.info("==================EventMeshHTTPServer shutdown==================");
     }
 
     /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshServer.java
@@ -25,7 +25,6 @@ import org.apache.eventmesh.common.config.CommonConfiguration;
 import org.apache.eventmesh.common.config.ConfigService;
 import org.apache.eventmesh.common.utils.AssertUtils;
 import org.apache.eventmesh.common.utils.ConfigurationContextUtil;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.acl.Acl;
 import org.apache.eventmesh.runtime.admin.controller.ClientManageController;
 import org.apache.eventmesh.runtime.common.ServiceState;
@@ -142,12 +141,12 @@ public class EventMeshServer {
 
         final String eventStore = System.getProperty(EventMeshConstants.EVENT_STORE_PROPERTIES, System.getenv(EventMeshConstants.EVENT_STORE_ENV));
 
-        LogUtils.info(log, "eventStore : {}", eventStore);
+        log.info("eventStore : {}", eventStore);
         producerTopicManager = new ProducerTopicManager(this);
         producerTopicManager.init();
         serviceState = ServiceState.INITED;
 
-        LogUtils.info(log, SERVER_STATE_MSG, serviceState);
+        log.info(SERVER_STATE_MSG, serviceState);
     }
 
     public void start() throws Exception {
@@ -170,13 +169,13 @@ public class EventMeshServer {
         }
         producerTopicManager.start();
         serviceState = ServiceState.RUNNING;
-        LogUtils.info(log, SERVER_STATE_MSG, serviceState);
+        log.info(SERVER_STATE_MSG, serviceState);
 
     }
 
     public void shutdown() throws Exception {
         serviceState = ServiceState.STOPPING;
-        LogUtils.info(log, SERVER_STATE_MSG, serviceState);
+        log.info(SERVER_STATE_MSG, serviceState);
 
         for (final EventMeshBootstrap eventMeshBootstrap : BOOTSTRAP_LIST) {
             eventMeshBootstrap.shutdown();
@@ -199,7 +198,7 @@ public class EventMeshServer {
         ConfigurationContextUtil.clear();
         serviceState = ServiceState.STOPPED;
 
-        LogUtils.info(log, SERVER_STATE_MSG, serviceState);
+        log.info(SERVER_STATE_MSG, serviceState);
     }
 
     public static Trace getTrace() {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshStartup.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshStartup.java
@@ -18,7 +18,6 @@
 package org.apache.eventmesh.runtime.boot;
 
 import org.apache.eventmesh.common.config.ConfigService;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.constants.EventMeshConstants;
 import org.apache.eventmesh.runtime.util.BannerUtil;
 
@@ -41,12 +40,12 @@ public class EventMeshStartup {
             server.start();
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 try {
-                    LogUtils.info(log, "eventMesh shutting down hook begin.");
+                    log.info("eventMesh shutting down hook begin.");
                     long start = System.currentTimeMillis();
                     server.shutdown();
                     long end = System.currentTimeMillis();
 
-                    LogUtils.info(log, "eventMesh shutdown cost {}ms", end - start);
+                    log.info("eventMesh shutdown cost {}ms", end - start);
                 } catch (Exception e) {
                     log.error("exception when shutdown.", e);
                 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshTCPServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshTCPServer.java
@@ -24,7 +24,6 @@ import org.apache.eventmesh.api.meta.dto.EventMeshUnRegisterInfo;
 import org.apache.eventmesh.common.exception.EventMeshException;
 import org.apache.eventmesh.common.protocol.tcp.Command;
 import org.apache.eventmesh.common.utils.IPUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.metrics.api.MetricsPluginFactory;
 import org.apache.eventmesh.metrics.api.MetricsRegistry;
@@ -89,7 +88,7 @@ public class EventMeshTCPServer extends AbstractTCPServer {
     }
 
     public void init() throws Exception {
-        LogUtils.info(log, "==================EventMeshTCPServer Initialing==================");
+        log.info("==================EventMeshTCPServer Initialing==================");
         super.init();
 
         rateLimiter = RateLimiter.create(eventMeshTCPConfiguration.getEventMeshTcpMsgReqnumPerSecond());
@@ -119,7 +118,7 @@ public class EventMeshTCPServer extends AbstractTCPServer {
 
         registerTCPRequestProcessor();
 
-        LogUtils.info(log, "--------------------------EventMeshTCPServer Inited");
+        log.info("--------------------------EventMeshTCPServer Inited");
     }
 
     @Override
@@ -135,7 +134,7 @@ public class EventMeshTCPServer extends AbstractTCPServer {
             eventMeshRebalanceService.start();
         }
 
-        LogUtils.info(log, "--------------------------EventMeshTCPServer Started");
+        log.info("--------------------------EventMeshTCPServer Started");
     }
 
     @Override
@@ -154,7 +153,7 @@ public class EventMeshTCPServer extends AbstractTCPServer {
             this.unRegister();
         }
 
-        LogUtils.info(log, "--------------------------EventMeshTCPServer Shutdown");
+        log.info("--------------------------EventMeshTCPServer Shutdown");
     }
 
     /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/FilterEngine.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/FilterEngine.java
@@ -19,7 +19,6 @@ package org.apache.eventmesh.runtime.boot;
 
 import org.apache.eventmesh.api.meta.MetaServiceListener;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.filter.pattern.Pattern;
 import org.apache.eventmesh.filter.patternbuild.PatternBuilder;
 import org.apache.eventmesh.runtime.core.protocol.http.consumer.ConsumerGroupManager;
@@ -86,7 +85,7 @@ public class FilterEngine {
                 for (String filterKey : filterPatternMap.keySet()) {
                     if (!StringUtils.contains(filterKey, producerGroup)) {
                         addFilterListener(producerGroup);
-                        LogUtils.info(log, "addFilterListener for producer group: " + producerGroup);
+                        log.info("addFilterListener for producer group: " + producerGroup);
                     }
                 }
             }
@@ -95,7 +94,7 @@ public class FilterEngine {
                 for (String filterKey : filterPatternMap.keySet()) {
                     if (!StringUtils.contains(filterKey, consumerGroup)) {
                         addFilterListener(consumerGroup);
-                        LogUtils.info(log, "addFilterListener for consumer group: " + consumerGroup);
+                        log.info("addFilterListener for consumer group: " + consumerGroup);
                     }
                 }
             }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/TransformerEngine.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/TransformerEngine.java
@@ -19,7 +19,6 @@ package org.apache.eventmesh.runtime.boot;
 
 import org.apache.eventmesh.api.meta.MetaServiceListener;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.core.protocol.http.consumer.ConsumerGroupManager;
 import org.apache.eventmesh.runtime.core.protocol.http.consumer.ConsumerManager;
 import org.apache.eventmesh.runtime.core.protocol.producer.EventMeshProducer;
@@ -87,7 +86,7 @@ public class TransformerEngine {
                 for (String transformerKey : transformerMap.keySet()) {
                     if (!StringUtils.contains(transformerKey, producerGroup)) {
                         addTransformerListener(producerGroup);
-                        LogUtils.info(log, "addTransformerListener for producer group: " + producerGroup);
+                        log.info("addTransformerListener for producer group: " + producerGroup);
                     }
                 }
             }
@@ -96,7 +95,7 @@ public class TransformerEngine {
                 for (String transformerKey : transformerMap.keySet()) {
                     if (!StringUtils.contains(transformerKey, consumerGroup)) {
                         addTransformerListener(consumerGroup);
-                        LogUtils.info(log, "addTransformerListener for consumer group: " + consumerGroup);
+                        log.info("addTransformerListener for consumer group: " + consumerGroup);
                     }
                 }
             }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/consumer/ConsumerManager.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/consumer/ConsumerManager.java
@@ -20,7 +20,6 @@ package org.apache.eventmesh.runtime.core.protocol.grpc.consumer;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.grpc.common.GrpcType;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.boot.EventMeshGrpcServer;
 import org.apache.eventmesh.runtime.common.ServiceState;
 import org.apache.eventmesh.runtime.core.protocol.grpc.consumer.consumergroup.ConsumerGroupClient;
@@ -65,12 +64,12 @@ public class ConsumerManager {
     }
 
     public void init() throws Exception {
-        LogUtils.info(log, "Grpc ConsumerManager initialized.");
+        log.info("Grpc ConsumerManager initialized.");
     }
 
     public void start() throws Exception {
         startClientCheck();
-        LogUtils.info(log, "Grpc ConsumerManager started.");
+        log.info("Grpc ConsumerManager started.");
     }
 
     public void shutdown() throws Exception {
@@ -78,7 +77,7 @@ public class ConsumerManager {
             consumer.shutdown();
         }
         scheduledExecutorService.shutdown();
-        LogUtils.info(log, "Grpc ConsumerManager shutdown.");
+        log.info("Grpc ConsumerManager shutdown.");
     }
 
     public EventMeshConsumer getEventMeshConsumer(final String consumerGroup) {
@@ -198,12 +197,12 @@ public class ConsumerManager {
         final int clientTimeout = eventMeshGrpcServer.getEventMeshGrpcConfiguration().getEventMeshSessionExpiredInMills();
         if (clientTimeout > 0) {
             scheduledExecutorService.scheduleAtFixedRate(() -> {
-                LogUtils.debug(log, "grpc client info check");
+                log.debug("grpc client info check");
 
                 final List<ConsumerGroupClient> clientList = new ArrayList<>();
                 clientTable.values().forEach(clientList::addAll);
 
-                LogUtils.debug(log, "total number of ConsumerGroupClients: {}", clientList.size());
+                log.debug("total number of ConsumerGroupClients: {}", clientList.size());
 
                 if (CollectionUtils.isEmpty(clientList)) {
                     return;
@@ -212,8 +211,8 @@ public class ConsumerManager {
                 final Set<String> consumerGroupRestart = new HashSet<>();
                 clientList.forEach(client -> {
                     if (System.currentTimeMillis() - client.getLastUpTime().getTime() > clientTimeout) {
-                        LogUtils.warn(log, "client {} lastUpdate time {} over three heartbeat cycles. Removing it",
-                            JsonUtils.toJSONString(client), client.getLastUpTime());
+                        log.warn("client {} lastUpdate time {} over three heartbeat cycles. Removing it", JsonUtils.toJSONString(client),
+                            client.getLastUpTime());
 
                         deregisterClient(client);
                         if (getEventMeshConsumer(client.getConsumerGroup()).deregisterClient(client)) {
@@ -227,7 +226,7 @@ public class ConsumerManager {
                     try {
                         restartEventMeshConsumer(consumerGroup);
                     } catch (Exception e) {
-                        LogUtils.error(log, "Error in restarting EventMeshConsumer [{}]", consumerGroup, e);
+                        log.error("Error in restarting EventMeshConsumer [{}]", consumerGroup, e);
                     }
                 });
             }, 10_000, 10_000, TimeUnit.MILLISECONDS);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/consumer/EventMeshConsumer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/consumer/EventMeshConsumer.java
@@ -35,7 +35,6 @@ import org.apache.eventmesh.common.protocol.SubscriptionItem;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.grpc.common.GrpcType;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.runtime.boot.EventMeshGrpcServer;
 import org.apache.eventmesh.runtime.common.ServiceState;
@@ -220,7 +219,7 @@ public class EventMeshConsumer {
         broadcastMqConsumer.registerEventListener(createEventListener(SubscriptionMode.BROADCASTING));
 
         serviceState = ServiceState.INITED;
-        LogUtils.info(log, "EventMeshConsumer [{}] initialized.............", consumerGroup);
+        log.info("EventMeshConsumer [{}] initialized.............", consumerGroup);
     }
 
     public synchronized void start() throws Exception {
@@ -241,7 +240,7 @@ public class EventMeshConsumer {
         broadcastMqConsumer.start();
 
         serviceState = ServiceState.RUNNING;
-        LogUtils.info(log, "EventMeshConsumer [{}] started..........", consumerGroup);
+        log.info("EventMeshConsumer [{}] started..........", consumerGroup);
     }
 
     public synchronized void shutdown() throws Exception {
@@ -249,7 +248,7 @@ public class EventMeshConsumer {
         broadcastMqConsumer.shutdown();
 
         serviceState = ServiceState.STOPPED;
-        LogUtils.info(log, "EventMeshConsumer [{}] shutdown.........", consumerGroup);
+        log.info("EventMeshConsumer [{}] shutdown.........", consumerGroup);
     }
 
     public ServiceState getStatus() {
@@ -347,7 +346,7 @@ public class EventMeshConsumer {
                     }
                 }
             } else {
-                LogUtils.debug(log, "no active consumer for topic={}|msg={}", topic, event);
+                log.debug("no active consumer for topic={}|msg={}", topic, event);
             }
 
             eventMeshAsyncConsumeContext.commit(EventMeshAction.CommitMessage);
@@ -359,8 +358,7 @@ public class EventMeshConsumer {
         final EventMeshProducer producer = eventMeshGrpcServer.getProducerManager().getEventMeshProducer(consumerGroup);
 
         if (producer == null) {
-            LogUtils.warn(log, "consumer:{} consume fail, sendMessageBack, bizSeqNo:{}, uniqueId:{}",
-                consumerGroup, bizSeqNo, uniqueId);
+            log.warn("consumer:{} consume fail, sendMessageBack, bizSeqNo:{}, uniqueId:{}", consumerGroup, bizSeqNo, uniqueId);
             return;
         }
 
@@ -375,8 +373,7 @@ public class EventMeshConsumer {
 
             @Override
             public void onException(final OnExceptionContext context) {
-                LogUtils.warn(log, "consumer:{} consume fail, sendMessageBack, bizSeqNo:{}, uniqueId:{}", consumerGroup,
-                    bizSeqNo, uniqueId);
+                log.warn("consumer:{} consume fail, sendMessageBack, bizSeqNo:{}, uniqueId:{}", consumerGroup, bizSeqNo, uniqueId);
             }
         });
     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/consumer/consumergroup/StreamTopicConfig.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/consumer/consumergroup/StreamTopicConfig.java
@@ -20,7 +20,6 @@ package org.apache.eventmesh.runtime.core.protocol.grpc.consumer.consumergroup;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.grpc.cloudevents.CloudEvent;
 import org.apache.eventmesh.common.protocol.grpc.common.GrpcType;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.core.protocol.grpc.service.EventEmitter;
 
 import org.apache.commons.collections4.MapUtils;
@@ -63,8 +62,7 @@ public class StreamTopicConfig extends ConsumerGroupTopicConfig {
         Objects.requireNonNull(client, "ConsumerGroupClient can not be null");
 
         if (client.getGrpcType() != grpcType) {
-            LogUtils.warn(log, "Invalid grpc type: {}, expecting grpc type: {}, can not register client {}",
-                client.getGrpcType(), grpcType, client);
+            log.warn("Invalid grpc type: {}, expecting grpc type: {}, can not register client {}", client.getGrpcType(), grpcType, client);
             return;
         }
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/SubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/SubscribeProcessor.java
@@ -25,7 +25,6 @@ import org.apache.eventmesh.common.protocol.grpc.common.GrpcType;
 import org.apache.eventmesh.common.protocol.grpc.common.StatusCode;
 import org.apache.eventmesh.common.protocol.http.common.RequestCode;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.acl.Acl;
 import org.apache.eventmesh.runtime.boot.EventMeshGrpcServer;
 import org.apache.eventmesh.runtime.core.protocol.grpc.consumer.ConsumerManager;
@@ -73,7 +72,7 @@ public class SubscribeProcessor {
         try {
             doAclCheck(subscription);
         } catch (AclException e) {
-            LogUtils.warn(log, "CLIENT HAS NO PERMISSION to Subscribe. failed", e);
+            log.warn("CLIENT HAS NO PERMISSION to Subscribe. failed", e);
             ServiceUtils.sendResponseCompleted(StatusCode.EVENTMESH_ACL_ERR, e.getMessage(), emitter);
             return;
         }
@@ -126,10 +125,10 @@ public class SubscribeProcessor {
 
         // restart consumer group if required
         if (requireRestart) {
-            LogUtils.info(log, "ConsumerGroup {} topic info changed, restart EventMesh Consumer", consumerGroup);
+            log.info("ConsumerGroup {} topic info changed, restart EventMesh Consumer", consumerGroup);
             consumerManager.restartEventMeshConsumer(consumerGroup);
         } else {
-            LogUtils.warn(log, "EventMesh consumer [{}] didn't restart.", consumerGroup);
+            log.warn("EventMesh consumer [{}] didn't restart.", consumerGroup);
         }
         ServiceUtils.sendResponseCompleted(StatusCode.SUCCESS, "subscribe success", emitter);
     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/HttpClientGroupMapping.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/consumer/HttpClientGroupMapping.java
@@ -21,7 +21,6 @@ import org.apache.eventmesh.common.protocol.SubscriptionItem;
 import org.apache.eventmesh.common.protocol.http.header.client.SubscribeRequestHeader;
 import org.apache.eventmesh.common.protocol.http.header.client.UnSubscribeRequestHeader;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.core.consumergroup.ConsumerGroupConf;
 import org.apache.eventmesh.runtime.core.consumergroup.ConsumerGroupMetadata;
 import org.apache.eventmesh.runtime.core.consumergroup.ConsumerGroupTopicConf;
@@ -255,11 +254,9 @@ public final class HttpClientGroupMapping {
                 final ConsumerGroupTopicConf currentTopicConf = map.get(subTopic.getTopic());
                 if (!currentTopicConf.getUrls().add(url)) {
                     isChange = true;
-                    LogUtils.info(log, "add subscribe success, group:{}, url:{} , topic:{}", consumerGroup, url,
-                        subTopic.getTopic());
+                    log.info("add subscribe success, group:{}, url:{} , topic:{}", consumerGroup, url, subTopic.getTopic());
                 } else {
-                    LogUtils.warn(log, "The group has subscribed, group:{}, url:{} , topic:{}", consumerGroup, url,
-                        subTopic.getTopic());
+                    log.warn("The group has subscribed, group:{}, url:{} , topic:{}", consumerGroup, url, subTopic.getTopic());
                 }
 
                 if (!currentTopicConf.getIdcUrls().containsKey(clientIdc)) {
@@ -267,18 +264,18 @@ public final class HttpClientGroupMapping {
                     urls.add(url);
                     currentTopicConf.getIdcUrls().put(clientIdc, urls);
                     isChange = true;
-                    LogUtils.info(log, "add url to idcUrlMap success, group:{}, url:{}, topic:{}, clientIdc:{}",
-                        consumerGroup, url, subTopic.getTopic(), clientIdc);
+                    log.info("add url to idcUrlMap success, group:{}, url:{}, topic:{}, clientIdc:{}", consumerGroup, url, subTopic.getTopic(),
+                        clientIdc);
                 } else {
                     final Set<String> tmpSet = new HashSet<>(currentTopicConf.getIdcUrls().get(clientIdc));
                     if (!tmpSet.contains(url)) {
                         currentTopicConf.getIdcUrls().get(clientIdc).add(url);
                         isChange = true;
-                        LogUtils.info(log, "add url to idcUrlMap success, group:{}, url:{}, topic:{}, clientIdc:{}",
-                            consumerGroup, url, subTopic.getTopic(), clientIdc);
+                        log.info("add url to idcUrlMap success, group:{}, url:{}, topic:{}, clientIdc:{}", consumerGroup, url, subTopic.getTopic(),
+                            clientIdc);
                     } else {
-                        LogUtils.warn(log, "The idcUrlMap has contains url, group:{}, url:{} , topic:{}, clientIdc:{}",
-                            consumerGroup, url, subTopic.getTopic(), clientIdc);
+                        log.warn("The idcUrlMap has contains url, group:{}, url:{} , topic:{}, clientIdc:{}", consumerGroup, url, subTopic.getTopic(),
+                            clientIdc);
                     }
                 }
             }
@@ -297,48 +294,46 @@ public final class HttpClientGroupMapping {
 
         final ConsumerGroupConf consumerGroupConf = localConsumerGroupMapping.get(consumerGroup);
         if (consumerGroupConf == null) {
-            LogUtils.warn(log, "unsubscribe fail, the current mesh does not have group subscriptionInfo, group:{}, url:{}",
-                consumerGroup, unSubscribeUrl);
+            log.warn("unsubscribe fail, the current mesh does not have group subscriptionInfo, group:{}, url:{}", consumerGroup, unSubscribeUrl);
             return false;
         }
 
         final ConsumerGroupTopicConf consumerGroupTopicConf = consumerGroupConf.getConsumerGroupTopicConf().get(unSubTopic);
         if (consumerGroupTopicConf == null) {
-            LogUtils.warn(log, "unsubscribe fail, the current mesh does not have group-topic subscriptionInfo, group:{}, topic:{}, url:{}",
-                consumerGroup, unSubTopic, unSubscribeUrl);
+            log.warn("unsubscribe fail, the current mesh does not have group-topic subscriptionInfo, group:{}, topic:{}, url:{}", consumerGroup,
+                unSubTopic, unSubscribeUrl);
             return false;
         }
 
         if (consumerGroupTopicConf.getUrls().remove(unSubscribeUrl)) {
             isChange = true;
-            LogUtils.info(log, "remove url success, group:{}, topic:{}, url:{}", consumerGroup, unSubTopic, unSubscribeUrl);
+            log.info("remove url success, group:{}, topic:{}, url:{}", consumerGroup, unSubTopic, unSubscribeUrl);
         } else {
-            LogUtils.warn(log, "remove url fail, not exist subscrition of this url, group:{}, topic:{}, url:{}",
-                consumerGroup, unSubTopic, unSubscribeUrl);
+            log.warn("remove url fail, not exist subscrition of this url, group:{}, topic:{}, url:{}", consumerGroup, unSubTopic, unSubscribeUrl);
         }
 
         if (consumerGroupTopicConf.getIdcUrls().containsKey(clientIdc)) {
             if (consumerGroupTopicConf.getIdcUrls().get(clientIdc).remove(unSubscribeUrl)) {
                 isChange = true;
-                LogUtils.info(log, "remove url from idcUrlMap success, group:{}, topic:{}, url:{}, clientIdc:{}",
-                    consumerGroup, unSubTopic, unSubscribeUrl, clientIdc);
+                log.info("remove url from idcUrlMap success, group:{}, topic:{}, url:{}, clientIdc:{}", consumerGroup, unSubTopic, unSubscribeUrl,
+                    clientIdc);
             } else {
-                LogUtils.warn(log, "remove url from idcUrlMap fail, not exist subscriber of this url, group:{}, topic:{}, url:{}, clientIdc:{}",
-                    consumerGroup, unSubTopic, unSubscribeUrl, clientIdc);
+                log.warn("remove url from idcUrlMap fail, not exist subscriber of this url, group:{}, topic:{}, url:{}, clientIdc:{}", consumerGroup,
+                    unSubTopic, unSubscribeUrl, clientIdc);
             }
         } else {
-            LogUtils.warn(log, "remove url from idcUrlMap fail,not exist subscrition of this idc , group:{}, topic:{}, url:{}, clientIdc:{}",
-                consumerGroup, unSubTopic, unSubscribeUrl, clientIdc);
+            log.warn("remove url from idcUrlMap fail,not exist subscrition of this idc , group:{}, topic:{}, url:{}, clientIdc:{}", consumerGroup,
+                unSubTopic, unSubscribeUrl, clientIdc);
         }
 
         if (isChange && CollectionUtils.isEmpty(consumerGroupTopicConf.getUrls())) {
             consumerGroupConf.getConsumerGroupTopicConf().remove(unSubTopic);
-            LogUtils.info(log, "group unsubscribe topic success,group:{}, topic:{}", consumerGroup, unSubTopic);
+            log.info("group unsubscribe topic success,group:{}, topic:{}", consumerGroup, unSubTopic);
         }
 
         if (isChange && MapUtils.isEmpty(consumerGroupConf.getConsumerGroupTopicConf())) {
             localConsumerGroupMapping.remove(consumerGroup);
-            LogUtils.info(log, "group unsubscribe success,group:{}", consumerGroup);
+            log.info("group unsubscribe success,group:{}", consumerGroup);
         }
         return isChange;
     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageProcessor.java
@@ -32,7 +32,6 @@ import org.apache.eventmesh.common.protocol.http.common.RequestCode;
 import org.apache.eventmesh.common.protocol.http.header.message.SendMessageBatchRequestHeader;
 import org.apache.eventmesh.common.protocol.http.header.message.SendMessageBatchResponseHeader;
 import org.apache.eventmesh.common.utils.IPUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.metrics.api.model.HttpSummaryMetrics;
 import org.apache.eventmesh.protocol.api.ProtocolAdaptor;
 import org.apache.eventmesh.protocol.api.ProtocolPluginFactory;
@@ -224,7 +223,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
                     topicBatchMessageMappings.put(cloudEvent.getSubject(), tmp);
                 }
 
-                LogUtils.debug(batchMessageLogger, "msg2MQMsg suc, event:{}", cloudEvent.getData());
+                batchMessageLogger.debug("msg2MQMsg suc, event:{}", cloudEvent.getData());
             } catch (Exception e) {
                 batchMessageLogger.error("msg2MQMsg err, event:{}", cloudEvent.getData(), e);
             }
@@ -283,8 +282,8 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
         long elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);
         summaryMetrics.recordBatchSendMsgCost(elapsed);
 
-        LogUtils.debug(batchMessageLogger, "batchMessage|eventMesh2mq|REQ|ASYNC|batchId={}|send2MQCost={}ms|msgNum={}|topics={}",
-            batchId, elapsed, eventSize, topicBatchMessageMappings.keySet());
+        batchMessageLogger.debug("batchMessage|eventMesh2mq|REQ|ASYNC|batchId={}|send2MQCost={}ms|msgNum={}|topics={}", batchId, elapsed, eventSize,
+            topicBatchMessageMappings.keySet());
         completeResponse(request, asyncContext, sendMessageBatchResponseHeader, EventMeshRetCode.SUCCESS, null,
             SendMessageBatchResponseBody.class);
         return;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageV2Processor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageV2Processor.java
@@ -31,7 +31,6 @@ import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.http.common.RequestCode;
 import org.apache.eventmesh.common.protocol.http.header.message.SendMessageBatchV2RequestHeader;
 import org.apache.eventmesh.common.protocol.http.header.message.SendMessageBatchV2ResponseHeader;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.metrics.api.model.HttpSummaryMetrics;
 import org.apache.eventmesh.protocol.api.ProtocolAdaptor;
 import org.apache.eventmesh.protocol.api.ProtocolPluginFactory;
@@ -198,7 +197,7 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
                 .withExtension(EventMeshConstants.REQ_EVENTMESH2MQ_TIMESTAMP,
                     String.valueOf(System.currentTimeMillis()))
                 .build();
-            LogUtils.debug(batchMessageLogger, "msg2MQMsg suc, topic:{}, msg:{}", topic, event.getData());
+            batchMessageLogger.debug("msg2MQMsg suc, topic:{}, msg:{}", topic, event.getData());
 
         } catch (Exception e) {
             batchMessageLogger.error("msg2MQMsg err, topic:{}, msg:{}", topic, event.getData(), e);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/CreateTopicProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/CreateTopicProcessor.java
@@ -23,7 +23,6 @@ import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.http.common.RequestURI;
 import org.apache.eventmesh.common.utils.IPUtils;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.boot.EventMeshHTTPServer;
 import org.apache.eventmesh.runtime.common.EventMeshTrace;
 import org.apache.eventmesh.runtime.constants.EventMeshConstants;
@@ -118,7 +117,7 @@ public class CreateTopicProcessor implements AsyncHttpProcessor {
 
             final CompleteHandler<HttpEventWrapper> handler = httpEventWrapper -> {
                 try {
-                    LogUtils.debug(httpLogger, "{}", httpEventWrapper);
+                    httpLogger.debug("{}", httpEventWrapper);
                     eventMeshHTTPServer.sendResponse(ctx, httpEventWrapper.httpResponse());
                     eventMeshHTTPServer.getMetrics().getSummaryMetrics().recordHTTPReqResTimeCost(
                         System.currentTimeMillis() - requestWrapper.getReqTime());

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/DeleteTopicProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/DeleteTopicProcessor.java
@@ -23,7 +23,6 @@ import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.http.common.RequestURI;
 import org.apache.eventmesh.common.utils.IPUtils;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.boot.EventMeshHTTPServer;
 import org.apache.eventmesh.runtime.common.EventMeshTrace;
 import org.apache.eventmesh.runtime.constants.EventMeshConstants;
@@ -141,7 +140,7 @@ public class DeleteTopicProcessor implements AsyncHttpProcessor {
 
             final CompleteHandler<HttpEventWrapper> handler = httpEventWrapper -> {
                 try {
-                    LogUtils.debug(httpLogger, "{}", httpEventWrapper);
+                    httpLogger.debug("{}", httpEventWrapper);
                     eventMeshHTTPServer.sendResponse(ctx, httpEventWrapper.httpResponse());
                     eventMeshHTTPServer.getMetrics().getSummaryMetrics().recordHTTPReqResTimeCost(
                         System.currentTimeMillis() - requestWrapper.getReqTime());

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/HandlerService.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/HandlerService.java
@@ -22,7 +22,6 @@ import org.apache.eventmesh.common.enums.ConnectionType;
 import org.apache.eventmesh.common.protocol.http.HttpEventWrapper;
 import org.apache.eventmesh.common.protocol.http.common.EventMeshRetCode;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.boot.HTTPTrace;
 import org.apache.eventmesh.runtime.boot.HTTPTrace.TraceOperation;
 import org.apache.eventmesh.runtime.common.EventMeshTrace;
@@ -297,7 +296,7 @@ public class HandlerService {
 
         private void postHandler(ConnectionType type) {
             metrics.getSummaryMetrics().recordHTTPRequest();
-            LogUtils.debug(httpLogger, "{}", request);
+            httpLogger.debug("{}", request);
             if (Objects.isNull(response)) {
                 this.response = HttpResponseUtils.createSuccess();
             }
@@ -311,7 +310,7 @@ public class HandlerService {
 
         private void preHandler() {
             metrics.getSummaryMetrics().recordHTTPReqResTimeCost(System.currentTimeMillis() - requestTime);
-            LogUtils.debug(httpLogger, "{}", response);
+            httpLogger.debug("{}", response);
         }
 
         private void error() {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/HeartBeatProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/HeartBeatProcessor.java
@@ -25,7 +25,6 @@ import org.apache.eventmesh.common.protocol.http.common.RequestCode;
 import org.apache.eventmesh.common.protocol.http.header.client.HeartbeatRequestHeader;
 import org.apache.eventmesh.common.protocol.http.header.client.HeartbeatResponseHeader;
 import org.apache.eventmesh.common.utils.IPUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.metrics.api.model.HttpSummaryMetrics;
 import org.apache.eventmesh.runtime.acl.Acl;
 import org.apache.eventmesh.runtime.boot.EventMeshHTTPServer;
@@ -69,10 +68,8 @@ public class HeartBeatProcessor implements HttpRequestProcessor {
         HttpCommand responseEventMeshCommand;
         final String localAddress = IPUtils.getLocalAddress();
         HttpCommand request = asyncContext.getRequest();
-        LogUtils.info(log, "cmd={}|{}|client2eventMesh|from={}|to={}",
-            RequestCode.get(Integer.valueOf(request.getRequestCode())),
-            EventMeshConstants.PROTOCOL_HTTP,
-            RemotingHelper.parseChannelRemoteAddr(ctx.channel()), localAddress);
+        log.info("cmd={}|{}|client2eventMesh|from={}|to={}", RequestCode.get(Integer.valueOf(request.getRequestCode())),
+            EventMeshConstants.PROTOCOL_HTTP, RemotingHelper.parseChannelRemoteAddr(ctx.channel()), localAddress);
         final HeartbeatRequestHeader heartbeatRequestHeader = (HeartbeatRequestHeader) request.getHeader();
         final HeartbeatRequestBody heartbeatRequestBody = (HeartbeatRequestBody) request.getBody();
         EventMeshHTTPConfiguration httpConfiguration = eventMeshHTTPServer.getEventMeshHttpConfiguration();
@@ -131,7 +128,7 @@ public class HeartBeatProcessor implements HttpRequestProcessor {
                 } catch (Exception e) {
                     completeResponse(request, asyncContext, heartbeatResponseHeader,
                         EventMeshRetCode.EVENTMESH_ACL_ERR, e.getMessage(), HeartbeatResponseBody.class);
-                    LogUtils.warn(log, "CLIENT HAS NO PERMISSION,HeartBeatProcessor subscribe failed", e);
+                    log.warn("CLIENT HAS NO PERMISSION,HeartBeatProcessor subscribe failed", e);
                     return;
                 }
             }
@@ -164,7 +161,7 @@ public class HeartBeatProcessor implements HttpRequestProcessor {
         try {
             final CompleteHandler<HttpCommand> handler = httpCommand -> {
                 try {
-                    LogUtils.debug(log, "{}", httpCommand);
+                    log.debug("{}", httpCommand);
                     eventMeshHTTPServer.sendResponse(ctx, httpCommand.httpResponse());
                     summaryMetrics.recordHTTPReqResTimeCost(
                         System.currentTimeMillis() - request.getReqTime());
@@ -180,7 +177,7 @@ public class HeartBeatProcessor implements HttpRequestProcessor {
                 EventMeshRetCode.EVENTMESH_HEARTBEAT_ERR.getErrMsg() + EventMeshUtil.stackTrace(e, 2),
                 HeartbeatResponseBody.class);
             final long elapsedTime = System.currentTimeMillis() - startTime;
-            LogUtils.error(log, "message|eventMesh2mq|REQ|ASYNC|heartBeatMessageCost={}ms", elapsedTime, e);
+            log.error("message|eventMesh2mq|REQ|ASYNC|heartBeatMessageCost={}ms", elapsedTime, e);
             summaryMetrics.recordSendMsgFailed();
             summaryMetrics.recordSendMsgCost(elapsedTime);
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalSubscribeEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalSubscribeEventProcessor.java
@@ -25,7 +25,6 @@ import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.http.common.RequestURI;
 import org.apache.eventmesh.common.utils.IPUtils;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.acl.Acl;
 import org.apache.eventmesh.runtime.boot.EventMeshHTTPServer;
 import org.apache.eventmesh.runtime.common.EventMeshTrace;
@@ -68,8 +67,8 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
         final HttpEventWrapper requestWrapper = handlerSpecific.getAsyncContext().getRequest();
         String localAddress = IPUtils.getLocalAddress();
         String remoteAddr = RemotingHelper.parseChannelRemoteAddr(channel);
-        LogUtils.info(log, "uri={}|{}|client2eventMesh|from={}|to={}", requestWrapper.getRequestURI(),
-            EventMeshConstants.PROTOCOL_HTTP, remoteAddr, localAddress);
+        log.info("uri={}|{}|client2eventMesh|from={}|to={}", requestWrapper.getRequestURI(), EventMeshConstants.PROTOCOL_HTTP, remoteAddr,
+            localAddress);
 
         // user request header
         requestWrapper.getHeaderMap().put(ProtocolKey.ClientInstanceKey.IP.getKey(), remoteAddr);
@@ -119,7 +118,7 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
                     this.acl.doAclCheckInHttpReceive(remoteAddr, user, pass, subsystem, item.getTopic(),
                         requestWrapper.getRequestURI());
                 } catch (Exception e) {
-                    LogUtils.warn(log, "CLIENT HAS NO PERMISSION,SubscribeProcessor subscribe failed", e);
+                    log.warn("CLIENT HAS NO PERMISSION,SubscribeProcessor subscribe failed", e);
 
                     handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_ACL_ERR, responseHeaderMap,
                         responseBodyMap, null);
@@ -132,14 +131,14 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
         try {
             if (!IPUtils.isValidDomainOrIp(url, eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshIpv4BlackList(),
                 eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshIpv6BlackList())) {
-                LogUtils.error(log, "subscriber url {} is not valid", url);
+                log.error("subscriber url {} is not valid", url);
 
                 handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR, responseHeaderMap,
                     responseBodyMap, null);
                 return;
             }
         } catch (Exception e) {
-            LogUtils.error(log, "subscriber url {} is not valid", url, e);
+            log.error("subscriber url {} is not valid", url, e);
 
             handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR, responseHeaderMap,
                 responseBodyMap, null);
@@ -149,7 +148,7 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
         // obtain webhook delivery agreement for Abuse Protection
         if (!WebhookUtil.obtainDeliveryAgreement(eventMeshHTTPServer.getHttpClientPool().getClient(),
             url, eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshWebhookOrigin())) {
-            LogUtils.error(log, "subscriber url {} is not allowed by the target system", url);
+            log.error("subscriber url {} is not allowed by the target system", url);
             handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR, responseHeaderMap,
                 responseBodyMap, null);
             return;
@@ -172,10 +171,8 @@ public class LocalSubscribeEventProcessor extends AbstractEventProcessor {
                 handlerSpecific.sendResponse(responseHeaderMap, responseBodyMap);
 
             } catch (Exception e) {
-                LogUtils.error(log, "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}|url={}",
-                    System.currentTimeMillis() - startTime,
-                    JsonUtils.toJSONString(subscriptionList),
-                    url, e);
+                log.error("message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}|url={}", System.currentTimeMillis() - startTime,
+                    JsonUtils.toJSONString(subscriptionList), url, e);
 
                 handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_SUBSCRIBE_ERR, responseHeaderMap,
                     responseBodyMap, null);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalUnSubscribeEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/LocalUnSubscribeEventProcessor.java
@@ -24,7 +24,6 @@ import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.http.common.RequestURI;
 import org.apache.eventmesh.common.utils.IPUtils;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.boot.EventMeshHTTPServer;
 import org.apache.eventmesh.runtime.common.EventMeshTrace;
 import org.apache.eventmesh.runtime.constants.EventMeshConstants;
@@ -78,8 +77,8 @@ public class LocalUnSubscribeEventProcessor extends AbstractEventProcessor {
         String localAddress = IPUtils.getLocalAddress();
         String remoteAddr = RemotingHelper.parseChannelRemoteAddr(ctx.channel());
 
-        LogUtils.info(log, "uri={}|{}|client2eventMesh|from={}|to={}", requestWrapper.getRequestURI(),
-            EventMeshConstants.PROTOCOL_HTTP, remoteAddr, localAddress);
+        log.info("uri={}|{}|client2eventMesh|from={}|to={}", requestWrapper.getRequestURI(), EventMeshConstants.PROTOCOL_HTTP, remoteAddr,
+            localAddress);
 
         // user request header
         requestWrapper.getHeaderMap().put(ProtocolKey.ClientInstanceKey.IP.getKey(), remoteAddr);
@@ -136,7 +135,7 @@ public class LocalUnSubscribeEventProcessor extends AbstractEventProcessor {
                     final Client client = clientIterator.next();
                     if (StringUtils.equals(client.getPid(), pid)
                         && StringUtils.equals(client.getUrl(), unSubscribeUrl)) {
-                        LogUtils.warn(log, "client {} start unsubscribe", JsonUtils.toJSONString(client));
+                        log.warn("client {} start unsubscribe", JsonUtils.toJSONString(client));
                         clientIterator.remove();
                     }
                 }
@@ -192,9 +191,8 @@ public class LocalUnSubscribeEventProcessor extends AbstractEventProcessor {
                     handlerSpecific.sendResponse(responseHeaderMap, responseBodyMap);
 
                 } catch (Exception e) {
-                    LogUtils.error(log, "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms"
-                        + "|topic={}|url={}", System.currentTimeMillis() - startTime,
-                        JsonUtils.toJSONString(unSubTopicList), unSubscribeUrl, e);
+                    log.error("message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms"
+                        + "|topic={}|url={}", System.currentTimeMillis() - startTime, JsonUtils.toJSONString(unSubTopicList), unSubscribeUrl, e);
                     handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_UNSUBSCRIBE_ERR, responseHeaderMap,
                         responseBodyMap, null);
                 }
@@ -214,9 +212,8 @@ public class LocalUnSubscribeEventProcessor extends AbstractEventProcessor {
                     eventMeshHTTPServer.getSubscriptionManager().getLocalConsumerGroupMapping().keySet()
                         .removeIf(s -> StringUtils.equals(consumerGroup, s));
                 } catch (Exception e) {
-                    LogUtils.error(log, "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms"
-                        + "|topic={}|url={}", System.currentTimeMillis() - startTime,
-                        JsonUtils.toJSONString(unSubTopicList), unSubscribeUrl, e);
+                    log.error("message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms"
+                        + "|topic={}|url={}", System.currentTimeMillis() - startTime, JsonUtils.toJSONString(unSubTopicList), unSubscribeUrl, e);
                     handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_UNSUBSCRIBE_ERR, responseHeaderMap,
                         responseBodyMap, null);
                 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/QuerySubscriptionProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/QuerySubscriptionProcessor.java
@@ -22,7 +22,6 @@ import org.apache.eventmesh.common.protocol.http.common.EventMeshRetCode;
 import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.http.common.RequestURI;
 import org.apache.eventmesh.common.utils.IPUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.boot.EventMeshHTTPServer;
 import org.apache.eventmesh.runtime.common.EventMeshTrace;
 import org.apache.eventmesh.runtime.constants.EventMeshConstants;
@@ -79,7 +78,7 @@ public class QuerySubscriptionProcessor implements AsyncHttpProcessor {
 
             final CompleteHandler<HttpEventWrapper> handler = httpEventWrapper -> {
                 try {
-                    LogUtils.debug(httpLogger, "{}", httpEventWrapper);
+                    httpLogger.debug("{}", httpEventWrapper);
                     eventMeshHTTPServer.sendResponse(ctx, httpEventWrapper.httpResponse());
                     eventMeshHTTPServer.getMetrics().getSummaryMetrics().recordHTTPReqResTimeCost(
                         System.currentTimeMillis() - requestWrapper.getReqTime());

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/ReplyMessageProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/ReplyMessageProcessor.java
@@ -31,7 +31,6 @@ import org.apache.eventmesh.common.protocol.http.common.RequestCode;
 import org.apache.eventmesh.common.protocol.http.header.message.ReplyMessageRequestHeader;
 import org.apache.eventmesh.common.protocol.http.header.message.ReplyMessageResponseHeader;
 import org.apache.eventmesh.common.utils.IPUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.metrics.api.model.HttpSummaryMetrics;
 import org.apache.eventmesh.protocol.api.ProtocolAdaptor;
 import org.apache.eventmesh.protocol.api.ProtocolPluginFactory;
@@ -176,7 +175,7 @@ public class ReplyMessageProcessor implements HttpRequestProcessor {
                 .withExtension(EventMeshConstants.REQ_C2EVENTMESH_TIMESTAMP, String.valueOf(System.currentTimeMillis()))
                 .build();
 
-            LogUtils.debug(messageLogger, "msg2MQMsg suc, bizSeqNo={}, topic={}", bizNo, replyTopic);
+            messageLogger.debug("msg2MQMsg suc, bizSeqNo={}, topic={}", bizNo, replyTopic);
 
         } catch (Exception e) {
             messageLogger.error("msg2MQMsg err, bizSeqNo={}, topic={}", bizNo, replyTopic, e);
@@ -191,7 +190,7 @@ public class ReplyMessageProcessor implements HttpRequestProcessor {
         summaryMetrics.recordReplyMsg();
         CompleteHandler<HttpCommand> handler = httpCommand -> {
             try {
-                LogUtils.debug(httpLogger, "{}", httpCommand);
+                httpLogger.debug("{}", httpCommand);
                 eventMeshHTTPServer.sendResponse(ctx, httpCommand.httpResponse());
                 summaryMetrics.recordHTTPReqResTimeCost(
                     System.currentTimeMillis() - request.getReqTime());

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendAsyncEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendAsyncEventProcessor.java
@@ -30,7 +30,6 @@ import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.http.common.RequestURI;
 import org.apache.eventmesh.common.utils.IPUtils;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.RandomStringUtils;
 import org.apache.eventmesh.filter.pattern.Pattern;
 import org.apache.eventmesh.protocol.api.ProtocolAdaptor;
@@ -85,8 +84,8 @@ public class SendAsyncEventProcessor implements AsyncHttpProcessor {
 
         final String localAddress = IPUtils.getLocalAddress();
 
-        LogUtils.info(log, "uri={}|{}|client2eventMesh|from={}|to={}", requestWrapper.getRequestURI(),
-            EventMeshConstants.PROTOCOL_HTTP, RemotingHelper.parseChannelRemoteAddr(ctx.channel()), localAddress);
+        log.info("uri={}|{}|client2eventMesh|from={}|to={}", requestWrapper.getRequestURI(), EventMeshConstants.PROTOCOL_HTTP,
+            RemotingHelper.parseChannelRemoteAddr(ctx.channel()), localAddress);
 
         // user request header
         final Map<String, Object> requestHeaderMap = requestWrapper.getHeaderMap();
@@ -188,7 +187,7 @@ public class SendAsyncEventProcessor implements AsyncHttpProcessor {
             } catch (Exception e) {
                 handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_ACL_ERR, responseHeaderMap,
                     responseBodyMap, EventMeshUtil.getCloudEventExtensionMap(SpecVersion.V1.toString(), event));
-                LogUtils.warn(log, "CLIENT HAS NO PERMISSION,SendAsyncMessageProcessor send failed", e);
+                log.warn("CLIENT HAS NO PERMISSION,SendAsyncMessageProcessor send failed", e);
                 return;
             }
         }
@@ -216,8 +215,7 @@ public class SendAsyncEventProcessor implements AsyncHttpProcessor {
 
         final String content = new String(Objects.requireNonNull(event.getData()).toBytes(), StandardCharsets.UTF_8);
         if (Objects.requireNonNull(content).length() > eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshEventSize()) {
-            LogUtils.error(log, "Event size exceeds the limit: {}",
-                eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshEventSize());
+            log.error("Event size exceeds the limit: {}", eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshEventSize());
             handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_SIZE_ERR, responseHeaderMap,
                 responseBodyMap, EventMeshUtil.getCloudEventExtensionMap(SpecVersion.V1.toString(), event));
             return;
@@ -230,9 +228,9 @@ public class SendAsyncEventProcessor implements AsyncHttpProcessor {
                 .withExtension(EventMeshConstants.REQ_EVENTMESH2MQ_TIMESTAMP, String.valueOf(System.currentTimeMillis()))
                 .build();
 
-            LogUtils.debug(log, "msg2MQMsg suc, bizSeqNo={}, topic={}", bizNo, topic);
+            log.debug("msg2MQMsg suc, bizSeqNo={}, topic={}", bizNo, topic);
         } catch (Exception e) {
-            LogUtils.error(log, "msg2MQMsg err, bizSeqNo={}, topic={}", bizNo, topic, e);
+            log.error("msg2MQMsg err, bizSeqNo={}, topic={}", bizNo, topic, e);
             handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_PACKAGE_MSG_ERR, responseHeaderMap,
                 responseBodyMap, EventMeshUtil.getCloudEventExtensionMap(SpecVersion.V1.toString(), event));
             return;
@@ -270,7 +268,7 @@ public class SendAsyncEventProcessor implements AsyncHttpProcessor {
                         responseBodyMap.put(EventMeshConstants.RET_CODE, EventMeshRetCode.SUCCESS.getRetCode());
                         responseBodyMap.put(EventMeshConstants.RET_MSG, EventMeshRetCode.SUCCESS.getErrMsg() + sendResult);
 
-                        LogUtils.info(log, "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}|bizSeqNo={}|uniqueId={}",
+                        log.info("message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}|bizSeqNo={}|uniqueId={}",
                             System.currentTimeMillis() - startTime, topic, bizNo, uniqueId);
                         handlerSpecific.getTraceOperation().endLatestTrace(sendMessageContext.getEvent());
                         handlerSpecific.sendResponse(responseHeaderMap, responseBodyMap);
@@ -286,12 +284,12 @@ public class SendAsyncEventProcessor implements AsyncHttpProcessor {
                             EventMeshUtil.getCloudEventExtensionMap(SpecVersion.V1.toString(), sendMessageContext.getEvent()));
 
                         handlerSpecific.sendResponse(responseHeaderMap, responseBodyMap);
-                        LogUtils.error(log, "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}|bizSeqNo={}|uniqueId={}",
+                        log.error("message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}|bizSeqNo={}|uniqueId={}",
                             System.currentTimeMillis() - startTime, topic, bizNo, uniqueId, context.getException());
                     }
                 });
             } else {
-                LogUtils.error(log, "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}|bizSeqNo={}|uniqueId={}|apply filter failed",
+                log.error("message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}|bizSeqNo={}|uniqueId={}|apply filter failed",
                     System.currentTimeMillis() - startTime, topic, bizNo, uniqueId);
                 handlerSpecific.getTraceOperation().endLatestTrace(sendMessageContext.getEvent());
                 handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_FILTER_MSG_ERR, responseHeaderMap, responseBodyMap,
@@ -303,8 +301,8 @@ public class SendAsyncEventProcessor implements AsyncHttpProcessor {
             handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_SEND_ASYNC_MSG_ERR, responseHeaderMap, responseBodyMap, null);
 
             final long endTime = System.currentTimeMillis();
-            LogUtils.error(log, "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}|bizSeqNo={}|uniqueId={}",
-                endTime - startTime, topic, bizNo, uniqueId, ex);
+            log.error("message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}|bizSeqNo={}|uniqueId={}", endTime - startTime, topic, bizNo, uniqueId,
+                ex);
         }
     }
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendAsyncMessageProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendAsyncMessageProcessor.java
@@ -31,7 +31,6 @@ import org.apache.eventmesh.common.protocol.http.common.RequestCode;
 import org.apache.eventmesh.common.protocol.http.header.message.SendMessageRequestHeader;
 import org.apache.eventmesh.common.protocol.http.header.message.SendMessageResponseHeader;
 import org.apache.eventmesh.common.utils.IPUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.metrics.api.model.HttpSummaryMetrics;
 import org.apache.eventmesh.protocol.api.ProtocolAdaptor;
 import org.apache.eventmesh.protocol.api.ProtocolPluginFactory;
@@ -213,7 +212,7 @@ public class SendAsyncMessageProcessor implements HttpRequestProcessor {
                 .withExtension(EventMeshConstants.REQ_SEND_EVENTMESH_IP, eventMeshHttpConfiguration.getEventMeshServerIp())
                 .build();
 
-            LogUtils.debug(MESSAGE_LOGGER, "msg2MQMsg suc, bizSeqNo={}, topic={}", bizNo, topic);
+            MESSAGE_LOGGER.debug("msg2MQMsg suc, bizSeqNo={}, topic={}", bizNo, topic);
         } catch (Exception e) {
             MESSAGE_LOGGER.error("msg2MQMsg err, bizSeqNo={}, topic={}", bizNo, topic, e);
             completeResponse(request, asyncContext, sendMessageResponseHeader,
@@ -232,7 +231,7 @@ public class SendAsyncMessageProcessor implements HttpRequestProcessor {
 
         final CompleteHandler<HttpCommand> handler = httpCommand -> {
             try {
-                LogUtils.debug(HTTP_LOGGER, "{}", httpCommand);
+                HTTP_LOGGER.debug("{}", httpCommand);
                 eventMeshHTTPServer.sendResponse(ctx, httpCommand.httpResponse());
 
                 summaryMetrics.recordHTTPReqResTimeCost(

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendAsyncRemoteEventProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendAsyncRemoteEventProcessor.java
@@ -28,7 +28,6 @@ import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.http.common.RequestURI;
 import org.apache.eventmesh.common.utils.IPUtils;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.RandomStringUtils;
 import org.apache.eventmesh.protocol.api.ProtocolAdaptor;
 import org.apache.eventmesh.protocol.api.ProtocolPluginFactory;
@@ -87,8 +86,8 @@ public class SendAsyncRemoteEventProcessor implements AsyncHttpProcessor {
         final HttpEventWrapper requestWrapper = asyncContext.getRequest();
 
         final String localAddress = IPUtils.getLocalAddress();
-        LogUtils.info(log, "uri={}|{}|client2eventMesh|from={}|to={}", requestWrapper.getRequestURI(),
-            EventMeshConstants.PROTOCOL_HTTP, RemotingHelper.parseChannelRemoteAddr(ctx.channel()), localAddress);
+        log.info("uri={}|{}|client2eventMesh|from={}|to={}", requestWrapper.getRequestURI(), EventMeshConstants.PROTOCOL_HTTP,
+            RemotingHelper.parseChannelRemoteAddr(ctx.channel()), localAddress);
 
         // user request header
         final Map<String, Object> requestHeaderMap = requestWrapper.getHeaderMap();
@@ -243,8 +242,7 @@ public class SendAsyncRemoteEventProcessor implements AsyncHttpProcessor {
 
         final String content = event.getData() == null ? "" : new String(event.getData().toBytes(), StandardCharsets.UTF_8);
         if (content.length() > eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshEventSize()) {
-            LogUtils.error(log, "Event size exceeds the limit: {}",
-                eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshEventSize());
+            log.error("Event size exceeds the limit: {}", eventMeshHTTPServer.getEventMeshHttpConfiguration().getEventMeshEventSize());
             handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_SIZE_ERR, responseHeaderMap,
                 responseBodyMap, EventMeshUtil.getCloudEventExtensionMap(SpecVersion.V1.toString(), event));
             return;
@@ -257,9 +255,9 @@ public class SendAsyncRemoteEventProcessor implements AsyncHttpProcessor {
                 .withExtension(EventMeshConstants.REQ_EVENTMESH2MQ_TIMESTAMP, String.valueOf(System.currentTimeMillis()))
                 .build();
 
-            LogUtils.debug(log, "msg2MQMsg suc, bizSeqNo={}, topic={}", bizNo, topic);
+            log.debug("msg2MQMsg suc, bizSeqNo={}, topic={}", bizNo, topic);
         } catch (Exception e) {
-            LogUtils.error(log, "msg2MQMsg err, bizSeqNo={}, topic={}", bizNo, topic, e);
+            log.error("msg2MQMsg err, bizSeqNo={}, topic={}", bizNo, topic, e);
             handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_PACKAGE_MSG_ERR, responseHeaderMap,
                 responseBodyMap, EventMeshUtil.getCloudEventExtensionMap(SpecVersion.V1.toString(), event));
             return;
@@ -285,7 +283,7 @@ public class SendAsyncRemoteEventProcessor implements AsyncHttpProcessor {
                     responseBodyMap.put(EventMeshConstants.RET_CODE, EventMeshRetCode.SUCCESS.getRetCode());
                     responseBodyMap.put(EventMeshConstants.RET_MSG, EventMeshRetCode.SUCCESS.getErrMsg() + sendResult);
 
-                    LogUtils.info(log, "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}|bizSeqNo={}|uniqueId={}",
+                    log.info("message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}|bizSeqNo={}|uniqueId={}",
                         System.currentTimeMillis() - startTime, topic, bizNo, uniqueId);
                     handlerSpecific.getTraceOperation().endLatestTrace(sendMessageContext.getEvent());
                     handlerSpecific.sendResponse(responseHeaderMap, responseBodyMap);
@@ -302,7 +300,7 @@ public class SendAsyncRemoteEventProcessor implements AsyncHttpProcessor {
 
                     handlerSpecific.sendResponse(responseHeaderMap, responseBodyMap);
 
-                    LogUtils.error(log, "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}|bizSeqNo={}|uniqueId={}",
+                    log.error("message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}|bizSeqNo={}|uniqueId={}",
                         System.currentTimeMillis() - startTime, topic, bizNo, uniqueId, context.getException());
                 }
             });
@@ -311,8 +309,8 @@ public class SendAsyncRemoteEventProcessor implements AsyncHttpProcessor {
             handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_SEND_ASYNC_MSG_ERR, responseHeaderMap,
                 responseBodyMap, null);
 
-            LogUtils.error(log, "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}|bizSeqNo={}|uniqueId={}",
-                System.currentTimeMillis() - startTime, topic, bizNo, uniqueId, ex);
+            log.error("message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}|bizSeqNo={}|uniqueId={}", System.currentTimeMillis() - startTime,
+                topic, bizNo, uniqueId, ex);
         }
     }
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendSyncMessageProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SendSyncMessageProcessor.java
@@ -30,7 +30,6 @@ import org.apache.eventmesh.common.protocol.http.header.message.SendMessageReque
 import org.apache.eventmesh.common.protocol.http.header.message.SendMessageResponseHeader;
 import org.apache.eventmesh.common.utils.IPUtils;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.metrics.api.model.HttpSummaryMetrics;
 import org.apache.eventmesh.protocol.api.ProtocolAdaptor;
 import org.apache.eventmesh.protocol.api.ProtocolPluginFactory;
@@ -78,8 +77,7 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
         HttpCommand request = asyncContext.getRequest();
         final String localAddress = IPUtils.getLocalAddress();
         final String remoteAddr = RemotingHelper.parseChannelRemoteAddr(ctx.channel());
-        LogUtils.info(log, "cmd={}|{}|client2eventMesh|from={}|to={}",
-            RequestCode.get(Integer.valueOf(request.getRequestCode())),
+        log.info("cmd={}|{}|client2eventMesh|from={}|to={}", RequestCode.get(Integer.valueOf(request.getRequestCode())),
             EventMeshConstants.PROTOCOL_HTTP, remoteAddr, localAddress);
 
         SendMessageRequestHeader sendMessageRequestHeader = (SendMessageRequestHeader) request.getHeader();
@@ -142,7 +140,7 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
             } catch (Exception e) {
                 completeResponse(request, asyncContext, sendMessageResponseHeader,
                     EventMeshRetCode.EVENTMESH_ACL_ERR, e.getMessage(), SendMessageResponseBody.class);
-                LogUtils.warn(log, "CLIENT HAS NO PERMISSION,SendSyncMessageProcessor send failed", e);
+                log.warn("CLIENT HAS NO PERMISSION,SendSyncMessageProcessor send failed", e);
                 return;
             }
         }
@@ -160,7 +158,7 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
         final String content = new String(Objects.requireNonNull(event.getData()).toBytes(), Constants.DEFAULT_CHARSET);
         int eventMeshEventSize = eventMeshHttpConfiguration.getEventMeshEventSize();
         if (content.length() > eventMeshEventSize) {
-            LogUtils.error(log, "Event size exceeds the limit: {}", eventMeshEventSize);
+            log.error("Event size exceeds the limit: {}", eventMeshEventSize);
             completeResponse(request, asyncContext, sendMessageResponseHeader,
                 EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR,
                 "Event size exceeds the limit: " + eventMeshEventSize,
@@ -185,10 +183,10 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
                 .withExtension(EventMeshConstants.REQ_EVENTMESH2MQ_TIMESTAMP, String.valueOf(System.currentTimeMillis()))
                 .build();
 
-            LogUtils.debug(log, "msg2MQMsg suc, bizSeqNo={}, topic={}", bizNo, topic);
+            log.debug("msg2MQMsg suc, bizSeqNo={}, topic={}", bizNo, topic);
 
         } catch (Exception e) {
-            LogUtils.error(log, "msg2MQMsg err, bizSeqNo={}, topic={}", bizNo, topic, e);
+            log.error("msg2MQMsg err, bizSeqNo={}, topic={}", bizNo, topic, e);
             completeResponse(request, asyncContext, sendMessageResponseHeader,
                 EventMeshRetCode.EVENTMESH_PACKAGE_MSG_ERR, null, SendMessageResponseBody.class);
             return;
@@ -202,7 +200,7 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
 
         final CompleteHandler<HttpCommand> handler = httpCommand -> {
             try {
-                LogUtils.debug(log, "{}", httpCommand);
+                log.debug("{}", httpCommand);
                 eventMeshHTTPServer.sendResponse(ctx, httpCommand.httpResponse());
                 eventMeshHTTPServer.getMetrics().getSummaryMetrics().recordHTTPReqResTimeCost(
                     System.currentTimeMillis() - asyncContext.getRequest().getReqTime());
@@ -217,9 +215,8 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
 
                 @Override
                 public void onSuccess(final CloudEvent event) {
-                    LogUtils.info(log, "message|mq2eventMesh|RSP|SYNC|rrCost={}ms|topic={}"
-                        + "|bizSeqNo={}|uniqueId={}", System.currentTimeMillis() - startTime,
-                        topic, bizNo, uniqueId);
+                    log.info("message|mq2eventMesh|RSP|SYNC|rrCost={}ms|topic={}"
+                        + "|bizSeqNo={}|uniqueId={}", System.currentTimeMillis() - startTime, topic, bizNo, uniqueId);
 
                     try {
                         final CloudEvent newEvent = CloudEventBuilder.from(event)
@@ -250,7 +247,7 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
                                     + EventMeshUtil.stackTrace(ex, 2)));
                         asyncContext.onComplete(err, handler);
 
-                        LogUtils.warn(log, "message|mq2eventMesh|RSP", ex);
+                        log.warn("message|mq2eventMesh|RSP", ex);
                     }
                 }
 
@@ -265,10 +262,8 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
                     asyncContext.onComplete(err, handler);
 
                     eventMeshHTTPServer.getHttpRetryer().newTimeout(sendMessageContext, 10, TimeUnit.SECONDS);
-                    LogUtils.error(log, "message|mq2eventMesh|RSP|SYNC|rrCost={}ms|topic={}"
-                        + "|bizSeqNo={}|uniqueId={}",
-                        System.currentTimeMillis() - startTime,
-                        topic, bizNo, uniqueId, e);
+                    log.error("message|mq2eventMesh|RSP|SYNC|rrCost={}ms|topic={}"
+                        + "|bizSeqNo={}|uniqueId={}", System.currentTimeMillis() - startTime, topic, bizNo, uniqueId, e);
                 }
             }, Integer.parseInt(ttl));
         } catch (Exception ex) {
@@ -281,8 +276,8 @@ public class SendSyncMessageProcessor implements HttpRequestProcessor {
             summaryMetrics.recordSendMsgFailed();
             summaryMetrics.recordSendMsgCost(endTime - startTime);
 
-            LogUtils.error(log, "message|eventMesh2mq|REQ|SYNC|send2MQCost={}ms|topic={}|bizSeqNo={}|uniqueId={}",
-                endTime - startTime, topic, bizNo, uniqueId, ex);
+            log.error("message|eventMesh2mq|REQ|SYNC|send2MQCost={}ms|topic={}|bizSeqNo={}|uniqueId={}", endTime - startTime, topic, bizNo, uniqueId,
+                ex);
         }
 
         return;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/SubscribeProcessor.java
@@ -27,7 +27,6 @@ import org.apache.eventmesh.common.protocol.http.header.client.SubscribeRequestH
 import org.apache.eventmesh.common.protocol.http.header.client.SubscribeResponseHeader;
 import org.apache.eventmesh.common.utils.IPUtils;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.metrics.api.model.HttpSummaryMetrics;
 import org.apache.eventmesh.runtime.acl.Acl;
 import org.apache.eventmesh.runtime.boot.EventMeshHTTPServer;
@@ -71,8 +70,8 @@ public class SubscribeProcessor implements HttpRequestProcessor {
         final Integer requestCode = Integer.valueOf(request.getRequestCode());
         final String localAddress = IPUtils.getLocalAddress();
         final String remoteAddr = RemotingHelper.parseChannelRemoteAddr(ctx.channel());
-        LogUtils.info(log, "cmd={}|{}|client2eventMesh|from={}|to={}",
-            RequestCode.get(requestCode), EventMeshConstants.PROTOCOL_HTTP, remoteAddr, localAddress);
+        log.info("cmd={}|{}|client2eventMesh|from={}|to={}", RequestCode.get(requestCode), EventMeshConstants.PROTOCOL_HTTP, remoteAddr,
+            localAddress);
 
         final SubscribeRequestHeader subscribeRequestHeader = (SubscribeRequestHeader) request.getHeader();
         final SubscribeRequestBody subscribeRequestBody = (SubscribeRequestBody) request.getBody();
@@ -115,7 +114,7 @@ public class SubscribeProcessor implements HttpRequestProcessor {
                 } catch (Exception e) {
                     completeResponse(request, asyncContext, subscribeResponseHeader,
                         EventMeshRetCode.EVENTMESH_ACL_ERR, e.getMessage(), SubscribeResponseBody.class);
-                    LogUtils.warn(log, "CLIENT HAS NO PERMISSION,SubscribeProcessor subscribe failed", e);
+                    log.warn("CLIENT HAS NO PERMISSION,SubscribeProcessor subscribe failed", e);
                     return;
                 }
             }
@@ -136,7 +135,7 @@ public class SubscribeProcessor implements HttpRequestProcessor {
                 return;
             }
         } catch (Exception e) {
-            LogUtils.error(log, "subscriber url:{} is invalid.", url, e);
+            log.error("subscriber url:{} is invalid.", url, e);
             completeResponse(request, asyncContext, subscribeResponseHeader,
                 EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR,
                 EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg() + " invalid URL: " + url,
@@ -170,7 +169,7 @@ public class SubscribeProcessor implements HttpRequestProcessor {
 
                 final CompleteHandler<HttpCommand> handler = httpCommand -> {
                     try {
-                        LogUtils.debug(log, "{}", httpCommand);
+                        log.debug("{}", httpCommand);
                         eventMeshHTTPServer.sendResponse(ctx, httpCommand.httpResponse());
 
                         summaryMetrics.recordHTTPReqResTimeCost(System.currentTimeMillis() - request.getReqTime());
@@ -187,10 +186,8 @@ public class SubscribeProcessor implements HttpRequestProcessor {
                     EventMeshRetCode.EVENTMESH_SUBSCRIBE_ERR.getErrMsg() + EventMeshUtil.stackTrace(e, 2),
                     SubscribeResponseBody.class);
                 final long endTime = System.currentTimeMillis();
-                LogUtils.error(log, "message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}"
-                    + "|bizSeqNo={}|uniqueId={}",
-                    endTime - startTime,
-                    JsonUtils.toJSONString(subscribeRequestBody.getTopics()),
+                log.error("message|eventMesh2mq|REQ|ASYNC|send2MQCost={}ms|topic={}"
+                    + "|bizSeqNo={}|uniqueId={}", endTime - startTime, JsonUtils.toJSONString(subscribeRequestBody.getTopics()),
                     subscribeRequestBody.getUrl(), e);
                 summaryMetrics.recordSendMsgFailed();
                 summaryMetrics.recordSendMsgCost(endTime - startTime);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/UnSubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/UnSubscribeProcessor.java
@@ -26,7 +26,6 @@ import org.apache.eventmesh.common.protocol.http.header.client.UnSubscribeReques
 import org.apache.eventmesh.common.protocol.http.header.client.UnSubscribeResponseHeader;
 import org.apache.eventmesh.common.utils.IPUtils;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.metrics.api.model.HttpSummaryMetrics;
 import org.apache.eventmesh.runtime.boot.EventMeshHTTPServer;
 import org.apache.eventmesh.runtime.configuration.EventMeshHTTPConfiguration;
@@ -74,10 +73,8 @@ public class UnSubscribeProcessor implements HttpRequestProcessor {
         final HttpCommand request = asyncContext.getRequest();
         final String localAddress = IPUtils.getLocalAddress();
 
-        LogUtils.info(log, "cmd={}|{}|client2eventMesh|from={}|to={}",
-            RequestCode.get(Integer.valueOf(request.getRequestCode())),
-            EventMeshConstants.PROTOCOL_HTTP,
-            RemotingHelper.parseChannelRemoteAddr(ctx.channel()), localAddress);
+        log.info("cmd={}|{}|client2eventMesh|from={}|to={}", RequestCode.get(Integer.valueOf(request.getRequestCode())),
+            EventMeshConstants.PROTOCOL_HTTP, RemotingHelper.parseChannelRemoteAddr(ctx.channel()), localAddress);
 
         final UnSubscribeRequestHeader unSubscribeRequestHeader = (UnSubscribeRequestHeader) request.getHeader();
         final UnSubscribeRequestBody unSubscribeRequestBody = (UnSubscribeRequestBody) request.getBody();
@@ -113,7 +110,7 @@ public class UnSubscribeProcessor implements HttpRequestProcessor {
         HttpSummaryMetrics summaryMetrics = eventMeshHTTPServer.getMetrics().getSummaryMetrics();
         final CompleteHandler<HttpCommand> handler = httpCommand -> {
             try {
-                LogUtils.debug(log, "{}", httpCommand);
+                log.debug("{}", httpCommand);
                 eventMeshHTTPServer.sendResponse(ctx, httpCommand.httpResponse());
                 summaryMetrics.recordHTTPReqResTimeCost(System.currentTimeMillis() - request.getReqTime());
             } catch (Exception ex) {
@@ -138,7 +135,7 @@ public class UnSubscribeProcessor implements HttpRequestProcessor {
                     final Client client = clientIterator.next();
                     if (StringUtils.equals(client.getPid(), pid)
                         && StringUtils.equals(client.getUrl(), unSubscribeUrl)) {
-                        LogUtils.warn(log, "client {} start unsubscribe", JsonUtils.toJSONString(client));
+                        log.warn("client {} start unsubscribe", JsonUtils.toJSONString(client));
                         clientIterator.remove();
                     }
                 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/push/AsyncHTTPPushRequest.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/push/AsyncHTTPPushRequest.java
@@ -29,7 +29,6 @@ import org.apache.eventmesh.common.protocol.http.common.ProtocolVersion;
 import org.apache.eventmesh.common.protocol.http.common.RequestCode;
 import org.apache.eventmesh.common.utils.IPUtils;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.RandomStringUtils;
 import org.apache.eventmesh.filter.pattern.Pattern;
 import org.apache.eventmesh.protocol.api.ProtocolAdaptor;
@@ -226,8 +225,7 @@ public class AsyncHTTPPushRequest extends AbstractHTTPPushRequest {
 
         addToWaitingMap(this);
 
-        LogUtils.info(CMD_LOGGER, "cmd={}|eventMesh2client|from={}|to={}", requestCode,
-            localAddress, currPushUrl);
+        CMD_LOGGER.info("cmd={}|eventMesh2client|from={}|to={}", requestCode, localAddress, currPushUrl);
 
         try {
             eventMeshHTTPServer.getHttpClientPool().getClient().execute(builder, response -> {
@@ -269,10 +267,9 @@ public class AsyncHTTPPushRequest extends AbstractHTTPPushRequest {
                     }
                 } else {
                     eventMeshHTTPServer.getMetrics().getSummaryMetrics().recordHttpPushMsgFailed();
-                    LogUtils.info(MESSAGE_LOGGER, "message|eventMesh2client|exception|url={}|topic={}|bizSeqNo={}"
-                        + "|uniqueId={}|cost={}",
-                        currPushUrl, handleMsgContext.getTopic(),
-                        handleMsgContext.getBizSeqNo(), handleMsgContext.getUniqueId(), cost);
+                    MESSAGE_LOGGER.info("message|eventMesh2client|exception|url={}|topic={}|bizSeqNo={}"
+                        + "|uniqueId={}|cost={}", currPushUrl, handleMsgContext.getTopic(), handleMsgContext.getBizSeqNo(),
+                        handleMsgContext.getUniqueId(), cost);
 
                     if (isComplete()) {
                         handleMsgContext.finish();
@@ -366,12 +363,12 @@ public class AsyncHTTPPushRequest extends AbstractHTTPPushRequest {
 
             return ClientRetCode.FAIL;
         } catch (NumberFormatException e) {
-            LogUtils.warn(MESSAGE_LOGGER, "url:{}, bizSeqno:{}, uniqueId:{}, httpResponse:{}", currPushUrl,
-                handleMsgContext.getBizSeqNo(), handleMsgContext.getUniqueId(), content);
+            MESSAGE_LOGGER.warn("url:{}, bizSeqno:{}, uniqueId:{}, httpResponse:{}", currPushUrl, handleMsgContext.getBizSeqNo(),
+                handleMsgContext.getUniqueId(), content);
             return ClientRetCode.FAIL;
         } catch (Exception e) {
-            LogUtils.warn(MESSAGE_LOGGER, "url:{}, bizSeqno:{}, uniqueId:{},  httpResponse:{}", currPushUrl,
-                handleMsgContext.getBizSeqNo(), handleMsgContext.getUniqueId(), content);
+            MESSAGE_LOGGER.warn("url:{}, bizSeqno:{}, uniqueId:{},  httpResponse:{}", currPushUrl, handleMsgContext.getBizSeqNo(),
+                handleMsgContext.getUniqueId(), content);
             return ClientRetCode.FAIL;
         }
     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/group/ClientGroupWrapper.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/group/ClientGroupWrapper.java
@@ -28,7 +28,6 @@ import org.apache.eventmesh.api.exception.OnExceptionContext;
 import org.apache.eventmesh.common.protocol.SubscriptionItem;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.boot.EventMeshTCPServer;
 import org.apache.eventmesh.runtime.configuration.EventMeshTCPConfiguration;
 import org.apache.eventmesh.runtime.constants.EventMeshConstants;
@@ -218,10 +217,10 @@ public class ClientGroupWrapper {
             }
             Session s = topic2sessionInGroupMapping.get(topic).putIfAbsent(session.getSessionId(), session);
             if (s == null) {
-                LogUtils.info(log, "Cache session success, group:{} topic:{} client:{} sessionId:{}", group,
-                    topic, session.getClient(), session.getSessionId());
+                log.info("Cache session success, group:{} topic:{} client:{} sessionId:{}", group, topic, session.getClient(),
+                    session.getSessionId());
             } else {
-                LogUtils.warn(log, "Session already exists in topic2sessionInGroupMapping. group:{} topic:{} client:{} sessionId:{}", group, topic,
+                log.warn("Session already exists in topic2sessionInGroupMapping. group:{} topic:{} client:{} sessionId:{}", group, topic,
                     session.getClient(), session.getSessionId());
             }
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/group/ClientSessionGroupMapping.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/group/ClientSessionGroupMapping.java
@@ -22,7 +22,6 @@ import org.apache.eventmesh.common.protocol.SubscriptionItem;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.runtime.boot.EventMeshTCPServer;
 import org.apache.eventmesh.runtime.constants.EventMeshConstants;
@@ -384,7 +383,7 @@ public class ClientSessionGroupMapping {
                     long interval = System.currentTimeMillis() - tmp.getLastHeartbeatTime();
                     if (interval > eventMeshTCPServer.getEventMeshTCPConfiguration().getEventMeshTcpSessionExpiredInMills()) {
                         try {
-                            LogUtils.warn(log, "clean expired session,client:{}", tmp.getClient());
+                            log.warn("clean expired session,client:{}", tmp.getClient());
                             closeSession(tmp.getContext());
                         } catch (Exception e) {
                             log.error("say goodbye to session error! {}", tmp, e);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/group/dispatch/FreePriorityDispatchStrategy.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/group/dispatch/FreePriorityDispatchStrategy.java
@@ -17,7 +17,6 @@
 
 package org.apache.eventmesh.runtime.core.protocol.tcp.client.group.dispatch;
 
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.core.protocol.tcp.client.session.Session;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -50,8 +49,8 @@ public class FreePriorityDispatchStrategy implements DownstreamDispatchStrategy 
 
             if (session.isIsolated()) {
                 isolatedSessions.add(session);
-                LogUtils.info(log, "session is not available because session is isolated,isolateTime:{},client:{}",
-                    session.getIsolateTime(), session.getClient());
+                log.info("session is not available because session is isolated,isolateTime:{},client:{}", session.getIsolateTime(),
+                    session.getClient());
                 continue;
             }
 
@@ -60,10 +59,10 @@ public class FreePriorityDispatchStrategy implements DownstreamDispatchStrategy 
 
         if (CollectionUtils.isEmpty(filtered)) {
             if (CollectionUtils.isEmpty(isolatedSessions)) {
-                LogUtils.warn(log, "all sessions can't downstream msg");
+                log.warn("all sessions can't downstream msg");
                 return null;
             } else {
-                LogUtils.warn(log, "all sessions are isolated,group:{},topic:{}", group, topic);
+                log.warn("all sessions are isolated,group:{},topic:{}", group, topic);
                 filtered.addAll(isolatedSessions);
             }
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/processor/SubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/processor/SubscribeProcessor.java
@@ -25,7 +25,6 @@ import org.apache.eventmesh.common.protocol.tcp.Header;
 import org.apache.eventmesh.common.protocol.tcp.OPStatus;
 import org.apache.eventmesh.common.protocol.tcp.Package;
 import org.apache.eventmesh.common.protocol.tcp.Subscription;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.acl.Acl;
 import org.apache.eventmesh.runtime.boot.EventMeshTCPServer;
 import org.apache.eventmesh.runtime.core.protocol.tcp.client.session.Session;
@@ -87,7 +86,7 @@ public class SubscribeProcessor implements TcpProcessor {
 
             synchronized (session) {
                 session.subscribe(subscriptionItems);
-                LogUtils.info(log, "SubscribeTask succeed|user={}|topics={}", session.getClient(), subscriptionItems);
+                log.info("SubscribeTask succeed|user={}|topics={}", session.getClient(), subscriptionItems);
             }
             eventMeshTCPServer.getClientSessionGroupMapping().updateMetaData();
             msg.setHeader(new Header(Command.SUBSCRIBE_RESPONSE, OPStatus.SUCCESS.getCode(), OPStatus.SUCCESS.getDesc(), pkg.getHeader().getSeq()));

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/recommend/EventMeshRecommendImpl.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/tcp/client/recommend/EventMeshRecommendImpl.java
@@ -18,7 +18,6 @@
 package org.apache.eventmesh.runtime.core.protocol.tcp.client.recommend;
 
 import org.apache.eventmesh.api.meta.dto.EventMeshDataInfo;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.boot.EventMeshTCPServer;
 import org.apache.eventmesh.runtime.util.ValueComparator;
 
@@ -51,7 +50,7 @@ public class EventMeshRecommendImpl implements EventMeshRecommendStrategy {
         List<EventMeshDataInfo> eventMeshDataInfoList;
 
         if (StringUtils.isAnyBlank(group, purpose)) {
-            LogUtils.warn(log, "EventMeshRecommend failed,params illegal,group:{},purpose:{}", group, purpose);
+            log.warn("EventMeshRecommend failed,params illegal,group:{},purpose:{}", group, purpose);
             return null;
         }
 
@@ -59,14 +58,13 @@ public class EventMeshRecommendImpl implements EventMeshRecommendStrategy {
         try {
             eventMeshDataInfoList = eventMeshTCPServer.getMetaStorage().findEventMeshInfoByCluster(cluster);
         } catch (Exception e) {
-            LogUtils.warn(log, "EventMeshRecommend failed, findEventMeshInfoByCluster failed, cluster:{}, group:{}, purpose:{}, errMsg:{}",
-                cluster, group, purpose, e);
+            log.warn("EventMeshRecommend failed, findEventMeshInfoByCluster failed, cluster:{}, group:{}, purpose:{}, errMsg:{}", cluster, group,
+                purpose, e);
             return null;
         }
 
         if (CollectionUtils.isEmpty(eventMeshDataInfoList)) {
-            LogUtils.warn(log, "EventMeshRecommend failed,not find eventMesh instances from registry,cluster:{},group:{},purpose:{}",
-                cluster, group, purpose);
+            log.warn("EventMeshRecommend failed,not find eventMesh instances from registry,cluster:{},group:{},purpose:{}", cluster, group, purpose);
             return null;
         }
 
@@ -80,7 +78,7 @@ public class EventMeshRecommendImpl implements EventMeshRecommendStrategy {
                     ? localEventMeshMap.put(eventMeshDataInfo.getEventMeshName(), eventMeshDataInfo.getEndpoint())
                     : remoteEventMeshMap.put(eventMeshDataInfo.getEventMeshName(), eventMeshDataInfo.getEndpoint());
             } else {
-                LogUtils.error(log, "EventMeshName may be illegal,idc is null,eventMeshName:{}", eventMeshDataInfo.getEventMeshName());
+                log.error("EventMeshName may be illegal,idc is null,eventMeshName:{}", eventMeshDataInfo.getEventMeshName());
             }
         }
 
@@ -109,8 +107,8 @@ public class EventMeshRecommendImpl implements EventMeshRecommendStrategy {
             return new ArrayList<String>();
         }
 
-        LogUtils.info(log, "eventMeshMap:{},clientDistributionMap:{},group:{},recommendNum:{},currEventMeshName:{}",
-            eventMeshMap, clientDistributedMap, group, recommendProxyNum, eventMeshName);
+        log.info("eventMeshMap:{},clientDistributionMap:{},group:{},recommendNum:{},currEventMeshName:{}", eventMeshMap, clientDistributedMap, group,
+            recommendProxyNum, eventMeshName);
 
         // find eventmesh with least client
         final List<Map.Entry<String, Integer>> clientDistributedList = new ArrayList<>();
@@ -118,7 +116,7 @@ public class EventMeshRecommendImpl implements EventMeshRecommendStrategy {
         clientDistributedMap.entrySet().forEach(clientDistributedList::add);
         Collections.sort(clientDistributedList, vc);
 
-        LogUtils.info(log, "clientDistributedLists after sort:{}", clientDistributedList);
+        log.info("clientDistributedLists after sort:{}", clientDistributedList);
 
         final List<String> recommendProxyList = new ArrayList<>(recommendProxyNum);
         while (recommendProxyList.size() < recommendProxyNum) {
@@ -128,11 +126,11 @@ public class EventMeshRecommendImpl implements EventMeshRecommendStrategy {
             clientDistributedMap.put(minProxyItem.getKey(), minProxyItem.getValue() + 1);
             clientDistributedMap.put(eventMeshName, currProxyNum - 1);
             Collections.sort(clientDistributedList, vc);
-            LogUtils.info(log, "clientDistributedList after sort:{}", clientDistributedList);
+            log.info("clientDistributedList after sort:{}", clientDistributedList);
         }
 
-        LogUtils.info(log, "choose proxys with min instance num, group:{}, recommendProxyNum:{}, recommendProxyList:{}",
-            group, recommendProxyNum, recommendProxyList);
+        log.info("choose proxys with min instance num, group:{}, recommendProxyNum:{}, recommendProxyList:{}", group, recommendProxyNum,
+            recommendProxyList);
         return recommendProxyList;
     }
 
@@ -140,15 +138,14 @@ public class EventMeshRecommendImpl implements EventMeshRecommendStrategy {
         final Map<String, String> eventMeshMap, final boolean caculateLocal) {
         Objects.requireNonNull(eventMeshMap, "eventMeshMap can not be null");
 
-        LogUtils.info(log, "eventMeshMap:{},cluster:{},group:{},purpose:{},caculateLocal:{}", eventMeshMap, cluster,
-            group, purpose, caculateLocal);
+        log.info("eventMeshMap:{},cluster:{},group:{},purpose:{},caculateLocal:{}", eventMeshMap, cluster, group, purpose, caculateLocal);
 
         Map<String, Map<String, Integer>> eventMeshClientDistributionDataMap = null;
         try {
             eventMeshClientDistributionDataMap = eventMeshTCPServer.getMetaStorage().findEventMeshClientDistributionData(
                 cluster, group, purpose);
         } catch (Exception e) {
-            LogUtils.warn(log, "EventMeshRecommend failed,findEventMeshClientDistributionData failed,"
+            log.warn("EventMeshRecommend failed,findEventMeshClientDistributionData failed,"
                 + "cluster:{},group:{},purpose:{}, errMsg:{}", cluster, group, purpose, e);
         }
 
@@ -161,8 +158,8 @@ public class EventMeshRecommendImpl implements EventMeshRecommendStrategy {
 
             Collections.shuffle(tmpProxyAddrList);
             recommendProxyAddr = tmpProxyAddrList.get(0);
-            LogUtils.info(log, "No distribute data in registry,cluster:{}, group:{},purpose:{}, recommendProxyAddr:{}",
-                cluster, group, purpose, recommendProxyAddr);
+            log.info("No distribute data in registry,cluster:{}, group:{},purpose:{}, recommendProxyAddr:{}", cluster, group, purpose,
+                recommendProxyAddr);
             return recommendProxyAddr;
         }
 
@@ -178,15 +175,15 @@ public class EventMeshRecommendImpl implements EventMeshRecommendStrategy {
                     remoteClientDistributionMap.put(entry.getKey(), entry.getValue().get(purpose));
                 }
             } else {
-                LogUtils.error(log, "eventMeshName may be illegal,idc is null,eventMeshName:{}", entry.getKey());
+                log.error("eventMeshName may be illegal,idc is null,eventMeshName:{}", entry.getKey());
             }
         });
 
         recommendProxyAddr = recommendProxy(eventMeshMap, (caculateLocal == true) ? localClientDistributionMap
             : remoteClientDistributionMap, group);
 
-        LogUtils.info(log, "eventMeshMap:{},group:{},purpose:{},caculateLocal:{},recommendProxyAddr:{}", eventMeshMap,
-            group, purpose, caculateLocal, recommendProxyAddr);
+        log.info("eventMeshMap:{},group:{},purpose:{},caculateLocal:{},recommendProxyAddr:{}", eventMeshMap, group, purpose, caculateLocal,
+            recommendProxyAddr);
 
         return recommendProxyAddr;
     }
@@ -197,10 +194,10 @@ public class EventMeshRecommendImpl implements EventMeshRecommendStrategy {
         Objects.requireNonNull(eventMeshMap, "eventMeshMap can not be null");
         Objects.requireNonNull(clientDistributionMap, "clientDistributionMap can not be null");
 
-        LogUtils.info(log, "eventMeshMap:{},clientDistributionMap:{},group:{}", eventMeshMap, clientDistributionMap, group);
+        log.info("eventMeshMap:{},clientDistributionMap:{},group:{}", eventMeshMap, clientDistributionMap, group);
 
         if (!eventMeshMap.keySet().containsAll(clientDistributionMap.keySet())) {
-            LogUtils.warn(log, "exist proxy not register but exist in distributionMap");
+            log.warn("exist proxy not register but exist in distributionMap");
             return null;
         }
 
@@ -208,13 +205,13 @@ public class EventMeshRecommendImpl implements EventMeshRecommendStrategy {
 
         // select the eventmesh with least instances
         if (MapUtils.isEmpty(clientDistributionMap)) {
-            LogUtils.error(log, "no legal distribute data,check eventMeshMap and distributeData, group:{}", group);
+            log.error("no legal distribute data,check eventMeshMap and distributeData, group:{}", group);
             return null;
         } else {
             final List<Map.Entry<String, Integer>> list = new ArrayList<>();
             clientDistributionMap.entrySet().forEach(list::add);
             Collections.sort(list, new ValueComparator());
-            LogUtils.info(log, "clientDistributionMap after sort:{}", list);
+            log.info("clientDistributionMap after sort:{}", list);
             return eventMeshMap.get(list.get(0).getKey());
         }
     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/metrics/http/HTTPMetricsServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/metrics/http/HTTPMetricsServer.java
@@ -18,7 +18,6 @@
 package org.apache.eventmesh.runtime.metrics.http;
 
 import org.apache.eventmesh.common.EventMeshThreadFactory;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.metrics.api.MetricsRegistry;
 import org.apache.eventmesh.metrics.api.model.HttpSummaryMetrics;
 import org.apache.eventmesh.metrics.api.model.RetrySummaryMetrics;
@@ -59,13 +58,13 @@ public class HTTPMetricsServer {
 
     private void init() {
         metricsRegistries.forEach(MetricsRegistry::start);
-        LogUtils.info(log, "HTTPMetricsServer initialized.");
+        log.info("HTTPMetricsServer initialized.");
     }
 
     public void start() {
         metricsRegistries.forEach(metricsRegistry -> {
             metricsRegistry.register(summaryMetrics);
-            LogUtils.info(log, "Register httpMetrics to {}", metricsRegistry.getClass().getName());
+            log.info("Register httpMetrics to {}", metricsRegistry.getClass().getName());
         });
 
         metricsSchedule.scheduleAtFixedRate(() -> {
@@ -87,13 +86,13 @@ public class HTTPMetricsServer {
             }
         }, 1000, 30 * 1000, TimeUnit.MILLISECONDS);
 
-        LogUtils.info(log, "HTTPMetricsServer started.");
+        log.info("HTTPMetricsServer started.");
     }
 
     public void shutdown() {
         metricsSchedule.shutdown();
         metricsRegistries.forEach(MetricsRegistry::showdown);
-        LogUtils.info(log, "HTTPMetricsServer shutdown.");
+        log.info("HTTPMetricsServer shutdown.");
     }
 
     private static ScheduledExecutorService metricsSchedule = Executors.newScheduledThreadPool(2,
@@ -103,59 +102,40 @@ public class HTTPMetricsServer {
 
     private void logPrintServerMetrics(final HttpSummaryMetrics summaryMetrics,
         final EventMeshHTTPServer eventMeshHTTPServer) {
-        LogUtils.info(log, "===========================================SERVER METRICS==================================================");
-        LogUtils.info(log, "maxHTTPTPS: {}, avgHTTPTPS: {}, maxHTTPCOST: {}, avgHTTPCOST: {}, avgHTTPBodyDecodeCost: {}, httpDiscard: {}",
-            summaryMetrics.maxHTTPTPS(),
-            summaryMetrics.avgHTTPTPS(),
-            summaryMetrics.maxHTTPCost(),
-            summaryMetrics.avgHTTPCost(),
-            summaryMetrics.avgHTTPBodyDecodeCost(),
-            summaryMetrics.getHttpDiscard());
+        log.info("===========================================SERVER METRICS==================================================");
+        log.info("maxHTTPTPS: {}, avgHTTPTPS: {}, maxHTTPCOST: {}, avgHTTPCOST: {}, avgHTTPBodyDecodeCost: {}, httpDiscard: {}",
+            summaryMetrics.maxHTTPTPS(), summaryMetrics.avgHTTPTPS(), summaryMetrics.maxHTTPCost(), summaryMetrics.avgHTTPCost(),
+            summaryMetrics.avgHTTPBodyDecodeCost(), summaryMetrics.getHttpDiscard());
 
         summaryMetrics.httpStatInfoClear();
 
-        LogUtils.info(log, "maxBatchSendMsgTPS: {}, avgBatchSendMsgTPS: {}, sum: {}. sumFail: {}, sumFailRate: {}, discard : {}",
-            summaryMetrics.maxSendBatchMsgTPS(),
-            summaryMetrics.avgSendBatchMsgTPS(),
-            summaryMetrics.getSendBatchMsgNumSum(),
-            summaryMetrics.getSendBatchMsgFailNumSum(),
-            summaryMetrics.getSendBatchMsgFailRate(),
-            summaryMetrics.getSendBatchMsgDiscardNumSum());
+        log.info("maxBatchSendMsgTPS: {}, avgBatchSendMsgTPS: {}, sum: {}. sumFail: {}, sumFailRate: {}, discard : {}",
+            summaryMetrics.maxSendBatchMsgTPS(), summaryMetrics.avgSendBatchMsgTPS(), summaryMetrics.getSendBatchMsgNumSum(),
+            summaryMetrics.getSendBatchMsgFailNumSum(), summaryMetrics.getSendBatchMsgFailRate(), summaryMetrics.getSendBatchMsgDiscardNumSum());
 
         summaryMetrics.cleanSendBatchStat();
 
-        LogUtils.info(log, "maxSendMsgTPS: {}, avgSendMsgTPS: {}, sum: {}, sumFail: {}, sumFailRate: {}, replyMsg: {}, replyFail: {}",
-            summaryMetrics.maxSendMsgTPS(),
-            summaryMetrics.avgSendMsgTPS(),
-            summaryMetrics.getSendMsgNumSum(),
-            summaryMetrics.getSendMsgFailNumSum(),
-            summaryMetrics.getSendMsgFailRate(),
-            summaryMetrics.getReplyMsgNumSum(),
-            summaryMetrics.getReplyMsgFailNumSum());
+        log.info("maxSendMsgTPS: {}, avgSendMsgTPS: {}, sum: {}, sumFail: {}, sumFailRate: {}, replyMsg: {}, replyFail: {}",
+            summaryMetrics.maxSendMsgTPS(), summaryMetrics.avgSendMsgTPS(), summaryMetrics.getSendMsgNumSum(), summaryMetrics.getSendMsgFailNumSum(),
+            summaryMetrics.getSendMsgFailRate(), summaryMetrics.getReplyMsgNumSum(), summaryMetrics.getReplyMsgFailNumSum());
 
         summaryMetrics.cleanSendMsgStat();
 
-        LogUtils.info(log, "maxPushMsgTPS: {}, avgPushMsgTPS: {}, sum: {}, sumFail: {}, sumFailRate: {}, maxClientLatency: {}, avgClientLatency: {}",
-            summaryMetrics.maxPushMsgTPS(),
-            summaryMetrics.avgPushMsgTPS(),
-            summaryMetrics.getHttpPushMsgNumSum(),
-            summaryMetrics.getHttpPushFailNumSum(),
-            summaryMetrics.getHttpPushMsgFailRate(),
-            summaryMetrics.maxHTTPPushLatency(),
+        log.info("maxPushMsgTPS: {}, avgPushMsgTPS: {}, sum: {}, sumFail: {}, sumFailRate: {}, maxClientLatency: {}, avgClientLatency: {}",
+            summaryMetrics.maxPushMsgTPS(), summaryMetrics.avgPushMsgTPS(), summaryMetrics.getHttpPushMsgNumSum(),
+            summaryMetrics.getHttpPushFailNumSum(), summaryMetrics.getHttpPushMsgFailRate(), summaryMetrics.maxHTTPPushLatency(),
             summaryMetrics.avgHTTPPushLatency());
 
         summaryMetrics.cleanHttpPushMsgStat();
 
-        LogUtils.info(log, "batchMsgQ: {}, sendMsgQ: {}, pushMsgQ: {}, httpRetryQ: {}",
+        log.info("batchMsgQ: {}, sendMsgQ: {}, pushMsgQ: {}, httpRetryQ: {}",
             eventMeshHTTPServer.getHttpThreadPoolGroup().getBatchMsgExecutor().getQueue().size(),
             eventMeshHTTPServer.getHttpThreadPoolGroup().getSendMsgExecutor().getQueue().size(),
             eventMeshHTTPServer.getHttpThreadPoolGroup().getPushMsgExecutor().getQueue().size(),
             eventMeshHTTPServer.getHttpRetryer().getPendingTimeouts());
 
-        LogUtils.info(log, "batchAvgSend2MQCost: {}, avgSend2MQCost: {}, avgReply2MQCost: {}",
-            summaryMetrics.avgBatchSendMsgCost(),
-            summaryMetrics.avgSendMsgCost(),
-            summaryMetrics.avgReplyMsgCost());
+        log.info("batchAvgSend2MQCost: {}, avgSend2MQCost: {}, avgReply2MQCost: {}", summaryMetrics.avgBatchSendMsgCost(),
+            summaryMetrics.avgSendMsgCost(), summaryMetrics.avgReplyMsgCost());
         summaryMetrics.send2MQStatInfoClear();
     }
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/metrics/tcp/EventMeshTcpMonitor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/metrics/tcp/EventMeshTcpMonitor.java
@@ -127,7 +127,7 @@ public class EventMeshTcpMonitor {
 
         }), delay, period, TimeUnit.MILLISECONDS);
 
-        monitorThreadPoolTask =  eventMeshTCPServer.getTcpThreadPoolGroup().getScheduler().scheduleAtFixedRate(() -> {
+        monitorThreadPoolTask = eventMeshTCPServer.getTcpThreadPoolGroup().getScheduler().scheduleAtFixedRate(() -> {
             appLogger.info("{TaskHandle:{},Send:{},Ack:{},Reply:{},Push:{},Scheduler:{},Rebalance:{}}",
                 eventMeshTCPServer.getTcpThreadPoolGroup().getTaskHandleExecutorService().getQueue().size(),
                 eventMeshTCPServer.getTcpThreadPoolGroup().getSendExecutorService().getQueue().size(),

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/EventMeshUtil.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/EventMeshUtil.java
@@ -20,7 +20,6 @@ package org.apache.eventmesh.runtime.util;
 import org.apache.eventmesh.common.EventMeshThreadFactory;
 import org.apache.eventmesh.common.protocol.tcp.EventMeshMessage;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.RandomStringUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.runtime.constants.EventMeshConstants;
@@ -172,7 +171,7 @@ public class EventMeshUtil {
     public static String getLocalAddr() {
         // priority of networkInterface when generating client ip
         final String priority = System.getProperty("networkInterface.priority", "bond1<eth1<eth0");
-        LogUtils.debug(log, "networkInterface.priority: {}", priority);
+        log.debug("networkInterface.priority: {}", priority);
 
         final List<String> preferList = new ArrayList<>();
         preferList.addAll(Arrays.asList(priority.split("<")));
@@ -196,11 +195,11 @@ public class EventMeshUtil {
             final ArrayList<String> ipv6Result = new ArrayList<>();
 
             if (preferNetworkInterface != null) {
-                LogUtils.debug(log, "use preferNetworkInterface:{}", preferNetworkInterface);
+                log.debug("use preferNetworkInterface:{}", preferNetworkInterface);
                 final Enumeration<InetAddress> en = preferNetworkInterface.getInetAddresses();
                 getIpResult(ipv4Result, ipv6Result, en);
             } else {
-                LogUtils.debug(log, "no preferNetworkInterface");
+                log.debug("no preferNetworkInterface");
                 final Enumeration<NetworkInterface> enumeration = NetworkInterface.getNetworkInterfaces();
                 while (enumeration.hasMoreElements()) {
                     final NetworkInterface networkInterface = enumeration.nextElement();
@@ -273,7 +272,7 @@ public class EventMeshUtil {
     }
 
     public static void printState(final ThreadPoolExecutor scheduledExecutorService) {
-        LogUtils.info(log, "{} [{} {} {} {}]", ((EventMeshThreadFactory) scheduledExecutorService.getThreadFactory())
+        log.info("{} [{} {} {} {}]", ((EventMeshThreadFactory) scheduledExecutorService.getThreadFactory())
             .getThreadNamePrefix(), scheduledExecutorService.getQueue().size(), scheduledExecutorService.getPoolSize(),
             scheduledExecutorService.getActiveCount(), scheduledExecutorService.getCompletedTaskCount());
     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/WebhookUtil.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/util/WebhookUtil.java
@@ -18,7 +18,6 @@
 package org.apache.eventmesh.runtime.util;
 
 import org.apache.eventmesh.api.auth.AuthService;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.spi.EventMeshExtensionFactory;
 
 import org.apache.commons.lang3.StringUtils;
@@ -58,10 +57,10 @@ public class WebhookUtil {
         final String targetUrl,
         final String requestOrigin) {
 
-        LogUtils.info(log, "obtain webhook delivery agreement for url: {}", targetUrl);
+        log.info("obtain webhook delivery agreement for url: {}", targetUrl);
 
         if (isInvalidUrl(targetUrl)) {
-            LogUtils.error(log, "Target url is invalid url: {}", targetUrl);
+            log.error("Target url is invalid url: {}", targetUrl);
             return false;
         }
 
@@ -77,7 +76,7 @@ public class WebhookUtil {
             return StringUtils.isEmpty(allowedOrigin)
                 || "*".equals(allowedOrigin) || allowedOrigin.equalsIgnoreCase(requestOrigin);
         } catch (Exception e) {
-            LogUtils.error(log, "HTTP Options Method is not supported at the Delivery Target: {}, "
+            log.error("HTTP Options Method is not supported at the Delivery Target: {}, "
                 + "unable to obtain the webhook delivery agreement.", targetUrl);
         }
         return true;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/client/common/RequestContext.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/client/common/RequestContext.java
@@ -18,7 +18,6 @@
 package org.apache.eventmesh.runtime.client.common;
 
 import org.apache.eventmesh.common.protocol.tcp.Package;
-import org.apache.eventmesh.common.utils.LogUtils;
 
 import java.util.concurrent.CountDownLatch;
 
@@ -77,7 +76,7 @@ public class RequestContext {
 
     public static RequestContext context(Object key, Package request, CountDownLatch latch) throws Exception {
         RequestContext c = new RequestContext(key, request, latch);
-        LogUtils.info(log, "_RequestContext|create|key=", key);
+        log.info("_RequestContext|create|key=", key);
         return c;
     }
 

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/client/impl/PubClientImpl.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/client/impl/PubClientImpl.java
@@ -21,7 +21,6 @@ import org.apache.eventmesh.common.protocol.tcp.Command;
 import org.apache.eventmesh.common.protocol.tcp.OPStatus;
 import org.apache.eventmesh.common.protocol.tcp.Package;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.client.api.PubClient;
 import org.apache.eventmesh.runtime.client.common.ClientConstants;
 import org.apache.eventmesh.runtime.client.common.MessageUtils;
@@ -61,7 +60,7 @@ public class PubClientImpl extends TCPClient implements PubClient {
     public void init() throws Exception {
         open(new Handler());
         hello();
-        LogUtils.info(log, "PubClientImpl|{}|started!", clientNo);
+        log.info("PubClientImpl|{}|started!", clientNo);
     }
 
     public void reconnect() throws Exception {
@@ -85,8 +84,7 @@ public class PubClientImpl extends TCPClient implements PubClient {
                     PubClientImpl.this.reconnect();
                 }
                 Package msg = MessageUtils.heartBeat();
-                LogUtils.debug(log, "PubClientImpl|{}|send heartbeat|Command={}|msg={}",
-                    clientNo, msg.getHeader().getCommand(), msg);
+                log.debug("PubClientImpl|{}|send heartbeat|Command={}|msg={}", clientNo, msg.getHeader().getCommand(), msg);
                 PubClientImpl.this.dispatcher(msg, ClientConstants.DEFAULT_TIMEOUT_IN_MILLISECONDS);
             } catch (Exception ignored) {
                 // ignore
@@ -114,7 +112,7 @@ public class PubClientImpl extends TCPClient implements PubClient {
      */
     @Override
     public Package rr(Package msg, long timeout) throws Exception {
-        LogUtils.info(log, "PubClientImpl|{}|rr|send|Command={}|msg={}", clientNo, Command.REQUEST_TO_SERVER, msg);
+        log.info("PubClientImpl|{}|rr|send|Command={}|msg={}", clientNo, Command.REQUEST_TO_SERVER, msg);
         return dispatcher(msg, timeout);
     }
 
@@ -159,7 +157,7 @@ public class PubClientImpl extends TCPClient implements PubClient {
      * Send an event message, the return value is ACCESS and ACK is given
      */
     public Package publish(Package msg, long timeout) throws Exception {
-        LogUtils.info(log, "PubClientImpl|{}|publish|send|command={}|msg={}", clientNo, msg.getHeader().getCommand(), msg);
+        log.info("PubClientImpl|{}|publish|send|command={}|msg={}", clientNo, msg.getHeader().getCommand(), msg);
         return dispatcher(msg, timeout);
     }
 
@@ -167,7 +165,7 @@ public class PubClientImpl extends TCPClient implements PubClient {
      * send broadcast message
      */
     public Package broadcast(Package msg, long timeout) throws Exception {
-        LogUtils.info(log, "PubClientImpl|{}|broadcast|send|type={}|msg={}", clientNo, msg.getHeader().getCommand(), msg);
+        log.info("PubClientImpl|{}|broadcast|send|type={}|msg={}", clientNo, msg.getHeader().getCommand(), msg);
         return dispatcher(msg, timeout);
     }
 
@@ -181,7 +179,7 @@ public class PubClientImpl extends TCPClient implements PubClient {
 
         @Override
         protected void channelRead0(ChannelHandlerContext ctx, Package msg) throws Exception {
-            LogUtils.info(log, "PubClientImpl|{}|receive|type={}|msg={}", clientNo, msg.getHeader().getCommand(), msg);
+            log.info("PubClientImpl|{}|receive|type={}|msg={}", clientNo, msg.getHeader().getCommand(), msg);
             Command cmd = msg.getHeader().getCommand();
             if (callback != null) {
                 callback.handle(msg, ctx);

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/client/impl/SubClientImpl.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/client/impl/SubClientImpl.java
@@ -24,7 +24,6 @@ import org.apache.eventmesh.common.protocol.tcp.Command;
 import org.apache.eventmesh.common.protocol.tcp.OPStatus;
 import org.apache.eventmesh.common.protocol.tcp.Package;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.client.api.SubClient;
 import org.apache.eventmesh.runtime.client.common.ClientConstants;
 import org.apache.eventmesh.runtime.client.common.MessageUtils;
@@ -70,7 +69,7 @@ public class SubClientImpl extends TCPClient implements SubClient {
     public void init() throws Exception {
         open(new Handler());
         hello();
-        LogUtils.info(log, "SubClientImpl|{}|started!", clientNo);
+        log.info("SubClientImpl|{}|started!", clientNo);
     }
 
     public void reconnect() throws Exception {
@@ -101,8 +100,7 @@ public class SubClientImpl extends TCPClient implements SubClient {
                     SubClientImpl.this.reconnect();
                 }
                 Package msg = MessageUtils.heartBeat();
-                LogUtils.debug(log, "SubClientImpl|{}|send heartbeat|Command={}|msg={}", clientNo,
-                    msg.getHeader().getCommand(), msg);
+                log.debug("SubClientImpl|{}|send heartbeat|Command={}|msg={}", clientNo, msg.getHeader().getCommand(), msg);
                 SubClientImpl.this.dispatcher(msg, ClientConstants.DEFAULT_TIMEOUT_IN_MILLISECONDS);
             } catch (Exception e) {
                 // ignore
@@ -200,8 +198,7 @@ public class SubClientImpl extends TCPClient implements SubClient {
         @SuppressWarnings("Duplicates")
         @Override
         protected void channelRead0(ChannelHandlerContext ctx, Package msg) throws Exception {
-            LogUtils.info(log, SubClientImpl.class.getSimpleName() + "|receive|command={}|msg={}",
-                msg.getHeader().getCommand(), msg);
+            log.info(SubClientImpl.class.getSimpleName() + "|receive|command={}|msg={}", msg.getHeader().getCommand(), msg);
             Command cmd = msg.getHeader().getCommand();
             if (callback != null) {
                 callback.handle(msg, ctx);

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/demo/AsyncPubClient.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/demo/AsyncPubClient.java
@@ -17,7 +17,6 @@
 
 package org.apache.eventmesh.runtime.demo;
 
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 import org.apache.eventmesh.runtime.client.common.ClientConstants;
 import org.apache.eventmesh.runtime.client.common.MessageUtils;
@@ -35,7 +34,7 @@ public class AsyncPubClient {
             pubClient.init();
             pubClient.heartbeat();
             pubClient.registerBusiHandler((msg, ctx) -> {
-                LogUtils.info(log, "server good by request: {}", msg);
+                log.info("server good by request: {}", msg);
             });
 
             for (int i = 0; i < 1; i++) {

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/demo/AsyncSubClient.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/demo/AsyncSubClient.java
@@ -20,7 +20,6 @@ package org.apache.eventmesh.runtime.demo;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
 import org.apache.eventmesh.common.protocol.tcp.EventMeshMessage;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.client.common.ClientConstants;
 import org.apache.eventmesh.runtime.client.common.MessageUtils;
 import org.apache.eventmesh.runtime.client.impl.SubClientImpl;
@@ -39,7 +38,7 @@ public class AsyncSubClient {
             client.registerBusiHandler((msg, ctx) -> {
                 if (msg.getBody() instanceof EventMeshMessage) {
                     String body = ((EventMeshMessage) msg.getBody()).getBody();
-                    LogUtils.info(log, "receive message : {}", body);
+                    log.info("receive message : {}", body);
                 }
             });
         }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/demo/CCSubClient.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/demo/CCSubClient.java
@@ -21,7 +21,6 @@ import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
 import org.apache.eventmesh.common.protocol.tcp.Command;
 import org.apache.eventmesh.common.protocol.tcp.Package;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.client.common.MessageUtils;
 import org.apache.eventmesh.runtime.client.common.UserAgentUtils;
 import org.apache.eventmesh.runtime.client.impl.SubClientImpl;
@@ -39,7 +38,7 @@ public class CCSubClient {
             subClient.listen();
             subClient.justSubscribe("TEST-TOPIC-TCP-SYNC", SubscriptionMode.CLUSTERING, SubscriptionType.SYNC);
             subClient.registerBusiHandler((msg, ctx) -> {
-                LogUtils.info(log, "Received message: {}", msg);
+                log.info("Received message: {}", msg);
                 if (msg.getHeader().getCommand() == Command.REQUEST_TO_CLIENT) {
                     Package rrResponse = MessageUtils.rrResponse(msg);
                     ctx.writeAndFlush(rrResponse);

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/demo/CClientDemo.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/demo/CClientDemo.java
@@ -20,7 +20,6 @@ package org.apache.eventmesh.runtime.demo;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
 import org.apache.eventmesh.common.protocol.tcp.Command;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.client.common.MessageUtils;
 import org.apache.eventmesh.runtime.client.impl.EventMeshClientImpl;
 
@@ -44,7 +43,7 @@ public class CClientDemo {
         client.listen();
         client.registerSubBusiHandler((msg, ctx) -> {
             if (msg.getHeader().getCmd() == Command.ASYNC_MESSAGE_TO_CLIENT || msg.getHeader().getCmd() == Command.BROADCAST_MESSAGE_TO_CLIENT) {
-                LogUtils.info(log, "receive message: {}", msg);
+                log.info("receive message: {}", msg);
             }
         });
         for (int i = 0; i < 10000; i++) {

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/demo/SyncPubClient.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/demo/SyncPubClient.java
@@ -19,7 +19,6 @@ package org.apache.eventmesh.runtime.demo;
 
 import org.apache.eventmesh.common.protocol.tcp.EventMeshMessage;
 import org.apache.eventmesh.common.protocol.tcp.Package;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.client.common.MessageUtils;
 import org.apache.eventmesh.runtime.client.common.UserAgentUtils;
 import org.apache.eventmesh.runtime.client.impl.PubClientImpl;
@@ -39,8 +38,7 @@ public class SyncPubClient {
                 Package rr = pubClient.rr(MessageUtils.rrMesssage("TEST-TOPIC-TCP-SYNC", i), 3000);
                 if (rr.getBody() instanceof EventMeshMessage) {
                     String body = ((EventMeshMessage) rr.getBody()).getBody();
-                    LogUtils.info(log, "rrMessage: ", body, "             ",
-                        "rr-reply-------------------------------------------------{}", rr);
+                    log.info("rrMessage: ", body, "             ", "rr-reply-------------------------------------------------{}", rr);
                 }
             }
         }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/demo/SyncSubClient.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/demo/SyncSubClient.java
@@ -20,7 +20,6 @@ package org.apache.eventmesh.runtime.demo;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.SubscriptionType;
 import org.apache.eventmesh.common.protocol.tcp.Command;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.runtime.client.common.ClientConstants;
 import org.apache.eventmesh.runtime.client.common.MessageUtils;
 import org.apache.eventmesh.runtime.client.impl.SubClientImpl;
@@ -38,7 +37,7 @@ public class SyncSubClient {
             client.justSubscribe(ClientConstants.SYNC_TOPIC, SubscriptionMode.CLUSTERING, SubscriptionType.SYNC);
             client.registerBusiHandler((msg, ctx) -> {
                 if (msg.getHeader().getCommand() == Command.REQUEST_TO_CLIENT) {
-                    LogUtils.info(log, "receive message:{}", msg);
+                    log.info("receive message:{}", msg);
                 }
             });
         }

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/catalog/EventMeshCatalogClient.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/catalog/EventMeshCatalogClient.java
@@ -28,7 +28,6 @@ import org.apache.eventmesh.common.protocol.catalog.protos.Operation;
 import org.apache.eventmesh.common.protocol.catalog.protos.QueryOperationsRequest;
 import org.apache.eventmesh.common.protocol.catalog.protos.QueryOperationsResponse;
 import org.apache.eventmesh.common.utils.AssertUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -67,7 +66,7 @@ public class EventMeshCatalogClient {
         final QueryOperationsRequest request = QueryOperationsRequest.newBuilder()
             .setServiceName(clientConfig.getAppServerName()).build();
         final QueryOperationsResponse response = catalogClient.queryOperations(request);
-        LogUtils.info(log, "received response: {}", response);
+        log.info("received response: {}", response);
 
         final List<Operation> operations = response.getOperationsList();
         if (CollectionUtils.isEmpty(operations)) {

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/grpc/consumer/EventMeshGrpcConsumer.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/grpc/consumer/EventMeshGrpcConsumer.java
@@ -42,7 +42,6 @@ import org.apache.eventmesh.common.protocol.grpc.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.grpc.common.Response;
 import org.apache.eventmesh.common.protocol.grpc.common.StatusCode;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 
 import org.apache.commons.collections4.MapUtils;
 
@@ -104,7 +103,7 @@ public class EventMeshGrpcConsumer implements AutoCloseable {
      * @return A response containing information about the subscription result.
      */
     public Response subscribe(final List<SubscriptionItem> subscriptionItems, final String url) {
-        LogUtils.info(log, "Create subscription: {} , url: {}", subscriptionItems, url);
+        log.info("Create subscription: {} , url: {}", subscriptionItems, url);
 
         addSubscription(subscriptionItems, url, GrpcType.WEBHOOK);
 
@@ -117,7 +116,7 @@ public class EventMeshGrpcConsumer implements AutoCloseable {
      * @param subscriptionItems The list of subscription items for streaming.
      */
     public void subscribe(final List<SubscriptionItem> subscriptionItems) {
-        LogUtils.info(log, "Create streaming subscription: {}", subscriptionItems);
+        log.info("Create streaming subscription: {}", subscriptionItems);
 
         if (listener == null) {
             log.error("Error in subscriber, no Event Listener is registered.");
@@ -142,7 +141,7 @@ public class EventMeshGrpcConsumer implements AutoCloseable {
             url, subscriptionItems);
         try {
             CloudEvent response = consumerClient.subscribe(subscription);
-            LogUtils.info(log, "Received response:{}", response);
+            log.info("Received response:{}", response);
             return Response.builder()
                 .respCode(EventMeshCloudEventUtils.getResponseCode(response))
                 .respMsg(EventMeshCloudEventUtils.getResponseMessage(response))
@@ -166,7 +165,7 @@ public class EventMeshGrpcConsumer implements AutoCloseable {
     }
 
     public Response unsubscribe(final List<SubscriptionItem> subscriptionItems, final String url) {
-        LogUtils.info(log, "Removing subscription: {}, url:{}", subscriptionItems, url);
+        log.info("Removing subscription: {}, url:{}", subscriptionItems, url);
 
         removeSubscription(subscriptionItems);
 
@@ -174,7 +173,7 @@ public class EventMeshGrpcConsumer implements AutoCloseable {
             subscriptionItems);
         try {
             final CloudEvent response = consumerClient.unsubscribe(cloudEvent);
-            LogUtils.info(log, "Received response:{}", response);
+            log.info("Received response:{}", response);
             return Response.builder()
                 .respCode(EventMeshCloudEventUtils.getResponseCode(response))
                 .respMsg(EventMeshCloudEventUtils.getResponseMessage(response))
@@ -188,7 +187,7 @@ public class EventMeshGrpcConsumer implements AutoCloseable {
 
     public Response unsubscribe(final List<SubscriptionItem> subscriptionItems) {
         Objects.requireNonNull(subscriptionItems, "subscriptionItems can not be null");
-        LogUtils.info(log, "Removing subscription stream: {}", subscriptionItems);
+        log.info("Removing subscription stream: {}", subscriptionItems);
 
         removeSubscription(subscriptionItems);
 
@@ -202,7 +201,7 @@ public class EventMeshGrpcConsumer implements AutoCloseable {
                 .respMsg(EventMeshCloudEventUtils.getResponseMessage(response))
                 .respTime(EventMeshCloudEventUtils.getResponseTime(response))
                 .build();
-            LogUtils.info(log, "Received response:{}", parsedResponse);
+            log.info("Received response:{}", parsedResponse);
 
             // there is no stream subscriptions, stop the subscription stream handler
             synchronized (this) {
@@ -249,7 +248,7 @@ public class EventMeshGrpcConsumer implements AutoCloseable {
                     .respMsg(EventMeshCloudEventUtils.getResponseMessage(cloudEventResp))
                     .respTime(EventMeshCloudEventUtils.getResponseTime(cloudEventResp))
                     .build();
-                LogUtils.debug(log, "Grpc Consumer Heartbeat cloudEvent: {}", response);
+                log.debug("Grpc Consumer Heartbeat cloudEvent: {}", response);
                 if (StatusCode.CLIENT_RESUBSCRIBE.getRetCode().equals(response.getRespCode())) {
                     resubscribe();
                 }
@@ -258,7 +257,7 @@ public class EventMeshGrpcConsumer implements AutoCloseable {
             }
         }, 10_000, EventMeshCommon.HEARTBEAT, TimeUnit.MILLISECONDS);
 
-        LogUtils.info(log, "Grpc Consumer Heartbeat started.");
+        log.info("Grpc Consumer Heartbeat started.");
     }
 
     private void resubscribe() {

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/grpc/consumer/SubStreamHandler.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/grpc/consumer/SubStreamHandler.java
@@ -25,7 +25,6 @@ import org.apache.eventmesh.common.protocol.grpc.cloudevents.CloudEvent.CloudEve
 import org.apache.eventmesh.common.protocol.grpc.cloudevents.ConsumerServiceGrpc.ConsumerServiceStub;
 import org.apache.eventmesh.common.protocol.grpc.common.EventMeshCloudEventUtils;
 import org.apache.eventmesh.common.protocol.grpc.common.ProtocolKey;
-import org.apache.eventmesh.common.utils.LogUtils;
 
 import java.io.Serializable;
 import java.util.Optional;
@@ -72,10 +71,9 @@ public class SubStreamHandler<T> extends Thread implements Serializable {
             public void onNext(final CloudEvent message) {
                 T msg = EventMeshCloudEventBuilder.buildMessageFromEventMeshCloudEvent(message, listener.getProtocolType());
                 if (msg instanceof Set) {
-                    LogUtils.info(log, "Received message from Server:{}", message);
+                    log.info("Received message from Server:{}", message);
                 } else {
-                    LogUtils.info(log, "Received message from Server.|seq={}|uniqueId={}|",
-                        EventMeshCloudEventUtils.getSeqNum(message),
+                    log.info("Received message from Server.|seq={}|uniqueId={}|", EventMeshCloudEventUtils.getSeqNum(message),
                         EventMeshCloudEventUtils.getUniqueId(message));
                     CloudEvent streamReply = null;
                     try {
@@ -84,13 +82,11 @@ public class SubStreamHandler<T> extends Thread implements Serializable {
                             streamReply = buildReplyMessage(message, reply.get());
                         }
                     } catch (Exception e) {
-                        LogUtils.error(log, "Error in handling reply message.|seq={}|uniqueId={}|",
-                            EventMeshCloudEventUtils.getSeqNum(message),
+                        log.error("Error in handling reply message.|seq={}|uniqueId={}|", EventMeshCloudEventUtils.getSeqNum(message),
                             EventMeshCloudEventUtils.getUniqueId(message), e);
                     }
                     if (streamReply != null) {
-                        LogUtils.info(log, "Sending reply message to Server.|seq={}|uniqueId={}|",
-                            EventMeshCloudEventUtils.getSeqNum(streamReply),
+                        log.info("Sending reply message to Server.|seq={}|uniqueId={}|", EventMeshCloudEventUtils.getSeqNum(streamReply),
                             EventMeshCloudEventUtils.getUniqueId(streamReply));
                         senderOnNext(streamReply);
                     }
@@ -104,7 +100,7 @@ public class SubStreamHandler<T> extends Thread implements Serializable {
 
             @Override
             public void onCompleted() {
-                LogUtils.info(log, "Finished receiving messages from server.");
+                log.info("Finished receiving messages from server.");
                 close();
             }
         };
@@ -139,7 +135,7 @@ public class SubStreamHandler<T> extends Thread implements Serializable {
 
         latch.countDown();
 
-        LogUtils.info(log, "SubStreamHandler closed.");
+        log.info("SubStreamHandler closed.");
     }
 
     private void senderOnNext(final CloudEvent subscription) {

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/grpc/producer/CloudEventProducer.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/grpc/producer/CloudEventProducer.java
@@ -25,7 +25,6 @@ import org.apache.eventmesh.common.protocol.grpc.cloudevents.CloudEventBatch;
 import org.apache.eventmesh.common.protocol.grpc.cloudevents.PublisherServiceGrpc.PublisherServiceBlockingStub;
 import org.apache.eventmesh.common.protocol.grpc.common.EventMeshCloudEventUtils;
 import org.apache.eventmesh.common.protocol.grpc.common.Response;
-import org.apache.eventmesh.common.utils.LogUtils;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -50,7 +49,7 @@ public class CloudEventProducer implements GrpcProducer<io.cloudevents.CloudEven
 
     @Override
     public Response publish(final List<io.cloudevents.CloudEvent> events) {
-        LogUtils.info(log, "BatchPublish message, batch size={}", events.size());
+        log.info("BatchPublish message, batch size={}", events.size());
 
         if (CollectionUtils.isEmpty(events)) {
             return null;
@@ -65,17 +64,17 @@ public class CloudEventProducer implements GrpcProducer<io.cloudevents.CloudEven
                 .respTime(EventMeshCloudEventUtils.getResponseTime(response))
                 .build();
 
-            LogUtils.info(log, "Received response:{}", parsedResponse);
+            log.info("Received response:{}", parsedResponse);
             return parsedResponse;
         } catch (Exception e) {
-            LogUtils.error(log, "Error in BatchPublish message {}", events, e);
+            log.error("Error in BatchPublish message {}", events, e);
         }
         return null;
     }
 
     @Override
     public Response publish(final io.cloudevents.CloudEvent cloudEvent) {
-        LogUtils.info(log, "Publish message: {}", cloudEvent.toString());
+        log.info("Publish message: {}", cloudEvent.toString());
         CloudEvent enhancedMessage = EventMeshCloudEventBuilder.buildEventMeshCloudEvent(cloudEvent, clientConfig, PROTOCOL_TYPE);
         try {
             final CloudEvent response = publisherClient.publish(enhancedMessage);
@@ -84,24 +83,24 @@ public class CloudEventProducer implements GrpcProducer<io.cloudevents.CloudEven
                 .respMsg(EventMeshCloudEventUtils.getResponseMessage(response))
                 .respTime(EventMeshCloudEventUtils.getResponseTime(response))
                 .build();
-            LogUtils.info(log, "Received response:{} ", parsedResponse);
+            log.info("Received response:{} ", parsedResponse);
             return parsedResponse;
         } catch (Exception e) {
-            LogUtils.error(log, "Error in publishing message {}", cloudEvent, e);
+            log.error("Error in publishing message {}", cloudEvent, e);
         }
         return null;
     }
 
     @Override
     public io.cloudevents.CloudEvent requestReply(final io.cloudevents.CloudEvent cloudEvent, final long timeout) {
-        LogUtils.info(log, "RequestReply message {}", cloudEvent);
+        log.info("RequestReply message {}", cloudEvent);
         final CloudEvent enhancedMessage = EventMeshCloudEventBuilder.buildEventMeshCloudEvent(cloudEvent, clientConfig, PROTOCOL_TYPE);
         try {
             final CloudEvent reply = publisherClient.requestReply(enhancedMessage);
-            LogUtils.info(log, "Received reply message:{}", reply);
+            log.info("Received reply message:{}", reply);
             return EventMeshCloudEventBuilder.buildMessageFromEventMeshCloudEvent(reply, PROTOCOL_TYPE);
         } catch (Exception e) {
-            LogUtils.error(log, "Error in RequestReply message {}", cloudEvent, e);
+            log.error("Error in RequestReply message {}", cloudEvent, e);
         }
         return null;
     }

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/grpc/producer/EventMeshGrpcProducer.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/grpc/producer/EventMeshGrpcProducer.java
@@ -23,7 +23,6 @@ import org.apache.eventmesh.common.EventMeshMessage;
 import org.apache.eventmesh.common.protocol.grpc.cloudevents.PublisherServiceGrpc;
 import org.apache.eventmesh.common.protocol.grpc.cloudevents.PublisherServiceGrpc.PublisherServiceBlockingStub;
 import org.apache.eventmesh.common.protocol.grpc.common.Response;
-import org.apache.eventmesh.common.utils.LogUtils;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -61,7 +60,7 @@ public class EventMeshGrpcProducer implements AutoCloseable {
     }
 
     public <T> Response publish(T message) {
-        LogUtils.info(log, "Publish message ", message.toString());
+        log.info("Publish message ", message.toString());
         if (message instanceof CloudEvent) {
             return cloudEventProducer.publish((CloudEvent) message);
         } else if (message instanceof EventMeshMessage) {
@@ -73,7 +72,7 @@ public class EventMeshGrpcProducer implements AutoCloseable {
 
     @SuppressWarnings("unchecked")
     public <T> Response publish(List<T> messageList) {
-        LogUtils.info(log, "BatchPublish message :{}", messageList);
+        log.info("BatchPublish message :{}", messageList);
 
         if (CollectionUtils.isEmpty(messageList)) {
             return null;

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/grpc/producer/EventMeshMessageProducer.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/grpc/producer/EventMeshMessageProducer.java
@@ -26,7 +26,6 @@ import org.apache.eventmesh.common.protocol.grpc.cloudevents.CloudEventBatch;
 import org.apache.eventmesh.common.protocol.grpc.cloudevents.PublisherServiceGrpc.PublisherServiceBlockingStub;
 import org.apache.eventmesh.common.protocol.grpc.common.EventMeshCloudEventUtils;
 import org.apache.eventmesh.common.protocol.grpc.common.Response;
-import org.apache.eventmesh.common.utils.LogUtils;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -56,7 +55,7 @@ public class EventMeshMessageProducer implements GrpcProducer<EventMeshMessage> 
             return null;
         }
 
-        LogUtils.debug(log, "Publish message: {}", message);
+        log.debug("Publish message: {}", message);
         CloudEvent cloudEvent = EventMeshCloudEventBuilder.buildEventMeshCloudEvent(message, clientConfig, PROTOCOL_TYPE);
         try {
             CloudEvent response = publisherClient.publish(cloudEvent);
@@ -65,7 +64,7 @@ public class EventMeshMessageProducer implements GrpcProducer<EventMeshMessage> 
                 .respMsg(EventMeshCloudEventUtils.getResponseMessage(response))
                 .respTime(EventMeshCloudEventUtils.getResponseTime(response))
                 .build();
-            LogUtils.info(log, "Received response:{}", parsedResponse);
+            log.info("Received response:{}", parsedResponse);
             return parsedResponse;
         } catch (Exception e) {
             log.error("Error in publishing message {}", message, e);
@@ -87,22 +86,22 @@ public class EventMeshMessageProducer implements GrpcProducer<EventMeshMessage> 
                 .respMsg(EventMeshCloudEventUtils.getResponseMessage(response))
                 .respTime(EventMeshCloudEventUtils.getResponseTime(response))
                 .build();
-            LogUtils.info(log, "Received response:{}", parsedResponse);
+            log.info("Received response:{}", parsedResponse);
             return parsedResponse;
         } catch (Exception e) {
-            LogUtils.error(log, "Error in BatchPublish message {}", messages, e);
+            log.error("Error in BatchPublish message {}", messages, e);
         }
         return null;
     }
 
     @Override
     public EventMeshMessage requestReply(EventMeshMessage message, long timeout) {
-        LogUtils.info(log, "RequestReply message:{}", message);
+        log.info("RequestReply message:{}", message);
 
         final CloudEvent cloudEvent = EventMeshCloudEventBuilder.buildEventMeshCloudEvent(message, clientConfig, PROTOCOL_TYPE);
         try {
             final CloudEvent reply = publisherClient.withDeadlineAfter(timeout, TimeUnit.MILLISECONDS).requestReply(cloudEvent);
-            LogUtils.info(log, "Received reply message:{}", reply);
+            log.info("Received reply message:{}", reply);
             return EventMeshCloudEventBuilder.buildMessageFromEventMeshCloudEvent(reply, PROTOCOL_TYPE);
         } catch (Exception e) {
             log.error("Error in RequestReply message {}", message, e);

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/http/consumer/EventMeshHttpConsumer.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/http/consumer/EventMeshHttpConsumer.java
@@ -37,7 +37,6 @@ import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.http.common.ProtocolVersion;
 import org.apache.eventmesh.common.protocol.http.common.RequestCode;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -167,7 +166,7 @@ public class EventMeshHttpConsumer extends AbstractHttpClient implements AutoClo
 
     @Override
     public void close() throws EventMeshException {
-        LogUtils.info(log, "LiteConsumer shutdown begin.");
+        log.info("LiteConsumer shutdown begin.");
         super.close();
 
         if (consumeExecutor != null) {
@@ -175,7 +174,7 @@ public class EventMeshHttpConsumer extends AbstractHttpClient implements AutoClo
         }
         scheduler.shutdown();
 
-        LogUtils.info(log, "LiteConsumer shutdown end.");
+        log.info("LiteConsumer shutdown end.");
     }
 
     private RequestParam buildCommonRequestParam() {

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/http/util/HttpUtils.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/http/util/HttpUtils.java
@@ -19,7 +19,6 @@ package org.apache.eventmesh.client.http.util;
 
 import org.apache.eventmesh.client.http.model.RequestParam;
 import org.apache.eventmesh.common.Constants;
-import org.apache.eventmesh.common.utils.LogUtils;
 
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -109,7 +108,7 @@ public final class HttpUtils {
 
         httpPost.setConfig(configBuilder.build());
 
-        LogUtils.debug(log, "{}", httpPost);
+        log.debug("{}", httpPost);
 
         return client.execute(httpPost, responseHandler);
     }
@@ -161,7 +160,7 @@ public final class HttpUtils {
 
         httpGet.setConfig(configBuilder.build());
 
-        LogUtils.debug(log, "{}", httpGet);
+        log.debug("{}", httpGet);
 
         return client.execute(httpGet, responseHandler);
     }

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/common/RequestContext.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/common/RequestContext.java
@@ -18,7 +18,6 @@
 package org.apache.eventmesh.client.tcp.common;
 
 import org.apache.eventmesh.common.protocol.tcp.Package;
-import org.apache.eventmesh.common.utils.LogUtils;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -73,7 +72,7 @@ public class RequestContext {
 
     public static RequestContext context(final Object key, final Package request) throws Exception {
         final RequestContext context = new RequestContext(key, request);
-        LogUtils.info(log, "_RequestContext|create|key={}", key);
+        log.info("_RequestContext|create|key={}", key);
         return context;
     }
 

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/common/TcpClient.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/common/TcpClient.java
@@ -23,7 +23,6 @@ import org.apache.eventmesh.common.ThreadPoolFactory;
 import org.apache.eventmesh.common.protocol.tcp.Package;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
 import org.apache.eventmesh.common.protocol.tcp.codec.Codec;
-import org.apache.eventmesh.common.utils.LogUtils;
 
 import java.io.Closeable;
 import java.net.InetSocketAddress;
@@ -118,8 +117,7 @@ public abstract class TcpClient implements Closeable {
         ChannelFuture f = bootstrap.connect(host, port).sync();
         InetSocketAddress localAddress = (InetSocketAddress) f.channel().localAddress();
         channel = f.channel();
-        LogUtils.info(log, "connected|local={}:{}|server={}", localAddress.getAddress().getHostAddress(),
-            localAddress.getPort(), host + ":" + port);
+        log.info("connected|local={}:{}|server={}", localAddress.getAddress().getHostAddress(), localAddress.getPort(), host + ":" + port);
     }
 
     @Override
@@ -134,7 +132,7 @@ public abstract class TcpClient implements Closeable {
         } catch (Exception e) {
             Thread.currentThread().interrupt();
 
-            LogUtils.warn(log, "close tcp client failed.|remote address={}", channel.remoteAddress(), e);
+            log.warn("close tcp client failed.|remote address={}", channel.remoteAddress(), e);
         }
     }
 
@@ -148,7 +146,7 @@ public abstract class TcpClient implements Closeable {
                         }
                         Package msg = MessageUtils.heartBeat();
                         io(msg, EventMeshCommon.DEFAULT_TIME_OUT_MILLS);
-                        LogUtils.debug(log, "heart beat start {}", msg);
+                        log.debug("heart beat start {}", msg);
                     } catch (Exception e) {
                         // ignore
                     }
@@ -170,7 +168,7 @@ public abstract class TcpClient implements Closeable {
         if (channel.isWritable()) {
             channel.writeAndFlush(msg).addListener((ChannelFutureListener) future -> {
                 if (!future.isSuccess()) {
-                    LogUtils.warn(log, "send msg failed", future.cause());
+                    log.warn("send msg failed", future.cause());
                 }
             });
         } else {
@@ -184,7 +182,7 @@ public abstract class TcpClient implements Closeable {
         if (!contexts.containsValue(context)) {
             contexts.put(key, context);
         } else {
-            LogUtils.info(log, "duplicate key : {}", key);
+            log.info("duplicate key : {}", key);
         }
         send(msg);
         Supplier<Package> supplier = () -> {
@@ -214,8 +212,7 @@ public abstract class TcpClient implements Closeable {
 
             @Override
             public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-                LogUtils.info(log, "exceptionCaught, close connection.|remote address={}",
-                    ctx.channel().remoteAddress(), cause);
+                log.info("exceptionCaught, close connection.|remote address={}", ctx.channel().remoteAddress(), cause);
                 ctx.close();
             }
         };

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/impl/eventmeshmessage/EventMeshMessageTCPPubClient.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/tcp/impl/eventmeshmessage/EventMeshMessageTCPPubClient.java
@@ -31,7 +31,6 @@ import org.apache.eventmesh.common.protocol.tcp.Command;
 import org.apache.eventmesh.common.protocol.tcp.EventMeshMessage;
 import org.apache.eventmesh.common.protocol.tcp.Package;
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -80,7 +79,7 @@ class EventMeshMessageTCPPubClient extends TcpClient implements EventMeshTCPPubC
     public Package rr(EventMeshMessage eventMeshMessage, long timeout) throws EventMeshException {
         try {
             Package msg = MessageUtils.buildPackage(eventMeshMessage, Command.REQUEST_TO_SERVER);
-            LogUtils.info(log, "{}|rr|send|type={}|msg={}", CLIENTNO, msg, msg);
+            log.info("{}|rr|send|type={}|msg={}", CLIENTNO, msg, msg);
             return io(msg, timeout);
         } catch (Exception e) {
             throw new EventMeshException("rr error", e);

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/workflow/EventMeshWorkflowClient.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/workflow/EventMeshWorkflowClient.java
@@ -24,7 +24,6 @@ import org.apache.eventmesh.client.workflow.config.EventMeshWorkflowClientConfig
 import org.apache.eventmesh.common.protocol.workflow.protos.ExecuteRequest;
 import org.apache.eventmesh.common.protocol.workflow.protos.ExecuteResponse;
 import org.apache.eventmesh.common.protocol.workflow.protos.WorkflowGrpc;
-import org.apache.eventmesh.common.utils.LogUtils;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -58,7 +57,7 @@ public class EventMeshWorkflowClient {
     public ExecuteResponse execute(final ExecuteRequest request) throws Exception {
         final WorkflowGrpc.WorkflowBlockingStub workflowClient = getWorkflowClient();
         final ExecuteResponse response = workflowClient.execute(request);
-        LogUtils.info(log, "received response:{}", response);
+        log.info("received response:{}", response);
         return response;
     }
 }

--- a/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/http/demo/SyncRequestInstance.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/test/java/org/apache/eventmesh/client/http/demo/SyncRequestInstance.java
@@ -21,7 +21,6 @@ import org.apache.eventmesh.client.http.conf.EventMeshHttpClientConfig;
 import org.apache.eventmesh.client.http.producer.EventMeshHttpProducer;
 import org.apache.eventmesh.common.EventMeshMessage;
 import org.apache.eventmesh.common.utils.IPUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.common.utils.RandomStringUtils;
 import org.apache.eventmesh.common.utils.ThreadUtils;
 
@@ -66,7 +65,7 @@ public class SyncRequestInstance {
                 .uniqueId(RandomStringUtils.generateNum(30)).build();
 
             EventMeshMessage rsp = eventMeshHttpProducer.request(eventMeshMessage, 10000);
-            LogUtils.debug(log, "sendmsg : {}, return : {}, cost:{}ms", eventMeshMessage.getContent(), rsp.getContent(),
+            log.debug("sendmsg : {}, return : {}, cost:{}ms", eventMeshMessage.getContent(), rsp.getContent(),
                 System.currentTimeMillis() - startTime);
         } catch (Exception e) {
             log.warn("send msg failed", e);

--- a/eventmesh-transformer/src/main/java/org/apache/eventmesh/transformer/TransformerBuilder.java
+++ b/eventmesh-transformer/src/main/java/org/apache/eventmesh/transformer/TransformerBuilder.java
@@ -32,7 +32,6 @@ public class TransformerBuilder {
         }
     }
 
-
     public static Transformer buildTemplateTransFormer(String jsonContent, String template) {
         JsonPathParser jsonPathParser = new JsonPathParser(jsonContent);
         Template templateEntry = new Template(template);

--- a/eventmesh-transformer/src/main/java/org/apache/eventmesh/transformer/TransformerType.java
+++ b/eventmesh-transformer/src/main/java/org/apache/eventmesh/transformer/TransformerType.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum TransformerType {
+
     ORIGINAL(1, "original"),
     CONSTANT(2, "constant"),
     TEMPLATE(3, "template");

--- a/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/AdminWebHookConfigOperationManager.java
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/AdminWebHookConfigOperationManager.java
@@ -21,7 +21,6 @@ import static org.apache.eventmesh.webhook.api.WebHookOperationConstant.OPERATIO
 import static org.apache.eventmesh.webhook.api.WebHookOperationConstant.OPERATION_MODE_NACOS;
 
 import org.apache.eventmesh.common.config.ConfigService;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.webhook.api.WebHookConfigOperation;
 import org.apache.eventmesh.webhook.config.AdminConfiguration;
 
@@ -73,7 +72,7 @@ public class AdminWebHookConfigOperationManager {
             constructor.setAccessible(true);
             final Properties operationProperties = adminConfiguration.getOperationProperties();
 
-            LogUtils.info(log, "operationMode is {}  properties is {} ", operationMode, operationProperties);
+            log.info("operationMode is {}  properties is {} ", operationMode, operationProperties);
             this.webHookConfigOperation = constructor.newInstance(operationProperties);
         } finally {
             // Restore the original accessibility of constructor

--- a/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperation.java
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/FileWebHookConfigOperation.java
@@ -18,7 +18,6 @@
 package org.apache.eventmesh.webhook.admin;
 
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.webhook.api.WebHookConfig;
 import org.apache.eventmesh.webhook.api.WebHookConfigOperation;
 import org.apache.eventmesh.webhook.api.WebHookOperationConstant;
@@ -63,8 +62,7 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
     @Override
     public Integer insertWebHookConfig(final WebHookConfig webHookConfig) {
         if (!webHookConfig.getCallbackPath().startsWith(WebHookOperationConstant.CALLBACK_PATH_PREFIX)) {
-            LogUtils.error(log, "webhookConfig callback path must start with {}",
-                WebHookOperationConstant.CALLBACK_PATH_PREFIX);
+            log.error("webhookConfig callback path must start with {}", WebHookOperationConstant.CALLBACK_PATH_PREFIX);
             return 0;
         }
 
@@ -75,7 +73,7 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
 
         final File webhookConfigFile = getWebhookConfigFile(webHookConfig);
         if (webhookConfigFile.exists()) {
-            LogUtils.error(log, "webhookConfig {} exists", webHookConfig.getCallbackPath());
+            log.error("webhookConfig {} exists", webHookConfig.getCallbackPath());
             return 0;
         }
         return writeToFile(webhookConfigFile, webHookConfig) ? 1 : 0;
@@ -85,7 +83,7 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
     public Integer updateWebHookConfig(final WebHookConfig webHookConfig) {
         final File webhookConfigFile = getWebhookConfigFile(webHookConfig);
         if (!webhookConfigFile.exists()) {
-            LogUtils.error(log, "webhookConfig {} does not exist", webHookConfig.getCallbackPath());
+            log.error("webhookConfig {} does not exist", webHookConfig.getCallbackPath());
             return 0;
         }
         return writeToFile(webhookConfigFile, webHookConfig) ? 1 : 0;
@@ -96,7 +94,7 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
         synchronized (SharedLatchHolder.lock) {
             final File webhookConfigFile = getWebhookConfigFile(webHookConfig);
             if (!webhookConfigFile.exists()) {
-                LogUtils.error(log, "webhookConfig {} does not exist", webHookConfig.getCallbackPath());
+                log.error("webhookConfig {} does not exist", webHookConfig.getCallbackPath());
                 return 0;
             }
             return webhookConfigFile.delete() ? 1 : 0;
@@ -110,7 +108,7 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
     public WebHookConfig queryWebHookConfigById(final WebHookConfig webHookConfig) {
         final File webhookConfigFile = getWebhookConfigFile(webHookConfig);
         if (!webhookConfigFile.exists()) {
-            LogUtils.error(log, "webhookConfig {} does not exist", webHookConfig.getCallbackPath());
+            log.error("webhookConfig {} does not exist", webHookConfig.getCallbackPath());
             return null;
         }
 
@@ -124,7 +122,7 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
         final String manuDirPath = getWebhookConfigManuDir(webHookConfig);
         final File manuDir = new File(manuDirPath);
         if (!manuDir.exists()) {
-            LogUtils.warn(log, "webhookConfig dir {} does not exist", manuDirPath);
+            log.warn("webhookConfig dir {} does not exist", manuDirPath);
             return new ArrayList<>();
         }
 
@@ -155,7 +153,7 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
                 fileContent.append(line);
             }
         } catch (IOException e) {
-            LogUtils.error(log, "get webHookConfig from file {} error", webhookConfigFile.getPath(), e);
+            log.error("get webHookConfig from file {} error", webhookConfigFile.getPath(), e);
             return null;
         }
 
@@ -171,7 +169,7 @@ public class FileWebHookConfigOperation implements WebHookConfigOperation {
                 fos.getChannel().lock();
                 bw.write(Objects.requireNonNull(JsonUtils.toJSONString(webHookConfig)));
             } catch (IOException e) {
-                LogUtils.error(log, "write webhookConfig {} to file error", webHookConfig.getCallbackPath());
+                log.error("write webhookConfig {} to file error", webHookConfig.getCallbackPath());
                 return false;
             }
             return true;

--- a/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/NacosWebHookConfigOperation.java
+++ b/eventmesh-webhook/eventmesh-webhook-admin/src/main/java/org/apache/eventmesh/webhook/admin/NacosWebHookConfigOperation.java
@@ -23,7 +23,6 @@ import static org.apache.eventmesh.webhook.api.WebHookOperationConstant.MANUFACT
 import static org.apache.eventmesh.webhook.api.WebHookOperationConstant.TIMEOUT_MS;
 
 import org.apache.eventmesh.common.utils.JsonUtils;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.webhook.api.Manufacturer;
 import org.apache.eventmesh.webhook.api.WebHookConfig;
 import org.apache.eventmesh.webhook.api.WebHookConfigOperation;
@@ -62,8 +61,7 @@ public class NacosWebHookConfigOperation implements WebHookConfigOperation {
     @Override
     public Integer insertWebHookConfig(final WebHookConfig webHookConfig) {
         if (!webHookConfig.getCallbackPath().startsWith(WebHookOperationConstant.CALLBACK_PATH_PREFIX)) {
-            LogUtils.error(log, "webhookConfig callback path must start with {}",
-                WebHookOperationConstant.CALLBACK_PATH_PREFIX);
+            log.error("webhookConfig callback path must start with {}", WebHookOperationConstant.CALLBACK_PATH_PREFIX);
             return 0;
         }
 
@@ -72,7 +70,7 @@ public class NacosWebHookConfigOperation implements WebHookConfigOperation {
         try {
             if (configService.getConfig(getWebHookConfigDataId(webHookConfig),
                 getManuGroupId(webHookConfig), TIMEOUT_MS) != null) {
-                LogUtils.error(log, "insertWebHookConfig failed, config has existed");
+                log.error("insertWebHookConfig failed, config has existed");
                 return 0;
             }
             result = configService.publishConfig(getWebHookConfigDataId(webHookConfig), getManuGroupId(webHookConfig),
@@ -109,7 +107,7 @@ public class NacosWebHookConfigOperation implements WebHookConfigOperation {
         try {
             if (configService.getConfig(getWebHookConfigDataId(webHookConfig), getManuGroupId(webHookConfig),
                 TIMEOUT_MS) == null) {
-                LogUtils.error(log, "updateWebHookConfig failed, config is not existed");
+                log.error("updateWebHookConfig failed, config is not existed");
                 return 0;
             }
             result = configService.publishConfig(getWebHookConfigDataId(webHookConfig),

--- a/eventmesh-webhook/eventmesh-webhook-receive/src/main/java/org/apache/eventmesh/webhook/receive/WebHookController.java
+++ b/eventmesh-webhook/eventmesh-webhook-receive/src/main/java/org/apache/eventmesh/webhook/receive/WebHookController.java
@@ -23,7 +23,6 @@ import org.apache.eventmesh.api.exception.OnExceptionContext;
 import org.apache.eventmesh.common.config.ConfigService;
 import org.apache.eventmesh.common.protocol.ProtocolTransportObject;
 import org.apache.eventmesh.common.protocol.http.WebhookProtocolTransportObject;
-import org.apache.eventmesh.common.utils.LogUtils;
 import org.apache.eventmesh.protocol.api.ProtocolAdaptor;
 import org.apache.eventmesh.protocol.api.ProtocolPluginFactory;
 import org.apache.eventmesh.webhook.api.WebHookConfig;
@@ -123,12 +122,12 @@ public class WebHookController {
 
             @Override
             public void onSuccess(SendResult sendResult) {
-                LogUtils.debug(log, sendResult.toString());
+                log.debug(sendResult.toString());
             }
 
             @Override
             public void onException(OnExceptionContext context) {
-                LogUtils.warn(log, "", context.getException());
+                log.warn("", context.getException());
             }
 
         });


### PR DESCRIPTION
### Motivation

The `LogUtils` class is not useful because:

 * it wraps every logger call in a `if (logger.isDebugEnabled())` or similar guard. These guards are not necessary since the arguments to the logger calls are simple variables and not computationally complex expressions. They don't provide any performance advantage,
 * if we remove the guards every `LogUtils` method is just a static version of a corresponding `Logger` method,
 * the current implementation it breaks location detection of the logger calls, which will always show `LogUtils` as origin; this problem can be fixed, but it is much simpler to inline all `LogUtils` methods,
 * it prevents the project from using source code rewrite tools like [`rewrite-logging-frameworks`](https://github.com/openrewrite/rewrite-logging-frameworks), which work on the original `Logger` class, not on wrappers.

### Modifications

This PR contains 3 commits:

 1. the first commit deprecates the `LogUtils` class and add Error Prone's [`@InlineMe`](https://errorprone.info/docs/inlineme) annotation to help current class users to rewrite their code automatically,
 2. the second commit is **only** for reviewer's sake: it introduces a simple `errorPronePatch` and `errorPronePatchTest` Gradle task to perform automatic inlining of all `LogUtils` call sites (cf. [Error Prone patching](https://errorprone.info/docs/patching)),
 3. the third commit contains **only automatic changes** performed by ErrorProne.

### Reviewer kit

I would suggest reviewer to:

- check the changes in the `LogUtils` class,
- checkout the code locally and **roll back** one commit,
- using JDK 11 run:
  ```
  ./gradlew clean errorPronePatch
  ./gradlew clean errorPronePatch
  ./gradlew clean :eventmesh-sdks:eventmesh-sdk-java:errorPronePatchTest
  ./gradlew clean :eventmesh-runtime:errorPronePatchTest
  ```
  in order to allow Error Prone to rewrite the codebase,
- after this only one Java source file should contain the string "LogUtils",
- verify that the contents of the working directory are **identical** to the head of this PR, i.e. that the last commit does not introduce **any** changes beyond those performed by Error Prone. 

### Documentation

This PR does not require changes in the documentation. The deprecation of `LogUtils` is documented in Javadoc.

On the other hand this change requires a minor version bump for EventMesh (cf. [semantic versioning pt. 7](https://semver.org/#spec-item-7)).
