### PR TITLE
[ISSUE #4705] Remove redundant Gradle build task 'jar'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,4 +112,4 @@ jobs:
 
       - name: Check third party dependencies
         run: |
-          ./gradlew clean jar dist -x spotlessJava -x test -x checkstyleMain -x javaDoc && ./gradlew installPlugin && ./gradlew tar && sh tools/dependency-check/check-dependencies.sh && echo "Thirty party dependencies check success"
+          ./gradlew clean dist -x spotlessJava -x test -x checkstyleMain -x javaDoc && ./gradlew installPlugin && ./gradlew tar && sh tools/dependency-check/check-dependencies.sh && echo "Thirty party dependencies check success"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
       # https://docs.gradle.org/current/userguide/performance.html
       - name: Build
-        run: ./gradlew clean build jar dist jacocoTestReport -x spotlessJava -x generateGrammarSource --parallel --daemon
+        run: ./gradlew clean build dist jacocoTestReport -x spotlessJava -x generateGrammarSource --parallel --daemon
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
 

--- a/build.gradle
+++ b/build.gradle
@@ -437,7 +437,7 @@ subprojects {
                     licenses {
                         license {
                             name = 'The Apache License, Version 2.0'
-                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                            url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                         }
                     }
                     developers {

--- a/docker/Dockerfile_jdk11
+++ b/docker/Dockerfile_jdk11
@@ -19,7 +19,7 @@
 FROM openjdk:11-jdk as builder
 WORKDIR /build
 COPY . .
-RUN ./gradlew clean build jar dist --parallel --daemon
+RUN ./gradlew clean build dist --parallel --daemon
 RUN ./gradlew installPlugin
 
 FROM openjdk:11-jdk

--- a/docker/Dockerfile_jdk8
+++ b/docker/Dockerfile_jdk8
@@ -24,7 +24,7 @@ RUN ./gradlew clean generateGrammarSource --parallel --daemon
 FROM openjdk:8-jdk as builder_8
 WORKDIR /build
 COPY --from=builder_11 /build ./
-RUN ./gradlew clean build jar dist -x spotlessJava -x generateGrammarSource --parallel --daemon
+RUN ./gradlew clean build dist -x spotlessJava -x generateGrammarSource --parallel --daemon
 RUN ./gradlew installPlugin
 
 FROM openjdk:8-jdk


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
-->

Fixes #4705.

### Motivation

When writing this PR https://github.com/apache/eventmesh-site/pull/170, I noticed this build task.

Gradle build task `jar` is already depended by `dist` and included in `build`, so there is no need to excute it.

![image](https://github.com/apache/eventmesh/assets/41445332/0ab9af2e-75ef-46e4-a1c8-5753516476d1)

### Modifications

Remove task `jar` from compilation commands.

### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
