### PR TITLE
[ISSUE #4711] Properly close resources used by WatchFileManagerTest

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/file/WatchFileTask.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/file/WatchFileTask.java
@@ -83,6 +83,11 @@ public class WatchFileTask extends Thread {
 
     public void shutdown() {
         watch = false;
+        try {
+            this.watchService.close();
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to close WatchService", e);
+        }
     }
 
     @Override

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/file/WatchFileTask.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/file/WatchFileTask.java
@@ -19,6 +19,7 @@ package org.apache.eventmesh.common.file;
 
 import org.apache.eventmesh.common.utils.LogUtils;
 
+import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
@@ -55,11 +56,21 @@ public class WatchFileTask extends Thread {
             throw new IllegalArgumentException("must be a file directory : " + directoryPath);
         }
 
-        try (WatchService watchService = FILE_SYSTEM.newWatchService()) {
-            this.watchService = watchService;
+        try {
+            this.watchService = FILE_SYSTEM.newWatchService();
+        } catch (IOException ex) {
+            throw new RuntimeException("WatchService initialization fail", ex);
+        }
+
+        try {
             path.register(this.watchService, StandardWatchEventKinds.OVERFLOW, StandardWatchEventKinds.ENTRY_MODIFY,
                 StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE);
-        } catch (Exception ex) {
+        } catch (IOException ex) {
+            try {
+                this.watchService.close();
+            } catch (IOException e) {
+                ex.addSuppressed(e);
+            }
             throw new UnsupportedOperationException("WatchService registry fail", ex);
         }
     }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
@@ -50,11 +50,11 @@ public class WatchFileManagerTest {
         WatchFileManager.registerFileChangeListener(tempConfigFile.getParent(), mockFileChangeListener);
 
         Properties properties = new Properties();
-        try (
-                BufferedReader bufferedReader = new BufferedReader(new FileReader(configFile));
-                FileWriter fw = new FileWriter(tempConfigFile)
-        ) {
+        try (BufferedReader bufferedReader = new BufferedReader(new FileReader(tempConfigFile))) {
             properties.load(bufferedReader);
+        }
+
+        try (FileWriter fw = new FileWriter(tempConfigFile)) {
             properties.setProperty("eventMesh.server.newAdd", "newAdd");
             properties.store(fw, "newAdd");
         }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
@@ -60,10 +60,14 @@ public class WatchFileManagerTest {
         WatchFileManager.registerFileChangeListener(tempConfigFile.getParent(), fileChangeListener);
 
         Properties properties = new Properties();
-        properties.load(new BufferedReader(new FileReader(tempConfigFile)));
-        properties.setProperty("eventMesh.server.newAdd", "newAdd");
-        FileWriter fw = new FileWriter(tempConfigFile);
-        properties.store(fw, "newAdd");
+        try (
+                BufferedReader bufferedReader = new BufferedReader(new FileReader(tempConfigFile));
+                FileWriter fw = new FileWriter(tempConfigFile)
+        ) {
+            properties.load(bufferedReader);
+            properties.setProperty("eventMesh.server.newAdd", "newAdd");
+            properties.store(fw, "newAdd");
+        }
 
         ThreadUtils.sleep(500, TimeUnit.MILLISECONDS);
     }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
@@ -59,7 +59,7 @@ public class WatchFileManagerTest {
             properties.store(fw, "newAdd");
         }
 
-        Mockito.verify(mockFileChangeListener, Mockito.timeout(15_000))
+        Mockito.verify(mockFileChangeListener, Mockito.timeout(15_000).atLeastOnce())
                 .onChanged(Mockito.argThat(isFileUnderTest(tempConfigFile.getParent(), tempConfigFile.getName())));
     }
 

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.eventmesh.common.file;
 
-import org.apache.eventmesh.common.utils.ThreadUtils;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -26,11 +24,11 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mockito;
 
 public class WatchFileManagerTest {
 
@@ -40,28 +38,20 @@ public class WatchFileManagerTest {
     @Test
     public void testWatchFile() throws IOException, InterruptedException {
         String file = WatchFileManagerTest.class.getResource("/configuration.properties").getFile();
-        File f = new File(file);
+        File configFile = new File(file);
         File tempConfigFile = new File(tempConfigDir, "configuration.properties");
-        Files.copy(f.toPath(), tempConfigFile.toPath());
+        Files.copy(configFile.toPath(), tempConfigFile.toPath());
 
-        final FileChangeListener fileChangeListener = new FileChangeListener() {
+        final FileChangeListener mockFileChangeListener = Mockito.mock(FileChangeListener.class);
+        Mockito.when(mockFileChangeListener.support(
+                Mockito.argThat(isFileUnderTest(tempConfigFile.getParent(), tempConfigFile.getName())))
+        ).thenReturn(true);
 
-            @Override
-            public void onChanged(FileChangeContext changeContext) {
-                Assertions.assertEquals(tempConfigFile.getName(), changeContext.getFileName());
-                Assertions.assertEquals(tempConfigFile.getParent(), changeContext.getDirectoryPath());
-            }
-
-            @Override
-            public boolean support(FileChangeContext changeContext) {
-                return changeContext.getWatchEvent().context().toString().contains(tempConfigFile.getName());
-            }
-        };
-        WatchFileManager.registerFileChangeListener(tempConfigFile.getParent(), fileChangeListener);
+        WatchFileManager.registerFileChangeListener(tempConfigFile.getParent(), mockFileChangeListener);
 
         Properties properties = new Properties();
         try (
-                BufferedReader bufferedReader = new BufferedReader(new FileReader(tempConfigFile));
+                BufferedReader bufferedReader = new BufferedReader(new FileReader(configFile));
                 FileWriter fw = new FileWriter(tempConfigFile)
         ) {
             properties.load(bufferedReader);
@@ -69,6 +59,11 @@ public class WatchFileManagerTest {
             properties.store(fw, "newAdd");
         }
 
-        ThreadUtils.sleep(500, TimeUnit.MILLISECONDS);
+        Mockito.verify(mockFileChangeListener, Mockito.timeout(15_000))
+                .onChanged(Mockito.argThat(isFileUnderTest(tempConfigFile.getParent(), tempConfigFile.getName())));
+    }
+
+    private ArgumentMatcher<FileChangeContext> isFileUnderTest(String directoryPath, String fileName) {
+        return argument -> argument.getDirectoryPath().equals(directoryPath) && argument.getFileName().equals(fileName);
     }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
-->

Fixes https://github.com/apache/eventmesh/issues/4711

### Motivation

The `@TempDir` added in the [Build caching optimizations PR](https://github.com/apache/eventmesh/pull/4689) caused tests to fail when run on a Windows machine. The failure was due to the fact that the directory could not be deleted because it was in use by other processes.

### Modifications

The resources holding on to the temporary config file that were preventing the temp directory from being deleted are now properly closed.

### Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented?
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
