### PR TITLE
[ISSUE #4721] Use gradle-build-action for caching and build scan link promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,8 @@ jobs:
           git submodule update
           make -C ./eventmesh-sdks/eventmesh-sdk-c  
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradle-
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
-->

Fixes #4721.

### Motivation

This is a follow on effort to the change in https://github.com/apache/eventmesh/pull/4685. This change will both show build scan links on GitHub Actions workflows and replace custom caching logic in the CI workflow.

### Modifications

- Add [gradle-build-action](https://github.com/gradle/gradle-build-action) to the CI GitHub Actions workflow.

### Documentation

- Does this pull request introduce a new feature? (no)