### PR TITLE
[ISSUE #4737] Separate codeql workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - if: matrix.language == 'cpp' || matrix.language == 'csharp'
+        name: Build C
+        run: |
+          git submodule init
+          git submodule update
+          make -C ./eventmesh-sdks/eventmesh-sdk-c  
+
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,28 +33,11 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macOS-latest ]
         java: [ 8, 11 ]
-        language: ['java', 'go']
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-        with:
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-          # queries: ./path/to/local/query, your-org/your-repo/queries@main
-          languages: ${{ matrix.language }}
-
-      - if: matrix.language == 'cpp' || matrix.language == 'csharp'
-        name: Build C
-        run: |
-          git submodule init
-          git submodule update
-          make -C ./eventmesh-sdks/eventmesh-sdk-c  
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
@@ -86,9 +69,6 @@ jobs:
         run: ./gradlew installPlugin
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
-
-      - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v2
 
       - name: Upload coverage report to codecov.io
         run: bash <(curl -s https://codecov.io/bash) || echo 'Failed to upload coverage report!'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macOS-latest ]
         java: [ 8, 11 ]
+        language: ['java']
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
 
       - name: GenerateGrammarSource
         run: ./gradlew clean generateGrammarSource --parallel --daemon
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3
@@ -107,3 +109,5 @@ jobs:
       - name: Check third party dependencies
         run: |
           ./gradlew clean dist -x spotlessJava -x test -x checkstyleMain -x javaDoc && ./gradlew installPlugin && ./gradlew tar && sh tools/dependency-check/check-dependencies.sh && echo "Thirty party dependencies check success"
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,69 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  build:
+    name: Build
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['java', 'go']
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
+          languages: ${{ matrix.language }}
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        if: matrix.language == 'java'
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 11
+        if: matrix.language == 'java'
+
+      # https://docs.gradle.org/current/userguide/performance.html
+      - name: Build
+        run: ./gradlew clean assemble compileTestJava --no-build-cache --parallel --daemon
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+        if: matrix.language == 'java'
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Analyze"
+name: "CodeQL"
 
 on:
   push:
@@ -27,7 +27,7 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Analyze
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "CodeQL"
+name: "Analyze"
 
 on:
   push:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: Build
+name: Docker
 on:
   release:
     types: [released]

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id 'com.gradle.enterprise' version '3.15.1'
+    id 'com.gradle.enterprise' version '3.16.1'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.12.1'
 }
 


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
-->

Fixes #4737.

### Motivation

The motivation for this PR is to fix an issue where CodeQL is not able to analyze a PR when the Gradle build cache prevents all Java compilation. CodeQL requires the compiler to execute during the workflow in order to perform its analysis, as documented [here](https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/no-source-code-seen-during-build).

### Modifications

This pull request moves the CodeQL verification to its own workflow, independent of the "Continuous Integration" workflow, where Gradle build caching is disabled. This not only addresses the issue, but should also have some improvements to the workflows:

* By moving CodeQL to its own workflow, it can execute in parallel. This removes CodeQL analysis from the critical path of a full build and lets the continuous integration workflow finish more quickly by leveraging build cache and skipping this analysis.
* By moving CodeQL to its own workflow, it is no longer necessary to run the "Continuous integration" workflow for both Java and Go, since the Go branch only seemed to run in order to get CodeQL results. This would eliminate four workflows per larger build. We can also skip the Gradle build on the Go CodeQL workflow.

### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
