### PR TITLE
[ISSUE #4734] Use the static final modifier to decorate Logger

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/constants/EventMeshConstants.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/constants/EventMeshConstants.java
@@ -152,7 +152,6 @@ public class EventMeshConstants {
     public static final String MESSAGE = "message";
     public static final String CMD = "cmd";
     public static final String ACL = "acl";
-    public static final String BATCH_MSG = "batchMessage";
     public static final String MSG_TYPE = "msgtype";
     public static final String PERSISTENT = "persistent";
     public static final String HANDLER_ORIGIN = "Access-Control-Allow-Origin";
@@ -161,6 +160,7 @@ public class EventMeshConstants {
     public static final String HANDLER_AGE = "Access-Control-Max-Age";
     public static final String MAX_AGE = "86400";
 
+    public static final String BATCH_MSG = "batchMessage";
     public static final String TCP_MONITOR = "tcpMonitor";
     public static final String APP_MONITOR = "appMonitor";
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/constants/EventMeshConstants.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/constants/EventMeshConstants.java
@@ -152,6 +152,7 @@ public class EventMeshConstants {
     public static final String MESSAGE = "message";
     public static final String CMD = "cmd";
     public static final String ACL = "acl";
+    public static final String BATCH_MSG = "batchMessage";
     public static final String MSG_TYPE = "msgtype";
     public static final String PERSISTENT = "persistent";
     public static final String HANDLER_ORIGIN = "Access-Control-Allow-Origin";
@@ -159,4 +160,7 @@ public class EventMeshConstants {
     public static final String HANDLER_HEADERS = "Access-Control-Allow-Headers";
     public static final String HANDLER_AGE = "Access-Control-Max-Age";
     public static final String MAX_AGE = "86400";
+
+    public static final String TCP_MONITOR = "tcpMonitor";
+    public static final String APP_MONITOR = "appMonitor";
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/constants/EventMeshConstants.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/constants/EventMeshConstants.java
@@ -152,6 +152,9 @@ public class EventMeshConstants {
     public static final String MESSAGE = "message";
     public static final String CMD = "cmd";
     public static final String ACL = "acl";
+    public static final String BATCH_MSG = "batchMessage";
+    public static final String TCP_MONITOR = "tcpMonitor";
+    public static final String APP_MONITOR = "appMonitor";
     public static final String MSG_TYPE = "msgtype";
     public static final String PERSISTENT = "persistent";
     public static final String HANDLER_ORIGIN = "Access-Control-Allow-Origin";
@@ -159,8 +162,4 @@ public class EventMeshConstants {
     public static final String HANDLER_HEADERS = "Access-Control-Allow-Headers";
     public static final String HANDLER_AGE = "Access-Control-Max-Age";
     public static final String MAX_AGE = "86400";
-
-    public static final String BATCH_MSG = "batchMessage";
-    public static final String TCP_MONITOR = "tcpMonitor";
-    public static final String APP_MONITOR = "appMonitor";
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/HeartbeatProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/HeartbeatProcessor.java
@@ -43,7 +43,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 
 public class HeartbeatProcessor {
 
-    private final Logger aclLogger = LoggerFactory.getLogger(EventMeshConstants.ACL);
+    private static final Logger ACL_LOGGER = LoggerFactory.getLogger(EventMeshConstants.ACL);
 
     private final EventMeshGrpcServer eventMeshGrpcServer;
 
@@ -69,7 +69,7 @@ public class HeartbeatProcessor {
         try {
             doAclCheck(heartbeat);
         } catch (AclException e) {
-            aclLogger.warn("CLIENT HAS NO PERMISSION, HeartbeatProcessor failed", e);
+            ACL_LOGGER.warn("CLIENT HAS NO PERMISSION, HeartbeatProcessor failed", e);
             ServiceUtils.sendResponseCompleted(StatusCode.EVENTMESH_ACL_ERR, e.getMessage(), emitter);
             return;
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/ReplyMessageProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/ReplyMessageProcessor.java
@@ -51,7 +51,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ReplyMessageProcessor {
 
-    private final Logger aclLogger = LoggerFactory.getLogger(EventMeshConstants.ACL);
+    private static final Logger ACL_LOGGER = LoggerFactory.getLogger(EventMeshConstants.ACL);
 
     private final EventMeshGrpcServer eventMeshGrpcServer;
 
@@ -77,7 +77,7 @@ public class ReplyMessageProcessor {
         try {
             doAclCheck(message);
         } catch (Exception e) {
-            aclLogger.warn("CLIENT HAS NO PERMISSION,RequestReplyMessageProcessor reply failed", e);
+            ACL_LOGGER.warn("CLIENT HAS NO PERMISSION,RequestReplyMessageProcessor reply failed", e);
             ServiceUtils.sendStreamResponseCompleted(message, StatusCode.EVENTMESH_ACL_ERR, e.getMessage(), emitter);
             return;
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/SubscribeStreamProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/SubscribeStreamProcessor.java
@@ -32,6 +32,7 @@ import org.apache.eventmesh.runtime.core.protocol.grpc.consumer.EventMeshConsume
 import org.apache.eventmesh.runtime.core.protocol.grpc.consumer.consumergroup.ConsumerGroupClient;
 import org.apache.eventmesh.runtime.core.protocol.grpc.service.EventEmitter;
 import org.apache.eventmesh.runtime.core.protocol.grpc.service.ServiceUtils;
+import org.apache.eventmesh.runtime.constants.EventMeshConstants;
 
 import java.util.Date;
 import java.util.LinkedList;
@@ -48,7 +49,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class SubscribeStreamProcessor {
 
-    private final Logger aclLogger = LoggerFactory.getLogger("acl");
+    private static final Logger ACL_LOGGER = LoggerFactory.getLogger(EventMeshConstants.ACL);
 
     private final EventMeshGrpcServer eventMeshGrpcServer;
 
@@ -77,7 +78,7 @@ public class SubscribeStreamProcessor {
         try {
             doAclCheck(subscription);
         } catch (AclException e) {
-            aclLogger.warn("CLIENT HAS NO PERMISSION to Subscribe. failed", e);
+            ACL_LOGGER.warn("CLIENT HAS NO PERMISSION to Subscribe. failed", e);
             ServiceUtils.sendStreamResponseCompleted(subscription, StatusCode.EVENTMESH_ACL_ERR, e.getMessage(), emitter);
             return;
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/SubscribeStreamProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/grpc/processor/SubscribeStreamProcessor.java
@@ -27,12 +27,12 @@ import org.apache.eventmesh.common.protocol.http.common.RequestCode;
 import org.apache.eventmesh.common.utils.JsonUtils;
 import org.apache.eventmesh.runtime.acl.Acl;
 import org.apache.eventmesh.runtime.boot.EventMeshGrpcServer;
+import org.apache.eventmesh.runtime.constants.EventMeshConstants;
 import org.apache.eventmesh.runtime.core.protocol.grpc.consumer.ConsumerManager;
 import org.apache.eventmesh.runtime.core.protocol.grpc.consumer.EventMeshConsumer;
 import org.apache.eventmesh.runtime.core.protocol.grpc.consumer.consumergroup.ConsumerGroupClient;
 import org.apache.eventmesh.runtime.core.protocol.grpc.service.EventEmitter;
 import org.apache.eventmesh.runtime.core.protocol.grpc.service.ServiceUtils;
-import org.apache.eventmesh.runtime.constants.EventMeshConstants;
 
 import java.util.Date;
 import java.util.LinkedList;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageProcessor.java
@@ -71,7 +71,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
 
     private static final Logger ACL_LOGGER = LoggerFactory.getLogger(EventMeshConstants.ACL);
 
-    private static final Logger BATCH_MESSAGE_LOGGER = LoggerFactory.getLogger(EventMeshConstants.BATCH_MSG);
+    private static final Logger BATCH_MSG_LOGGER = LoggerFactory.getLogger(EventMeshConstants.BATCH_MSG);
 
     private final EventMeshHTTPServer eventMeshHTTPServer;
 
@@ -112,7 +112,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
         int eventSize = eventList.size();
 
         if (eventSize > httpConfiguration.getEventMeshEventBatchSize()) {
-            BATCH_MESSAGE_LOGGER.error("Event batch size exceeds the limit: {}", httpConfiguration.getEventMeshEventBatchSize());
+            BATCH_MSG_LOGGER.error("Event batch size exceeds the limit: {}", httpConfiguration.getEventMeshEventBatchSize());
             completeResponse(request, asyncContext, sendMessageBatchResponseHeader, EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR,
                 "Event batch size exceeds the limit: " + httpConfiguration.getEventMeshEventBatchSize(), SendMessageBatchResponseBody.class);
             return;
@@ -129,7 +129,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
 
             String content = event.getData() == null ? "" : new String(event.getData().toBytes(), Constants.DEFAULT_CHARSET);
             if (content.length() > httpConfiguration.getEventMeshEventSize()) {
-                BATCH_MESSAGE_LOGGER.error("Event size exceeds the limit: {}", httpConfiguration.getEventMeshEventSize());
+                BATCH_MSG_LOGGER.error("Event size exceeds the limit: {}", httpConfiguration.getEventMeshEventSize());
                 completeResponse(request, asyncContext, sendMessageBatchResponseHeader, EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR,
                     "Event size exceeds the limit: " + httpConfiguration.getEventMeshEventSize(), SendMessageBatchResponseBody.class);
                 return;
@@ -223,9 +223,9 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
                     topicBatchMessageMappings.put(cloudEvent.getSubject(), tmp);
                 }
 
-                BATCH_MESSAGE_LOGGER.debug("msg2MQMsg suc, event:{}", cloudEvent.getData());
+                BATCH_MSG_LOGGER.debug("msg2MQMsg suc, event:{}", cloudEvent.getData());
             } catch (Exception e) {
-                BATCH_MESSAGE_LOGGER.error("msg2MQMsg err, event:{}", cloudEvent.getData(), e);
+                BATCH_MSG_LOGGER.error("msg2MQMsg err, event:{}", cloudEvent.getData(), e);
             }
 
         }
@@ -253,7 +253,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
 
                     @Override
                     public void onException(OnExceptionContext context) {
-                        BATCH_MESSAGE_LOGGER.warn("", context.getException());
+                        BATCH_MSG_LOGGER.warn("", context.getException());
                         eventMeshHTTPServer.getHttpRetryer().newTimeout(sendMessageContext, 10, TimeUnit.SECONDS);
                     }
 
@@ -271,7 +271,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
 
                     @Override
                     public void onException(OnExceptionContext context) {
-                        BATCH_MESSAGE_LOGGER.warn("", context.getException());
+                        BATCH_MSG_LOGGER.warn("", context.getException());
                         eventMeshHTTPServer.getHttpRetryer().newTimeout(sendMessageContext, 10, TimeUnit.SECONDS);
                     }
 
@@ -282,7 +282,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
         long elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);
         summaryMetrics.recordBatchSendMsgCost(elapsed);
 
-        BATCH_MESSAGE_LOGGER.debug("batchMessage|eventMesh2mq|REQ|ASYNC|batchId={}|send2MQCost={}ms|msgNum={}|topics={}",
+        BATCH_MSG_LOGGER.debug("batchMessage|eventMesh2mq|REQ|ASYNC|batchId={}|send2MQCost={}ms|msgNum={}|topics={}",
             batchId, elapsed, eventSize, topicBatchMessageMappings.keySet());
         completeResponse(request, asyncContext, sendMessageBatchResponseHeader, EventMeshRetCode.SUCCESS, null,
             SendMessageBatchResponseBody.class);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageProcessor.java
@@ -67,11 +67,11 @@ import com.google.common.base.Stopwatch;
 
 public class BatchSendMessageProcessor implements HttpRequestProcessor {
 
-    private final Logger cmdLogger = LoggerFactory.getLogger(EventMeshConstants.CMD);
+    private static final Logger CMD_LOGGER = LoggerFactory.getLogger(EventMeshConstants.CMD);
 
-    private final Logger aclLogger = LoggerFactory.getLogger(EventMeshConstants.ACL);
+    private static final Logger ACL_LOGGER = LoggerFactory.getLogger(EventMeshConstants.ACL);
 
-    private final Logger batchMessageLogger = LoggerFactory.getLogger("batchMessage");
+    private static final Logger BATCH_MESSAGE_LOGGER = LoggerFactory.getLogger(EventMeshConstants.BATCH_MSG);
 
     private final EventMeshHTTPServer eventMeshHTTPServer;
 
@@ -87,7 +87,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
 
         String localAddress = IPUtils.getLocalAddress();
         HttpCommand request = asyncContext.getRequest();
-        cmdLogger.info("cmd={}|{}|client2eventMesh|from={}|to={}", RequestCode.get(Integer.valueOf(request.getRequestCode())),
+        CMD_LOGGER.info("cmd={}|{}|client2eventMesh|from={}|to={}", RequestCode.get(Integer.valueOf(request.getRequestCode())),
             EventMeshConstants.PROTOCOL_HTTP, RemotingHelper.parseChannelRemoteAddr(ctx.channel()), localAddress);
 
         SendMessageBatchRequestHeader sendMessageBatchRequestHeader = (SendMessageBatchRequestHeader) request.getHeader();
@@ -112,7 +112,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
         int eventSize = eventList.size();
 
         if (eventSize > httpConfiguration.getEventMeshEventBatchSize()) {
-            batchMessageLogger.error("Event batch size exceeds the limit: {}", httpConfiguration.getEventMeshEventBatchSize());
+            BATCH_MESSAGE_LOGGER.error("Event batch size exceeds the limit: {}", httpConfiguration.getEventMeshEventBatchSize());
             completeResponse(request, asyncContext, sendMessageBatchResponseHeader, EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR,
                 "Event batch size exceeds the limit: " + httpConfiguration.getEventMeshEventBatchSize(), SendMessageBatchResponseBody.class);
             return;
@@ -129,7 +129,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
 
             String content = event.getData() == null ? "" : new String(event.getData().toBytes(), Constants.DEFAULT_CHARSET);
             if (content.length() > httpConfiguration.getEventMeshEventSize()) {
-                batchMessageLogger.error("Event size exceeds the limit: {}", httpConfiguration.getEventMeshEventSize());
+                BATCH_MESSAGE_LOGGER.error("Event size exceeds the limit: {}", httpConfiguration.getEventMeshEventSize());
                 completeResponse(request, asyncContext, sendMessageBatchResponseHeader, EventMeshRetCode.EVENTMESH_PROTOCOL_HEADER_ERR,
                     "Event size exceeds the limit: " + httpConfiguration.getEventMeshEventSize(), SendMessageBatchResponseBody.class);
                 return;
@@ -200,7 +200,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
                 } catch (Exception e) {
                     completeResponse(request, asyncContext, sendMessageBatchResponseHeader,
                         EventMeshRetCode.EVENTMESH_ACL_ERR, e.getMessage(), SendMessageBatchResponseBody.class);
-                    aclLogger.warn("CLIENT HAS NO PERMISSION,BatchSendMessageProcessor send failed", e);
+                    ACL_LOGGER.warn("CLIENT HAS NO PERMISSION,BatchSendMessageProcessor send failed", e);
                     return;
                 }
             }
@@ -223,9 +223,9 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
                     topicBatchMessageMappings.put(cloudEvent.getSubject(), tmp);
                 }
 
-                batchMessageLogger.debug("msg2MQMsg suc, event:{}", cloudEvent.getData());
+                BATCH_MESSAGE_LOGGER.debug("msg2MQMsg suc, event:{}", cloudEvent.getData());
             } catch (Exception e) {
-                batchMessageLogger.error("msg2MQMsg err, event:{}", cloudEvent.getData(), e);
+                BATCH_MESSAGE_LOGGER.error("msg2MQMsg err, event:{}", cloudEvent.getData(), e);
             }
 
         }
@@ -253,7 +253,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
 
                     @Override
                     public void onException(OnExceptionContext context) {
-                        batchMessageLogger.warn("", context.getException());
+                        BATCH_MESSAGE_LOGGER.warn("", context.getException());
                         eventMeshHTTPServer.getHttpRetryer().newTimeout(sendMessageContext, 10, TimeUnit.SECONDS);
                     }
 
@@ -271,7 +271,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
 
                     @Override
                     public void onException(OnExceptionContext context) {
-                        batchMessageLogger.warn("", context.getException());
+                        BATCH_MESSAGE_LOGGER.warn("", context.getException());
                         eventMeshHTTPServer.getHttpRetryer().newTimeout(sendMessageContext, 10, TimeUnit.SECONDS);
                     }
 
@@ -282,7 +282,7 @@ public class BatchSendMessageProcessor implements HttpRequestProcessor {
         long elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);
         summaryMetrics.recordBatchSendMsgCost(elapsed);
 
-        batchMessageLogger.debug("batchMessage|eventMesh2mq|REQ|ASYNC|batchId={}|send2MQCost={}ms|msgNum={}|topics={}",
+        BATCH_MESSAGE_LOGGER.debug("batchMessage|eventMesh2mq|REQ|ASYNC|batchId={}|send2MQCost={}ms|msgNum={}|topics={}",
             batchId, elapsed, eventSize, topicBatchMessageMappings.keySet());
         completeResponse(request, asyncContext, sendMessageBatchResponseHeader, EventMeshRetCode.SUCCESS, null,
             SendMessageBatchResponseBody.class);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageV2Processor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/BatchSendMessageV2Processor.java
@@ -60,11 +60,11 @@ import io.netty.channel.ChannelHandlerContext;
 
 public class BatchSendMessageV2Processor implements HttpRequestProcessor {
 
-    private final Logger cmdLogger = LoggerFactory.getLogger(EventMeshConstants.CMD);
+    private static final Logger CMD_LOGGER = LoggerFactory.getLogger(EventMeshConstants.CMD);
 
-    private final Logger aclLogger = LoggerFactory.getLogger(EventMeshConstants.ACL);
+    private static final Logger ACL_LOGGER = LoggerFactory.getLogger(EventMeshConstants.ACL);
 
-    private final Logger batchMessageLogger = LoggerFactory.getLogger("batchMessage");
+    private static final Logger BATCH_MESSAGE_LOGGER = LoggerFactory.getLogger(EventMeshConstants.BATCH_MSG);
 
     private final EventMeshHTTPServer eventMeshHTTPServer;
 
@@ -81,7 +81,7 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
         final HttpCommand request = asyncContext.getRequest();
         final Integer requestCode = Integer.valueOf(request.getRequestCode());
 
-        cmdLogger.info("cmd={}|{}|client2eventMesh|from={}|to={}",
+        CMD_LOGGER.info("cmd={}|{}|client2eventMesh|from={}|to={}",
             RequestCode.get(requestCode),
             EventMeshConstants.PROTOCOL_HTTP,
             RemotingHelper.parseChannelRemoteAddr(ctx.channel()),
@@ -137,7 +137,7 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
 
         String content = new String(Objects.requireNonNull(event.getData()).toBytes(), Constants.DEFAULT_CHARSET);
         if (content.length() > httpConfiguration.getEventMeshEventSize()) {
-            batchMessageLogger.error("Event size exceeds the limit: {}", httpConfiguration.getEventMeshEventSize());
+            BATCH_MESSAGE_LOGGER.error("Event size exceeds the limit: {}", httpConfiguration.getEventMeshEventSize());
             completeResponse(request, asyncContext, sendMessageBatchV2ResponseHeader,
                 EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR,
                 "Event size exceeds the limit: " + httpConfiguration.getEventMeshEventSize(),
@@ -156,7 +156,7 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
             } catch (Exception e) {
                 completeResponse(request, asyncContext, sendMessageBatchV2ResponseHeader,
                     EventMeshRetCode.EVENTMESH_ACL_ERR, e.getMessage(), SendMessageBatchV2ResponseBody.class);
-                aclLogger.warn("CLIENT HAS NO PERMISSION,BatchSendMessageV2Processor send failed", e);
+                ACL_LOGGER.warn("CLIENT HAS NO PERMISSION,BatchSendMessageV2Processor send failed", e);
                 return;
             }
         }
@@ -197,10 +197,10 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
                 .withExtension(EventMeshConstants.REQ_EVENTMESH2MQ_TIMESTAMP,
                     String.valueOf(System.currentTimeMillis()))
                 .build();
-            batchMessageLogger.debug("msg2MQMsg suc, topic:{}, msg:{}", topic, event.getData());
+            BATCH_MESSAGE_LOGGER.debug("msg2MQMsg suc, topic:{}, msg:{}", topic, event.getData());
 
         } catch (Exception e) {
-            batchMessageLogger.error("msg2MQMsg err, topic:{}, msg:{}", topic, event.getData(), e);
+            BATCH_MESSAGE_LOGGER.error("msg2MQMsg err, topic:{}, msg:{}", topic, event.getData(), e);
             completeResponse(request, asyncContext, sendMessageBatchV2ResponseHeader, EventMeshRetCode.EVENTMESH_PACKAGE_MSG_ERR,
                 EventMeshRetCode.EVENTMESH_PACKAGE_MSG_ERR.getErrMsg()
                     +
@@ -221,7 +221,7 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
                 public void onSuccess(SendResult sendResult) {
                     long batchEndTime = System.currentTimeMillis();
                     summaryMetrics.recordBatchSendMsgCost(batchEndTime - batchStartTime);
-                    batchMessageLogger.debug(
+                    BATCH_MESSAGE_LOGGER.debug(
                         "batchMessageV2|eventMesh2mq|REQ|ASYNC|bizSeqNo={}|send2MQCost={}ms|topic={}",
                         bizNo, batchEndTime - batchStartTime, topic);
                 }
@@ -231,7 +231,7 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
                     long batchEndTime = System.currentTimeMillis();
                     eventMeshHTTPServer.getHttpRetryer().newTimeout(sendMessageContext, 10, TimeUnit.SECONDS);
                     summaryMetrics.recordBatchSendMsgCost(batchEndTime - batchStartTime);
-                    batchMessageLogger.error(
+                    BATCH_MESSAGE_LOGGER.error(
                         "batchMessageV2|eventMesh2mq|REQ|ASYNC|bizSeqNo={}|send2MQCost={}ms|topic={}",
                         bizNo, batchEndTime - batchStartTime, topic, context.getException());
                 }
@@ -246,7 +246,7 @@ public class BatchSendMessageV2Processor implements HttpRequestProcessor {
             long batchEndTime = System.currentTimeMillis();
             eventMeshHTTPServer.getHttpRetryer().newTimeout(sendMessageContext, 10, TimeUnit.SECONDS);
             summaryMetrics.recordBatchSendMsgCost(batchEndTime - batchStartTime);
-            batchMessageLogger.error(
+            BATCH_MESSAGE_LOGGER.error(
                 "batchMessageV2|eventMesh2mq|REQ|ASYNC|bizSeqNo={}|send2MQCost={}ms|topic={}",
                 bizNo, batchEndTime - batchStartTime, topic, e);
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/CreateTopicProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/CreateTopicProcessor.java
@@ -149,6 +149,6 @@ public class CreateTopicProcessor implements AsyncHttpProcessor {
 
     @Override
     public String[] paths() {
-        return new String[]{RequestURI.CREATE_TOPIC.getRequestURI()};
+        return new String[] {RequestURI.CREATE_TOPIC.getRequestURI()};
     }
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/CreateTopicProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/CreateTopicProcessor.java
@@ -49,7 +49,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 @EventMeshTrace
 public class CreateTopicProcessor implements AsyncHttpProcessor {
 
-    private final Logger httpLogger = LoggerFactory.getLogger("http");
+    private static final Logger HTTP_LOGGER = LoggerFactory.getLogger(EventMeshConstants.PROTOCOL_HTTP);
 
     private final transient EventMeshHTTPServer eventMeshHTTPServer;
 
@@ -66,7 +66,7 @@ public class CreateTopicProcessor implements AsyncHttpProcessor {
 
         HttpEventWrapper responseWrapper;
 
-        httpLogger.info("uri={}|{}|client2eventMesh|from={}|to={}", requestWrapper.getRequestURI(),
+        HTTP_LOGGER.info("uri={}|{}|client2eventMesh|from={}|to={}", requestWrapper.getRequestURI(),
             EventMeshConstants.PROTOCOL_HTTP, RemotingHelper.parseChannelRemoteAddr(ctx.channel()), IPUtils.getLocalAddress());
 
         // user request header
@@ -93,7 +93,7 @@ public class CreateTopicProcessor implements AsyncHttpProcessor {
             Map<String, Object> responseBodyMap = new HashMap<>();
             responseBodyMap.put("retCode", EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getRetCode());
             responseBodyMap.put("retMsg", EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR.getErrMsg() + "topic is null");
-            httpLogger.warn("create topic fail, topic is null");
+            HTTP_LOGGER.warn("create topic fail, topic is null");
             responseWrapper = requestWrapper.createHttpResponse(responseHeaderMap, responseBodyMap);
             responseWrapper.setHttpResponseStatus(HttpResponseStatus.BAD_REQUEST);
             handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_PROTOCOL_BODY_ERR, responseHeaderMap,
@@ -111,19 +111,19 @@ public class CreateTopicProcessor implements AsyncHttpProcessor {
                 item = StringUtils.deleteWhitespace(item);
                 if (!HttpClientGroupMapping.getInstance().getLocalTopicSet().contains(item)) {
                     HttpClientGroupMapping.getInstance().getLocalTopicSet().add(item);
-                    httpLogger.info("create topic success, topic:{}", item);
+                    HTTP_LOGGER.info("create topic success, topic:{}", item);
                 }
             }
 
             final CompleteHandler<HttpEventWrapper> handler = httpEventWrapper -> {
                 try {
-                    httpLogger.debug("{}", httpEventWrapper);
+                    HTTP_LOGGER.debug("{}", httpEventWrapper);
                     eventMeshHTTPServer.sendResponse(ctx, httpEventWrapper.httpResponse());
                     eventMeshHTTPServer.getMetrics().getSummaryMetrics().recordHTTPReqResTimeCost(
                         System.currentTimeMillis() - requestWrapper.getReqTime());
                 } catch (Exception ex) {
                     // ignore
-                    httpLogger.warn("create topic, sendResponse fail,", ex);
+                    HTTP_LOGGER.warn("create topic, sendResponse fail,", ex);
                 }
             };
 
@@ -140,7 +140,7 @@ public class CreateTopicProcessor implements AsyncHttpProcessor {
             handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_RUNTIME_ERR, responseHeaderMap,
                 responseBodyMap, null);
             long endTime = System.currentTimeMillis();
-            httpLogger.warn(
+            HTTP_LOGGER.warn(
                 "create topic fail, eventMesh2client|cost={}ms|topic={}", endTime - startTime, topic, e);
             eventMeshHTTPServer.getMetrics().getSummaryMetrics().recordSendMsgFailed();
             eventMeshHTTPServer.getMetrics().getSummaryMetrics().recordSendMsgCost(endTime - startTime);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/DeleteTopicProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/DeleteTopicProcessor.java
@@ -172,6 +172,6 @@ public class DeleteTopicProcessor implements AsyncHttpProcessor {
 
     @Override
     public String[] paths() {
-        return new String[]{RequestURI.DELETE_TOPIC.getRequestURI()};
+        return new String[] {RequestURI.DELETE_TOPIC.getRequestURI()};
     }
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/HandlerService.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/HandlerService.java
@@ -70,7 +70,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class HandlerService {
 
-    private final Logger httpLogger = LoggerFactory.getLogger(EventMeshConstants.PROTOCOL_HTTP);
+    private static final Logger HTTP_LOGGER = LoggerFactory.getLogger(EventMeshConstants.PROTOCOL_HTTP);
 
     private final Map<String, ProcessorWrapper> httpProcessorMap = new ConcurrentHashMap<>();
 
@@ -158,7 +158,7 @@ public class HandlerService {
         ReferenceCountUtil.release(httpRequest);
         ctx.writeAndFlush(response).addListener((ChannelFutureListener) f -> {
             if (!f.isSuccess()) {
-                httpLogger.warn("send response to [{}] fail, will close this channel",
+                HTTP_LOGGER.warn("send response to [{}] fail, will close this channel",
                     RemotingHelper.parseChannelRemoteAddr(f.channel()));
                 if (isClose) {
                     f.channel().close();
@@ -174,7 +174,7 @@ public class HandlerService {
         ReferenceCountUtil.release(httpRequest);
         ctx.writeAndFlush(response).addListener((ChannelFutureListener) f -> {
             if (!f.isSuccess()) {
-                httpLogger.warn("send response to [{}] with short-lived connection fail, will close this channel",
+                HTTP_LOGGER.warn("send response to [{}] with short-lived connection fail, will close this channel",
                     RemotingHelper.parseChannelRemoteAddr(f.channel()));
             }
         }).addListener(ChannelFutureListener.CLOSE);
@@ -296,7 +296,7 @@ public class HandlerService {
 
         private void postHandler(ConnectionType type) {
             metrics.getSummaryMetrics().recordHTTPRequest();
-            httpLogger.debug("{}", request);
+            HTTP_LOGGER.debug("{}", request);
             if (Objects.isNull(response)) {
                 this.response = HttpResponseUtils.createSuccess();
             }
@@ -310,7 +310,7 @@ public class HandlerService {
 
         private void preHandler() {
             metrics.getSummaryMetrics().recordHTTPReqResTimeCost(System.currentTimeMillis() - requestTime);
-            httpLogger.debug("{}", response);
+            HTTP_LOGGER.debug("{}", response);
         }
 
         private void error() {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/QuerySubscriptionProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/QuerySubscriptionProcessor.java
@@ -112,6 +112,6 @@ public class QuerySubscriptionProcessor implements AsyncHttpProcessor {
 
     @Override
     public String[] paths() {
-        return new String[]{RequestURI.SUBSCRIPTION_QUERY.getRequestURI()};
+        return new String[] {RequestURI.SUBSCRIPTION_QUERY.getRequestURI()};
     }
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/QuerySubscriptionProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/processor/QuerySubscriptionProcessor.java
@@ -44,7 +44,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 @EventMeshTrace
 public class QuerySubscriptionProcessor implements AsyncHttpProcessor {
 
-    private final Logger httpLogger = LoggerFactory.getLogger("http");
+    private static final Logger HTTP_LOGGER = LoggerFactory.getLogger(EventMeshConstants.PROTOCOL_HTTP);
 
     private final transient EventMeshHTTPServer eventMeshHTTPServer;
 
@@ -61,7 +61,7 @@ public class QuerySubscriptionProcessor implements AsyncHttpProcessor {
 
         HttpEventWrapper responseWrapper;
 
-        httpLogger.info("uri={}|{}|client2eventMesh|from={}|to={}", requestWrapper.getRequestURI(),
+        HTTP_LOGGER.info("uri={}|{}|client2eventMesh|from={}|to={}", requestWrapper.getRequestURI(),
             EventMeshConstants.PROTOCOL_HTTP, RemotingHelper.parseChannelRemoteAddr(ctx.channel()), IPUtils.getLocalAddress());
 
         Map<String, Object> responseHeaderMap = new HashMap<>();
@@ -78,12 +78,12 @@ public class QuerySubscriptionProcessor implements AsyncHttpProcessor {
 
             final CompleteHandler<HttpEventWrapper> handler = httpEventWrapper -> {
                 try {
-                    httpLogger.debug("{}", httpEventWrapper);
+                    HTTP_LOGGER.debug("{}", httpEventWrapper);
                     eventMeshHTTPServer.sendResponse(ctx, httpEventWrapper.httpResponse());
                     eventMeshHTTPServer.getMetrics().getSummaryMetrics().recordHTTPReqResTimeCost(
                         System.currentTimeMillis() - requestWrapper.getReqTime());
                 } catch (Exception ex) {
-                    httpLogger.warn("query subscription, sendResponse fail", ex);
+                    HTTP_LOGGER.warn("query subscription, sendResponse fail", ex);
                 }
             };
 
@@ -104,7 +104,7 @@ public class QuerySubscriptionProcessor implements AsyncHttpProcessor {
             handlerSpecific.sendErrorResponse(EventMeshRetCode.EVENTMESH_RUNTIME_ERR, responseHeaderMap,
                 responseBodyMap, null);
             long endTime = System.currentTimeMillis();
-            httpLogger.warn("query subscription fail,eventMesh2client|cost={}ms", endTime - startTime, e);
+            HTTP_LOGGER.warn("query subscription fail,eventMesh2client|cost={}ms", endTime - startTime, e);
             eventMeshHTTPServer.getMetrics().getSummaryMetrics().recordSendMsgFailed();
             eventMeshHTTPServer.getMetrics().getSummaryMetrics().recordSendMsgCost(endTime - startTime);
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/metrics/tcp/EventMeshTcpMonitor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/metrics/tcp/EventMeshTcpMonitor.java
@@ -51,9 +51,9 @@ public class EventMeshTcpMonitor {
         return eventMeshTCPServer;
     }
 
-    private final Logger tcpLogger = LoggerFactory.getLogger("tcpMonitor");
+    private static final Logger TCP_LOGGER = LoggerFactory.getLogger(EventMeshConstants.TCP_MONITOR);
 
-    private final Logger appLogger = LoggerFactory.getLogger("appMonitor");
+    private static final Logger APP_LOGGER = LoggerFactory.getLogger(EventMeshConstants.APP_MONITOR);
 
     private static final int period = 60 * 1000;
 
@@ -115,7 +115,7 @@ public class EventMeshTcpMonitor {
                 int sendTopics = session.getSessionContext().getSendTopics().size();
                 int subscribeTopics = session.getSessionContext().getSubscribeTopics().size();
 
-                tcpLogger.info("session|deliveredFailCount={}|deliveredMsgsCount={}|unAckMsgsCount={}|sendTopics={}|subscribeTopics={}|user={}",
+                TCP_LOGGER.info("session|deliveredFailCount={}|deliveredMsgsCount={}|unAckMsgsCount={}|sendTopics={}|subscribeTopics={}|user={}",
                     deliveredFailCount.longValue(), deliveredMsgsCount.longValue(),
                     unAckMsgsCount, sendTopics, subscribeTopics, session.getClient());
 
@@ -128,7 +128,7 @@ public class EventMeshTcpMonitor {
         }), delay, period, TimeUnit.MILLISECONDS);
 
         monitorThreadPoolTask = eventMeshTCPServer.getTcpThreadPoolGroup().getScheduler().scheduleAtFixedRate(() -> {
-            appLogger.info("{TaskHandle:{},Send:{},Ack:{},Reply:{},Push:{},Scheduler:{},Rebalance:{}}",
+            APP_LOGGER.info("{TaskHandle:{},Send:{},Ack:{},Reply:{},Push:{},Scheduler:{},Rebalance:{}}",
                 eventMeshTCPServer.getTcpThreadPoolGroup().getTaskHandleExecutorService().getQueue().size(),
                 eventMeshTCPServer.getTcpThreadPoolGroup().getSendExecutorService().getQueue().size(),
                 eventMeshTCPServer.getTcpThreadPoolGroup().getAckExecutorService().getQueue().size(),
@@ -141,7 +141,7 @@ public class EventMeshTcpMonitor {
 
             // monitor retry queue size
             tcpSummaryMetrics.setRetrySize(eventMeshTCPServer.getTcpRetryer().getPendingTimeouts());
-            appLogger.info(
+            APP_LOGGER.info(
                 MonitorMetricConstants.EVENTMESH_MONITOR_FORMAT_COMMON,
                 EventMeshConstants.PROTOCOL_TCP,
                 MonitorMetricConstants.RETRY_QUEUE_SIZE,
@@ -151,25 +151,25 @@ public class EventMeshTcpMonitor {
     }
 
     private void printAppLogger(TcpSummaryMetrics tcpSummaryMetrics) {
-        appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.CLIENT_2_EVENTMESH_TPS,
+        APP_LOGGER.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.CLIENT_2_EVENTMESH_TPS,
             tcpSummaryMetrics.getClient2eventMeshTPS());
 
-        appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.EVENTMESH_2_MQ_TPS,
+        APP_LOGGER.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.EVENTMESH_2_MQ_TPS,
             tcpSummaryMetrics.getEventMesh2mqTPS());
 
-        appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.MQ_2_EVENTMESH_TPS,
+        APP_LOGGER.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.MQ_2_EVENTMESH_TPS,
             tcpSummaryMetrics.getMq2eventMeshTPS());
 
-        appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.EVENTMESH_2_CLIENT_TPS,
+        APP_LOGGER.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.EVENTMESH_2_CLIENT_TPS,
             tcpSummaryMetrics.getEventMesh2clientTPS());
 
-        appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.ALL_TPS,
+        APP_LOGGER.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.ALL_TPS,
             tcpSummaryMetrics.getAllTPS());
 
-        appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.CONNECTION,
+        APP_LOGGER.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.CONNECTION,
             tcpSummaryMetrics.getAllConnections());
 
-        appLogger.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.SUB_TOPIC_NUM,
+        APP_LOGGER.info("protocol: {}, s: {}, t: {}", EventMeshConstants.PROTOCOL_TCP, MonitorMetricConstants.SUB_TOPIC_NUM,
             tcpSummaryMetrics.getSubTopicNum());
     }
 


### PR DESCRIPTION
Fixes #4734 

### Motivation
In Java, it is a best practice to declare a logger static final.

private - so that no other class can hijack your logger
static - so there is only one logger instance per class, also avoiding attempts to serialize loggers
final - no need to change the logger over the lifetime of the class

### Modifications
For all `private final Logger` declarations a `static` modifier has been added and the UPPER_CASE has been applied.
Logger names has been substituted with constants from `org.apache.eventmesh.runtime.constants.EventMeshConstants`, in particular 3 new constants have been added to it.
### Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
- If a feature is not applicable for documentation, explain why? (minor refactoring)
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
