### PR TITLE
[ISSUE #4781]management life cycle

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/acl/Acl.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/acl/Acl.java
@@ -22,32 +22,26 @@ import org.apache.eventmesh.api.acl.AclService;
 import org.apache.eventmesh.api.exception.AclException;
 import org.apache.eventmesh.api.meta.bo.EventMeshAppSubTopicInfo;
 import org.apache.eventmesh.api.meta.bo.EventMeshServicePubTopicInfo;
+import org.apache.eventmesh.common.config.CommonConfiguration;
 import org.apache.eventmesh.common.protocol.tcp.UserAgent;
+import org.apache.eventmesh.runtime.lifecircle.EventMeshSwitchableComponent;
 import org.apache.eventmesh.spi.EventMeshExtensionFactory;
 
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class Acl {
+public class Acl extends EventMeshSwitchableComponent {
 
     private static final Map<String, Acl> ACL_CACHE = new HashMap<>(16);
 
     private AclService aclService;
 
-    private final AtomicBoolean inited = new AtomicBoolean(false);
-
-    private final AtomicBoolean started = new AtomicBoolean(false);
-
-    private final AtomicBoolean shutdown = new AtomicBoolean(false);
-
     private Acl() {
-
     }
 
     public static Acl getInstance(String aclPluginType) {
@@ -67,26 +61,20 @@ public class Acl {
         return acl;
     }
 
-    public void init() throws AclException {
-        if (!inited.compareAndSet(false, true)) {
-            return;
-        }
+    @Override
+    protected boolean shouldTurn(CommonConfiguration configuration) {
+        return configuration.isEventMeshServerSecurityEnable();
+    }
+
+    public void componentInit() throws AclException {
         aclService.init();
     }
 
-    public void start() throws AclException {
-        if (!started.compareAndSet(false, true)) {
-            return;
-        }
+    public void componentStart() throws AclException {
         aclService.start();
     }
 
-    public void shutdown() throws AclException {
-        inited.compareAndSet(true, false);
-        started.compareAndSet(true, false);
-        if (!shutdown.compareAndSet(false, true)) {
-            return;
-        }
+    public void componentStop() throws AclException {
         aclService.shutdown();
     }
 
@@ -112,7 +100,7 @@ public class Acl {
     }
 
     public void doAclCheckInHttpSend(String remoteAddr, String user, String pass, String subsystem, String topic,
-        String requestURI) throws AclException {
+                                     String requestURI) throws AclException {
         aclService.doAclCheckInSend(buildHttpAclProperties(remoteAddr, user, pass, subsystem, topic, requestURI));
     }
 
@@ -122,17 +110,17 @@ public class Acl {
     }
 
     public void doAclCheckInHttpReceive(String remoteAddr, String user, String pass, String subsystem, String topic,
-        int requestCode) throws AclException {
+                                        int requestCode) throws AclException {
         aclService.doAclCheckInReceive(buildHttpAclProperties(remoteAddr, user, pass, subsystem, topic, requestCode));
     }
 
     public void doAclCheckInHttpReceive(String remoteAddr, String user, String pass, String subsystem, String topic,
-        String requestURI) throws AclException {
+                                        String requestURI) throws AclException {
         aclService.doAclCheckInReceive(buildHttpAclProperties(remoteAddr, user, pass, subsystem, topic, requestURI));
     }
 
     public void doAclCheckInTcpReceive(String remoteAddr, String token, String subsystem, String topic,
-        String requestURI, Object obj) throws AclException {
+                                       String requestURI, Object obj) throws AclException {
         aclService.doAclCheckInReceive(buildTcpAclProperties(remoteAddr, token, subsystem, topic, requestURI, obj));
     }
 
@@ -141,7 +129,7 @@ public class Acl {
     }
 
     public void doAclCheckInHttpHeartbeat(String remoteAddr, String user, String pass, String subsystem, String topic,
-        int requestCode) throws AclException {
+                                          int requestCode) throws AclException {
         aclService.doAclCheckInHeartbeat(buildHttpAclProperties(remoteAddr, user, pass, subsystem, topic, requestCode));
     }
 
@@ -235,5 +223,6 @@ public class Acl {
         }
         return aclProperties;
     }
+
 
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/acl/Acl.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/acl/Acl.java
@@ -66,14 +66,17 @@ public class Acl extends EventMeshSwitchableComponent {
         return configuration.isEventMeshServerSecurityEnable();
     }
 
+    @Override
     public void componentInit() throws AclException {
         aclService.init();
     }
 
+    @Override
     public void componentStart() throws AclException {
         aclService.start();
     }
 
+    @Override
     public void componentStop() throws AclException {
         aclService.shutdown();
     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshAdminBootstrap.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshAdminBootstrap.java
@@ -17,18 +17,32 @@
 
 package org.apache.eventmesh.runtime.boot;
 
-public class EventMeshAdminBootstrap implements EventMeshBootstrap {
+import org.apache.eventmesh.common.config.CommonConfiguration;
+import org.apache.eventmesh.runtime.lifecircle.EventMeshSwitchableComponent;
+
+import java.util.List;
+
+public class EventMeshAdminBootstrap extends EventMeshSwitchableComponent implements EventMeshBootstrap {
 
     private EventMeshAdminServer eventMeshAdminServer;
 
     private EventMeshServer eventMeshServer;
+
+    // http grpc tcp
+    private final int ALL_SERVER_CHANNEL_COUNT = 3;
 
     public EventMeshAdminBootstrap(EventMeshServer eventMeshServer) {
         this.eventMeshServer = eventMeshServer;
     }
 
     @Override
-    public void init() throws Exception {
+    protected boolean shouldTurn(CommonConfiguration configuration) {
+        final List<String> provideServerProtocols = configuration.getEventMeshProvideServerProtocols();
+        return !(provideServerProtocols.size() == ALL_SERVER_CHANNEL_COUNT);
+    }
+
+    @Override
+    public void componentInit() throws Exception {
         if (eventMeshServer != null) {
             eventMeshAdminServer = new EventMeshAdminServer(eventMeshServer);
             eventMeshAdminServer.init();
@@ -37,7 +51,7 @@ public class EventMeshAdminBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void start() throws Exception {
+    public void componentStart() throws Exception {
         if (eventMeshAdminServer != null) {
             eventMeshAdminServer.start();
         }
@@ -45,7 +59,7 @@ public class EventMeshAdminBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void shutdown() throws Exception {
+    public void componentStop() throws Exception {
         if (eventMeshAdminServer != null) {
             eventMeshAdminServer.shutdown();
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshGrpcBootstrap.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshGrpcBootstrap.java
@@ -22,8 +22,9 @@ import static org.apache.eventmesh.common.Constants.GRPC;
 import org.apache.eventmesh.common.config.ConfigService;
 import org.apache.eventmesh.common.utils.ConfigurationContextUtil;
 import org.apache.eventmesh.runtime.configuration.EventMeshGrpcConfiguration;
+import org.apache.eventmesh.runtime.lifecircle.EventMeshComponent;
 
-public class EventMeshGrpcBootstrap implements EventMeshBootstrap {
+public class EventMeshGrpcBootstrap extends EventMeshComponent implements EventMeshBootstrap {
 
     private final EventMeshGrpcConfiguration eventMeshGrpcConfiguration;
 
@@ -40,7 +41,7 @@ public class EventMeshGrpcBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void init() throws Exception {
+    public void componentInit() throws Exception {
         // server init
         if (eventMeshGrpcConfiguration != null) {
             eventMeshGrpcServer = new EventMeshGrpcServer(this.eventMeshServer, this.eventMeshGrpcConfiguration);
@@ -49,7 +50,7 @@ public class EventMeshGrpcBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void start() throws Exception {
+    public void componentStart() throws Exception {
         // server start
         if (eventMeshGrpcConfiguration != null) {
             eventMeshGrpcServer.start();
@@ -57,7 +58,7 @@ public class EventMeshGrpcBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void shutdown() throws Exception {
+    public void componentStop() throws Exception {
         if (eventMeshGrpcConfiguration != null) {
             eventMeshGrpcServer.shutdown();
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshHttpBootstrap.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshHttpBootstrap.java
@@ -22,8 +22,9 @@ import static org.apache.eventmesh.common.Constants.HTTP;
 import org.apache.eventmesh.common.config.ConfigService;
 import org.apache.eventmesh.common.utils.ConfigurationContextUtil;
 import org.apache.eventmesh.runtime.configuration.EventMeshHTTPConfiguration;
+import org.apache.eventmesh.runtime.lifecircle.EventMeshComponent;
 
-public class EventMeshHttpBootstrap implements EventMeshBootstrap {
+public class EventMeshHttpBootstrap extends EventMeshComponent implements EventMeshBootstrap  {
 
     private final EventMeshHTTPConfiguration eventMeshHttpConfiguration;
 
@@ -41,7 +42,7 @@ public class EventMeshHttpBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void init() throws Exception {
+    public void componentInit() throws Exception {
         // server init
         if (eventMeshHttpConfiguration != null) {
             eventMeshHttpServer = new EventMeshHTTPServer(eventMeshServer, eventMeshHttpConfiguration);
@@ -50,7 +51,7 @@ public class EventMeshHttpBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void start() throws Exception {
+    public void componentStart() throws Exception {
         // server start
         if (eventMeshHttpServer != null) {
             eventMeshHttpServer.start();
@@ -58,7 +59,7 @@ public class EventMeshHttpBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void shutdown() throws Exception {
+    public void componentStop() throws Exception {
         // server shutdown
         if (eventMeshHttpServer != null) {
             eventMeshHttpServer.shutdown();

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshServer.java
@@ -128,6 +128,7 @@ public class EventMeshServer extends EventMeshSwitchableComponent {
         return true;
     }
 
+    @Override
     public void componentInit() throws Exception {
     }
 
@@ -156,7 +157,7 @@ public class EventMeshServer extends EventMeshSwitchableComponent {
         log.info(SERVER_STATE_MSG, serviceState);
     }
 
-
+    @Override
     public void componentStart() throws Exception {
     }
 
@@ -165,6 +166,7 @@ public class EventMeshServer extends EventMeshSwitchableComponent {
         log.info(SERVER_STATE_MSG, serviceState);
     }
 
+    @Override
     public void componentStop() throws Exception {
         serviceState = ServiceState.STOPPING;
         log.info(SERVER_STATE_MSG, serviceState);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshTcpBootstrap.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshTcpBootstrap.java
@@ -22,8 +22,9 @@ import static org.apache.eventmesh.common.Constants.TCP;
 import org.apache.eventmesh.common.config.ConfigService;
 import org.apache.eventmesh.common.utils.ConfigurationContextUtil;
 import org.apache.eventmesh.runtime.configuration.EventMeshTCPConfiguration;
+import org.apache.eventmesh.runtime.lifecircle.EventMeshComponent;
 
-public class EventMeshTcpBootstrap implements EventMeshBootstrap {
+public class EventMeshTcpBootstrap extends EventMeshComponent implements EventMeshBootstrap {
 
     private EventMeshTCPServer eventMeshTcpServer;
 
@@ -41,7 +42,7 @@ public class EventMeshTcpBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void init() throws Exception {
+    public void componentInit() throws Exception {
         // server init
         if (eventMeshTcpConfiguration != null) {
             eventMeshTcpServer = new EventMeshTCPServer(eventMeshServer, eventMeshTcpConfiguration);
@@ -50,7 +51,7 @@ public class EventMeshTcpBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void start() throws Exception {
+    public void componentStart() throws Exception {
         // server start
         if (eventMeshTcpConfiguration != null) {
             eventMeshTcpServer.start();
@@ -58,7 +59,7 @@ public class EventMeshTcpBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void shutdown() throws Exception {
+    public void componentStop() throws Exception {
         if (eventMeshTcpConfiguration != null) {
             eventMeshTcpServer.shutdown();
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/producer/ProducerTopicManager.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/producer/ProducerTopicManager.java
@@ -47,12 +47,14 @@ public class ProducerTopicManager extends EventMeshComponent {
         this.eventMeshServer = eventMeshServer;
     }
 
+    @Override
     public void componentInit() {
         scheduler = ThreadPoolFactory.createScheduledExecutor(Runtime.getRuntime().availableProcessors(),
             new EventMeshThreadFactory("Producer-Topic-Manager", true));
         log.info("ProducerTopicManager inited......");
     }
 
+    @Override
     public void componentStart() {
 
         if (scheduledTask == null) {
@@ -75,6 +77,7 @@ public class ProducerTopicManager extends EventMeshComponent {
         log.info("ProducerTopicManager started......");
     }
 
+    @Override
     public void componentStop() {
         if (scheduledTask != null) {
             scheduledTask.cancel(false);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/producer/ProducerTopicManager.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/producer/ProducerTopicManager.java
@@ -21,6 +21,7 @@ import org.apache.eventmesh.api.meta.bo.EventMeshServicePubTopicInfo;
 import org.apache.eventmesh.common.EventMeshThreadFactory;
 import org.apache.eventmesh.common.ThreadPoolFactory;
 import org.apache.eventmesh.runtime.boot.EventMeshServer;
+import org.apache.eventmesh.runtime.lifecircle.EventMeshComponent;
 
 import java.util.List;
 import java.util.Optional;
@@ -32,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class ProducerTopicManager {
+public class ProducerTopicManager extends EventMeshComponent {
 
     private final EventMeshServer eventMeshServer;
 
@@ -46,13 +47,13 @@ public class ProducerTopicManager {
         this.eventMeshServer = eventMeshServer;
     }
 
-    public void init() {
+    public void componentInit() {
         scheduler = ThreadPoolFactory.createScheduledExecutor(Runtime.getRuntime().availableProcessors(),
             new EventMeshThreadFactory("Producer-Topic-Manager", true));
         log.info("ProducerTopicManager inited......");
     }
 
-    public void start() {
+    public void componentStart() {
 
         if (scheduledTask == null) {
             synchronized (ProducerTopicManager.class) {
@@ -74,7 +75,7 @@ public class ProducerTopicManager {
         log.info("ProducerTopicManager started......");
     }
 
-    public void shutdown() {
+    public void componentStop() {
         if (scheduledTask != null) {
             scheduledTask.cancel(false);
         }
@@ -88,5 +89,6 @@ public class ProducerTopicManager {
     public EventMeshServicePubTopicInfo getEventMeshServicePubTopicInfo(String producerGroup) {
         return eventMeshServicePubTopicInfoMap.get(producerGroup);
     }
+
 
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/lifecircle/AbstractEventMeshComponent.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/lifecircle/AbstractEventMeshComponent.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.lifecircle;
+
+
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class AbstractEventMeshComponent implements EventMeshLifeCycle {
+
+    protected final AtomicBoolean inited = new AtomicBoolean(false);
+    protected final AtomicBoolean started = new AtomicBoolean(false);
+    protected final AtomicBoolean shutdown = new AtomicBoolean(false);
+    protected final List<EventMeshLifeCycle> bindLifeCycleComponents = new CopyOnWriteArrayList<>();
+
+    public void bindLifeCycle(EventMeshLifeCycle meshLifeCircle) {
+        bindLifeCycleComponents.add(meshLifeCircle);
+    }
+
+
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/lifecircle/EventMeshComponent.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/lifecircle/EventMeshComponent.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.lifecircle;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class EventMeshComponent extends AbstractEventMeshComponent {
+
+
+    public void init() throws Exception {
+        if (shouldSkip()) {
+            return;
+        }
+        if (!inited.compareAndSet(false, true)) {
+            return;
+        }
+        componentInit();
+        for (EventMeshLifeCycle component : bindLifeCycleComponents) {
+            component.init();
+        }
+        postBindInited();
+    }
+
+    protected void postBindInited() throws Exception {
+    }
+
+
+    public void start() throws Exception {
+        if (shouldSkip()) {
+            return;
+        }
+        if (!started.compareAndSet(false, true)) {
+            return;
+        }
+        componentStart();
+        for (EventMeshLifeCycle component : bindLifeCycleComponents) {
+            component.start();
+        }
+        postBindStarted();
+    }
+
+    protected void postBindStarted()  throws Exception{
+    }
+
+    public void shutdown() throws Exception {
+        if (shouldSkip()) {
+            return;
+        }
+        inited.compareAndSet(true, false);
+        started.compareAndSet(true, false);
+        if (!shutdown.compareAndSet(false, true)) {
+            return;
+        }
+        componentStop();
+        for (int index = bindLifeCycleComponents.size() - 1; index >= 0; index--) {
+            bindLifeCycleComponents.get(index).shutdown();
+        }
+        postBindStopped();
+    }
+
+    protected void postBindStopped()  throws Exception{
+    }
+
+    protected boolean shouldSkip() {
+        return false;
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/lifecircle/EventMeshLifeCycle.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/lifecircle/EventMeshLifeCycle.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.lifecircle;
+
+/**
+ * Life cycle transition
+ */
+public interface EventMeshLifeCycle {
+
+    void init() throws Exception;
+
+    void componentInit() throws Exception;
+
+    void start() throws Exception;
+
+    void componentStart() throws Exception;
+
+    void shutdown() throws Exception;
+
+    void componentStop() throws Exception;
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/lifecircle/EventMeshSwitchableComponent.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/lifecircle/EventMeshSwitchableComponent.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.lifecircle;
+
+import org.apache.eventmesh.common.config.CommonConfiguration;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class EventMeshSwitchableComponent extends EventMeshComponent {
+
+    protected static CommonConfiguration configuration;
+
+    protected abstract boolean shouldTurn(CommonConfiguration configuration);
+
+    @Override
+    protected boolean shouldSkip() {
+        return !shouldTurn(configuration);
+    }
+
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/meta/MetaStorage.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/meta/MetaStorage.java
@@ -25,6 +25,8 @@ import org.apache.eventmesh.api.meta.bo.EventMeshServicePubTopicInfo;
 import org.apache.eventmesh.api.meta.dto.EventMeshDataInfo;
 import org.apache.eventmesh.api.meta.dto.EventMeshRegisterInfo;
 import org.apache.eventmesh.api.meta.dto.EventMeshUnRegisterInfo;
+import org.apache.eventmesh.common.config.CommonConfiguration;
+import org.apache.eventmesh.runtime.lifecircle.EventMeshSwitchableComponent;
 import org.apache.eventmesh.spi.EventMeshExtensionFactory;
 
 import java.util.HashMap;
@@ -35,17 +37,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class MetaStorage {
+public class MetaStorage extends EventMeshSwitchableComponent {
 
     private static final Map<String, MetaStorage> META_CACHE = new HashMap<>(16);
 
     private MetaService metaService;
-
-    private final AtomicBoolean inited = new AtomicBoolean(false);
-
-    private final AtomicBoolean started = new AtomicBoolean(false);
-
-    private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
     private MetaStorage() {
 
@@ -68,26 +64,20 @@ public class MetaStorage {
         return metaStorage;
     }
 
-    public void init() throws MetaException {
-        if (!inited.compareAndSet(false, true)) {
-            return;
-        }
+    @Override
+    protected boolean shouldTurn(CommonConfiguration configuration) {
+        return configuration.isEventMeshServerMetaStorageEnable();
+    }
+
+    public void componentInit() throws MetaException {
         metaService.init();
     }
 
-    public void start() throws MetaException {
-        if (!started.compareAndSet(false, true)) {
-            return;
-        }
+    public void componentStart() throws MetaException {
         metaService.start();
     }
 
-    public void shutdown() throws MetaException {
-        inited.compareAndSet(true, false);
-        started.compareAndSet(true, false);
-        if (!shutdown.compareAndSet(false, true)) {
-            return;
-        }
+    public void componentStop() throws MetaException {
         synchronized (this) {
             metaService.shutdown();
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/meta/MetaStorage.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/meta/MetaStorage.java
@@ -69,14 +69,17 @@ public class MetaStorage extends EventMeshSwitchableComponent {
         return configuration.isEventMeshServerMetaStorageEnable();
     }
 
+    @Override
     public void componentInit() throws MetaException {
         metaService.init();
     }
 
+    @Override
     public void componentStart() throws MetaException {
         metaService.start();
     }
 
+    @Override
     public void componentStop() throws MetaException {
         synchronized (this) {
             metaService.shutdown();

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/storage/StorageResource.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/storage/StorageResource.java
@@ -56,16 +56,17 @@ public class StorageResource extends EventMeshComponent {
         return storageResource;
     }
 
-
-
+    @Override
     public void componentInit() throws Exception {
         storageResourceService.init();
     }
 
+    @Override
     public void componentStart() throws Exception {
         log.debug("StorageResource Component Starting...");
     }
 
+    @Override
     public void componentStop() throws Exception {
         storageResourceService.release();
     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/storage/StorageResource.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/storage/StorageResource.java
@@ -18,24 +18,22 @@
 package org.apache.eventmesh.runtime.storage;
 
 import org.apache.eventmesh.api.storage.StorageResourceService;
+import org.apache.eventmesh.common.config.CommonConfiguration;
+import org.apache.eventmesh.runtime.lifecircle.EventMeshComponent;
+import org.apache.eventmesh.runtime.lifecircle.EventMeshSwitchableComponent;
 import org.apache.eventmesh.spi.EventMeshExtensionFactory;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class StorageResource {
+public class StorageResource extends EventMeshComponent {
 
     private static final Map<String, StorageResource> STORAGE_RESOURCE_CACHE = new HashMap<>(16);
 
     private StorageResourceService storageResourceService;
-
-    private final AtomicBoolean inited = new AtomicBoolean(false);
-
-    private final AtomicBoolean released = new AtomicBoolean(false);
 
     private StorageResource() {
 
@@ -58,18 +56,18 @@ public class StorageResource {
         return storageResource;
     }
 
-    public void init() throws Exception {
-        if (!inited.compareAndSet(false, true)) {
-            return;
-        }
+
+
+    public void componentInit() throws Exception {
         storageResourceService.init();
     }
 
-    public void release() throws Exception {
-        if (!released.compareAndSet(false, true)) {
-            return;
-        }
-        inited.compareAndSet(true, false);
+    public void componentStart() throws Exception {
+        log.debug("StorageResource Component Starting...");
+    }
+
+    public void componentStop() throws Exception {
         storageResourceService.release();
     }
+
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/trace/Trace.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/trace/Trace.java
@@ -17,13 +17,14 @@
 
 package org.apache.eventmesh.runtime.trace;
 
+import org.apache.eventmesh.common.config.CommonConfiguration;
+import org.apache.eventmesh.runtime.lifecircle.EventMeshSwitchableComponent;
 import org.apache.eventmesh.trace.api.EventMeshTraceService;
 import org.apache.eventmesh.trace.api.TracePluginFactory;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.cloudevents.CloudEvent;
 import io.netty.channel.ChannelHandlerContext;
@@ -35,11 +36,9 @@ import io.opentelemetry.context.Context;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class Trace {
+public class Trace extends EventMeshSwitchableComponent {
 
     private static final Map<String, Trace> TRACE_CACHE = new HashMap<>(16);
-
-    private final AtomicBoolean inited = new AtomicBoolean(false);
 
     private EventMeshTraceService eventMeshTraceService;
 
@@ -60,11 +59,21 @@ public class Trace {
 
     }
 
-    public void init() throws Exception {
-        if (!inited.compareAndSet(false, true)) {
-            return;
-        }
+    @Override
+    protected boolean shouldTurn(CommonConfiguration configuration) {
+        return configuration.isEventMeshServerTraceEnable();
+    }
+
+    public void componentInit() throws Exception {
         eventMeshTraceService.init();
+    }
+
+    public void componentStart() throws Exception {
+        log.debug("Trace Component Starting...");
+    }
+
+    public void componentStop() throws Exception {
+        log.debug("Trace Component stopping...");
     }
 
     public Span createSpan(String spanName, SpanKind spanKind, long startTime, TimeUnit timeUnit,

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/trace/Trace.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/trace/Trace.java
@@ -64,16 +64,19 @@ public class Trace extends EventMeshSwitchableComponent {
         return configuration.isEventMeshServerTraceEnable();
     }
 
+    @Override
     public void componentInit() throws Exception {
         eventMeshTraceService.init();
     }
 
+    @Override
     public void componentStart() throws Exception {
         log.debug("Trace Component Starting...");
     }
 
+    @Override
     public void componentStop() throws Exception {
-        log.debug("Trace Component stopping...");
+        eventMeshTraceService.shutdown();
     }
 
     public Span createSpan(String spanName, SpanKind spanKind, long startTime, TimeUnit timeUnit,
@@ -217,9 +220,4 @@ public class Trace extends EventMeshSwitchableComponent {
         }
     }
 
-    public void shutdown() throws Exception {
-        if (useTrace && inited.compareAndSet(true, false)) {
-            eventMeshTraceService.shutdown();
-        }
-    }
 }


### PR DESCRIPTION
Fixes #4781 

########
UnMergeable！！！     its demo
########

### Motivation

I found that Events have a large number of components that need to be collectively converted to a certain life cycle at a certain time,
Starting from the top level EventMeshServer, it needs to manage a series of internal related components, such as Acl MetaStorage, while its own life cycle changes, so I want to design an interface that allows these components to have the same method to be invoked at different times of life cycle states. In a way similar to the observer, I managed and bound components at the time of their own life cycle changes, so I implemented this PR, and now the implementation is the top-level, as well as the internal management of components, such as AclService inside the Acl is also a component, and there are a bunch of internal components
我发现Event有大量需要在某一特定时间共同转换到某一生命周期的组件，从最上层的 EventMeshServer 开始，他需要在自己生命周期变化的同时管理内部关联的一系列组件，如 Acl MetaStorage等，所以我想设计一个接口，让这些组件在不同的生命周期状态的时刻有同样的方法可以被调用，在通过类似观察者的方式，在自己生命周期变化的时刻管理和自己绑定的组件，所以我实现了这个PR，目前实现的是最顶层的，还有组件内部的管理，如 Acl 内部的 AclService也是一个组件，内部也有一堆组件，这个后续慢慢实现

### Modifications
New org/apache/eventmesh/runtime/lifecircle EventMeshLifeCycle. Java is responsible for defining the eventmesh state transition method
New org/apache/eventmesh/runtime/lifecircle AbstractEventMeshComponent. Java implementation EventMeshLifeCycle define life cycle changes involved in the state and the binding of other components
New org/apache/eventmesh/runtime/lifecircle EventMeshComponent. Java eventmesh without switch control components, the implementation of state transition method, state huan rear method
New org/apache/eventmesh/runtime/lifecircle EventMeshSwitchableComponent. Java eventmesh with switch components, in EventMeshComponent increased switch function

Top-level component modification
EventMeshServer
-Acl Components with switches
-MetaStorage Components with switches
-Trace Components with switches
-StorageResource component
-ProducerTopicManager component
-EventMeshAdminBootstrap Component with a switch
-EventMeshGrpcBootstrap component

新增 org/apache/eventmesh/runtime/lifecircle/EventMeshLifeCycle.java 负责定义EventMesh中状态转换方法
新增 org/apache/eventmesh/runtime/lifecircle/AbstractEventMeshComponent.java 实现 EventMeshLifeCycle 定义生命周期变化中涉及的状态和绑定的其他组件
新增 org/apache/eventmesh/runtime/lifecircle/EventMeshComponent.java 没有开关控制的EventMesh组件，具体实现状态转换时的方法，状态装欢后置方法
新增 org/apache/eventmesh/runtime/lifecircle/EventMeshSwitchableComponent.java 带有开关的EventMesh组件，在EventMeshComponent增加了开关功能

顶层组件修改 
EventMeshServer 
-Acl   带有开关的组件
-MetaStorage   带有开关的组件
-Trace  带有开关的组件
-StorageResource  组件
-ProducerTopicManager 组件
-EventMeshAdminBootstrap 带有开关的组件
-EventMeshGrpcBootstrap  组件
### Documentation

- Does this pull request introduce a new feature? ( no)
