### PR TITLE
[ISSUE #4781]management life cycle

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshAdminBootstrap.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshAdminBootstrap.java
@@ -17,18 +17,32 @@
 
 package org.apache.eventmesh.runtime.boot;
 
-public class EventMeshAdminBootstrap implements EventMeshBootstrap {
+import org.apache.eventmesh.common.config.CommonConfiguration;
+import org.apache.eventmesh.runtime.lifecircle.EventMeshSwitchableComponent;
+
+import java.util.List;
+
+public class EventMeshAdminBootstrap extends EventMeshSwitchableComponent implements EventMeshBootstrap {
 
     private EventMeshAdminServer eventMeshAdminServer;
 
     private EventMeshServer eventMeshServer;
+
+    // http grpc tcp
+    private final int exposeServerChannelCount = 3;
 
     public EventMeshAdminBootstrap(EventMeshServer eventMeshServer) {
         this.eventMeshServer = eventMeshServer;
     }
 
     @Override
-    public void init() throws Exception {
+    protected boolean shouldTurn(CommonConfiguration configuration) {
+        final List<String> provideServerProtocols = configuration.getEventMeshProvideServerProtocols();
+        return !(provideServerProtocols.size() == exposeServerChannelCount);
+    }
+
+    @Override
+    protected void componentInit() throws Exception {
         if (eventMeshServer != null) {
             eventMeshAdminServer = new EventMeshAdminServer(eventMeshServer);
             eventMeshAdminServer.init();
@@ -37,7 +51,7 @@ public class EventMeshAdminBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void start() throws Exception {
+    protected void componentStart() throws Exception {
         if (eventMeshAdminServer != null) {
             eventMeshAdminServer.start();
         }
@@ -45,7 +59,7 @@ public class EventMeshAdminBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void shutdown() throws Exception {
+    protected void componentStop() throws Exception {
         if (eventMeshAdminServer != null) {
             eventMeshAdminServer.shutdown();
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshGrpcBootstrap.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshGrpcBootstrap.java
@@ -22,8 +22,9 @@ import static org.apache.eventmesh.common.Constants.GRPC;
 import org.apache.eventmesh.common.config.ConfigService;
 import org.apache.eventmesh.common.utils.ConfigurationContextUtil;
 import org.apache.eventmesh.runtime.configuration.EventMeshGrpcConfiguration;
+import org.apache.eventmesh.runtime.lifecircle.EventMeshComponent;
 
-public class EventMeshGrpcBootstrap implements EventMeshBootstrap {
+public class EventMeshGrpcBootstrap extends EventMeshComponent implements EventMeshBootstrap {
 
     private final EventMeshGrpcConfiguration eventMeshGrpcConfiguration;
 
@@ -40,7 +41,7 @@ public class EventMeshGrpcBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void init() throws Exception {
+    public void componentInit() throws Exception {
         // server init
         if (eventMeshGrpcConfiguration != null) {
             eventMeshGrpcServer = new EventMeshGrpcServer(this.eventMeshServer, this.eventMeshGrpcConfiguration);
@@ -49,7 +50,7 @@ public class EventMeshGrpcBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void start() throws Exception {
+    protected void componentStart() throws Exception {
         // server start
         if (eventMeshGrpcConfiguration != null) {
             eventMeshGrpcServer.start();
@@ -57,13 +58,13 @@ public class EventMeshGrpcBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void shutdown() throws Exception {
+    protected void componentStop() throws Exception {
         if (eventMeshGrpcConfiguration != null) {
             eventMeshGrpcServer.shutdown();
         }
     }
 
-    public EventMeshGrpcServer getEventMeshGrpcServer() {
+    protected EventMeshGrpcServer getEventMeshGrpcServer() {
         return eventMeshGrpcServer;
     }
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshHttpBootstrap.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshHttpBootstrap.java
@@ -22,8 +22,9 @@ import static org.apache.eventmesh.common.Constants.HTTP;
 import org.apache.eventmesh.common.config.ConfigService;
 import org.apache.eventmesh.common.utils.ConfigurationContextUtil;
 import org.apache.eventmesh.runtime.configuration.EventMeshHTTPConfiguration;
+import org.apache.eventmesh.runtime.lifecircle.EventMeshComponent;
 
-public class EventMeshHttpBootstrap implements EventMeshBootstrap {
+public class EventMeshHttpBootstrap extends EventMeshComponent implements EventMeshBootstrap  {
 
     private final EventMeshHTTPConfiguration eventMeshHttpConfiguration;
 
@@ -41,7 +42,7 @@ public class EventMeshHttpBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void init() throws Exception {
+    protected void componentInit() throws Exception {
         // server init
         if (eventMeshHttpConfiguration != null) {
             eventMeshHttpServer = new EventMeshHTTPServer(eventMeshServer, eventMeshHttpConfiguration);
@@ -50,7 +51,7 @@ public class EventMeshHttpBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void start() throws Exception {
+    protected void componentStart() throws Exception {
         // server start
         if (eventMeshHttpServer != null) {
             eventMeshHttpServer.start();
@@ -58,7 +59,7 @@ public class EventMeshHttpBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void shutdown() throws Exception {
+    protected void componentStop() throws Exception {
         // server shutdown
         if (eventMeshHttpServer != null) {
             eventMeshHttpServer.shutdown();

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshServer.java
@@ -29,19 +29,24 @@ import org.apache.eventmesh.runtime.acl.Acl;
 import org.apache.eventmesh.runtime.common.ServiceState;
 import org.apache.eventmesh.runtime.constants.EventMeshConstants;
 import org.apache.eventmesh.runtime.core.protocol.http.producer.ProducerTopicManager;
+import org.apache.eventmesh.runtime.lifecircle.EventMeshSwitchableComponent;
 import org.apache.eventmesh.runtime.meta.MetaStorage;
 import org.apache.eventmesh.runtime.storage.StorageResource;
 import org.apache.eventmesh.runtime.trace.Trace;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class EventMeshServer {
+public class EventMeshServer extends EventMeshSwitchableComponent {
 
+    private static final ConfigService configService = ConfigService.getInstance();
+
+    private ServiceState serviceState;
+
+    private static final String SERVER_STATE_MSG = "server state:{}";
     private final Acl acl;
 
     private MetaStorage metaStorage;
@@ -50,19 +55,11 @@ public class EventMeshServer {
 
     private final StorageResource storageResource;
 
-    private ServiceState serviceState;
-
     private ProducerTopicManager producerTopicManager;
-
-    private final CommonConfiguration configuration;
 
     //  private transient ClientManageController clientManageController;
 
     private static final List<EventMeshBootstrap> BOOTSTRAP_LIST = new CopyOnWriteArrayList<>();
-
-    private static final String SERVER_STATE_MSG = "server state:{}";
-
-    private static final ConfigService configService = ConfigService.getInstance();
 
     private EventMeshAdminBootstrap adminBootstrap;
 
@@ -73,29 +70,42 @@ public class EventMeshServer {
     private EventMeshHTTPServer eventMeshHTTPServer = null;
 
     public EventMeshServer() {
-
         // Initialize configuration
         this.configuration = configService.buildConfigInstance(CommonConfiguration.class);
+        /*EventMeshSwitchableComponent.setCommonConfiguration(configuration);*/
         AssertUtils.notNull(this.configuration, "configuration is null");
 
         // Initialize acl, registry, trace and storageResource
         this.acl = Acl.getInstance(this.configuration.getEventMeshSecurityPluginType());
+        bindLifeCycle(this.acl);
+
         this.metaStorage = MetaStorage.getInstance(this.configuration.getEventMeshMetaStoragePluginType());
+        bindLifeCycle(this.metaStorage);
+
         trace = Trace.getInstance(this.configuration.getEventMeshTracePluginType(), this.configuration.isEventMeshServerTraceEnable());
+        bindLifeCycle(this.trace);
+
         this.storageResource = StorageResource.getInstance(this.configuration.getEventMeshStoragePluginType());
+        bindLifeCycle(this.storageResource);
 
         // Initialize BOOTSTRAP_LIST based on protocols provided in configuration
         final List<String> provideServerProtocols = configuration.getEventMeshProvideServerProtocols();
         for (String provideServerProtocol : provideServerProtocols) {
             switch (provideServerProtocol.toUpperCase()) {
                 case HTTP:
-                    BOOTSTRAP_LIST.add(new EventMeshHttpBootstrap(this));
+                    EventMeshHttpBootstrap httpBootstrap = new EventMeshHttpBootstrap(this);
+                    BOOTSTRAP_LIST.add(httpBootstrap);
+                    bindLifeCycle(httpBootstrap);
                     break;
                 case TCP:
-                    BOOTSTRAP_LIST.add(new EventMeshTcpBootstrap(this));
+                    EventMeshTcpBootstrap tcpBootstrap = new EventMeshTcpBootstrap(this);
+                    BOOTSTRAP_LIST.add(tcpBootstrap);
+                    bindLifeCycle(tcpBootstrap);
                     break;
                 case GRPC:
-                    BOOTSTRAP_LIST.add(new EventMeshGrpcBootstrap(this));
+                    EventMeshGrpcBootstrap grpcBootstrap = new EventMeshGrpcBootstrap(this);
+                    BOOTSTRAP_LIST.add(grpcBootstrap);
+                    bindLifeCycle(grpcBootstrap);
                     break;
                 default:
                     // nothing to do
@@ -104,25 +114,27 @@ public class EventMeshServer {
 
         // If no protocols are provided, initialize BOOTSTRAP_LIST with default protocols
         if (BOOTSTRAP_LIST.isEmpty()) {
-            BOOTSTRAP_LIST.add(new EventMeshTcpBootstrap(this));
+            EventMeshTcpBootstrap tcpBootstrap = new EventMeshTcpBootstrap(this);
+            BOOTSTRAP_LIST.add(tcpBootstrap);
+            bindLifeCycle(tcpBootstrap);
         }
+
+        producerTopicManager = new ProducerTopicManager(this);
+        bindLifeCycle(producerTopicManager);
     }
 
-    public void init() throws Exception {
-        storageResource.init();
-        if (configuration.isEventMeshServerSecurityEnable()) {
-            acl.init();
-        }
-        if (configuration.isEventMeshServerMetaStorageEnable()) {
-            metaStorage.init();
-        }
-        if (configuration.isEventMeshServerTraceEnable()) {
-            trace.init();
-        }
+    @Override
+    protected boolean shouldTurn(CommonConfiguration configuration) {
+        return true;
+    }
 
-        // server init
+    @Override
+    protected void componentInit() throws Exception {
+    }
+
+    @Override
+    protected void postBindInited() throws Exception {
         for (final EventMeshBootstrap eventMeshBootstrap : BOOTSTRAP_LIST) {
-            eventMeshBootstrap.init();
             if (eventMeshBootstrap instanceof EventMeshTcpBootstrap) {
                 eventMeshTCPServer = ((EventMeshTcpBootstrap) eventMeshBootstrap).getEventMeshTcpServer();
             }
@@ -134,70 +146,36 @@ public class EventMeshServer {
             }
         }
 
-        if (Objects.nonNull(eventMeshTCPServer) && Objects.nonNull(eventMeshHTTPServer) && Objects.nonNull(eventMeshGrpcServer)) {
-            adminBootstrap = new EventMeshAdminBootstrap(this);
-            adminBootstrap.init();
-        }
+        // adminBootstrap Depend on http\grpc\tcp Server
+        adminBootstrap = new EventMeshAdminBootstrap(this);
+        bindLifeCycle(adminBootstrap);
 
         final String eventStore = System.getProperty(EventMeshConstants.EVENT_STORE_PROPERTIES, System.getenv(EventMeshConstants.EVENT_STORE_ENV));
-
         log.info("eventStore : {}", eventStore);
-        producerTopicManager = new ProducerTopicManager(this);
-        producerTopicManager.init();
-        serviceState = ServiceState.INITED;
 
+        serviceState = ServiceState.INITED;
         log.info(SERVER_STATE_MSG, serviceState);
     }
 
-    public void start() throws Exception {
-        if (Objects.nonNull(configuration)) {
-            if (configuration.isEventMeshServerSecurityEnable()) {
-                acl.start();
-            }
-            // registry start
-            if (configuration.isEventMeshServerMetaStorageEnable()) {
-                metaStorage.start();
-            }
-        }
-        // server start
-        for (final EventMeshBootstrap eventMeshBootstrap : BOOTSTRAP_LIST) {
-            eventMeshBootstrap.start();
-        }
+    @Override
+    protected void componentStart() throws Exception {
+    }
 
-        if (Objects.nonNull(adminBootstrap)) {
-            adminBootstrap.start();
-        }
-        producerTopicManager.start();
+    protected void postBindStarted() throws Exception {
         serviceState = ServiceState.RUNNING;
         log.info(SERVER_STATE_MSG, serviceState);
-
     }
 
-    public void shutdown() throws Exception {
+    @Override
+    protected void componentStop() throws Exception {
         serviceState = ServiceState.STOPPING;
         log.info(SERVER_STATE_MSG, serviceState);
+    }
 
-        for (final EventMeshBootstrap eventMeshBootstrap : BOOTSTRAP_LIST) {
-            eventMeshBootstrap.shutdown();
-        }
-
-        if (configuration != null && configuration.isEventMeshServerMetaStorageEnable()) {
-            metaStorage.shutdown();
-        }
-
-        storageResource.release();
-
-        if (configuration != null && configuration.isEventMeshServerSecurityEnable()) {
-            acl.shutdown();
-        }
-
-        if (configuration != null && configuration.isEventMeshServerTraceEnable()) {
-            trace.shutdown();
-        }
-        producerTopicManager.shutdown();
+    @Override
+    protected void postBindStopped() {
         ConfigurationContextUtil.clear();
         serviceState = ServiceState.STOPPED;
-
         log.info(SERVER_STATE_MSG, serviceState);
     }
 
@@ -240,4 +218,6 @@ public class EventMeshServer {
     public EventMeshHTTPServer getEventMeshHTTPServer() {
         return eventMeshHTTPServer;
     }
+
+
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshTcpBootstrap.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshTcpBootstrap.java
@@ -22,8 +22,9 @@ import static org.apache.eventmesh.common.Constants.TCP;
 import org.apache.eventmesh.common.config.ConfigService;
 import org.apache.eventmesh.common.utils.ConfigurationContextUtil;
 import org.apache.eventmesh.runtime.configuration.EventMeshTCPConfiguration;
+import org.apache.eventmesh.runtime.lifecircle.EventMeshComponent;
 
-public class EventMeshTcpBootstrap implements EventMeshBootstrap {
+public class EventMeshTcpBootstrap extends EventMeshComponent implements EventMeshBootstrap {
 
     private EventMeshTCPServer eventMeshTcpServer;
 
@@ -41,7 +42,7 @@ public class EventMeshTcpBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void init() throws Exception {
+    protected void componentInit() throws Exception {
         // server init
         if (eventMeshTcpConfiguration != null) {
             eventMeshTcpServer = new EventMeshTCPServer(eventMeshServer, eventMeshTcpConfiguration);
@@ -50,7 +51,7 @@ public class EventMeshTcpBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void start() throws Exception {
+    protected void componentStart() throws Exception {
         // server start
         if (eventMeshTcpConfiguration != null) {
             eventMeshTcpServer.start();
@@ -58,7 +59,7 @@ public class EventMeshTcpBootstrap implements EventMeshBootstrap {
     }
 
     @Override
-    public void shutdown() throws Exception {
+    protected void componentStop() throws Exception {
         if (eventMeshTcpConfiguration != null) {
             eventMeshTcpServer.shutdown();
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/producer/ProducerTopicManager.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/http/producer/ProducerTopicManager.java
@@ -21,6 +21,7 @@ import org.apache.eventmesh.api.meta.bo.EventMeshServicePubTopicInfo;
 import org.apache.eventmesh.common.EventMeshThreadFactory;
 import org.apache.eventmesh.common.ThreadPoolFactory;
 import org.apache.eventmesh.runtime.boot.EventMeshServer;
+import org.apache.eventmesh.runtime.lifecircle.EventMeshComponent;
 
 import java.util.List;
 import java.util.Optional;
@@ -32,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class ProducerTopicManager {
+public class ProducerTopicManager extends EventMeshComponent {
 
     private final EventMeshServer eventMeshServer;
 
@@ -46,13 +47,15 @@ public class ProducerTopicManager {
         this.eventMeshServer = eventMeshServer;
     }
 
-    public void init() {
+    @Override
+    protected void componentInit() {
         scheduler = ThreadPoolFactory.createScheduledExecutor(Runtime.getRuntime().availableProcessors(),
             new EventMeshThreadFactory("Producer-Topic-Manager", true));
         log.info("ProducerTopicManager inited......");
     }
 
-    public void start() {
+    @Override
+    protected void componentStart() {
 
         if (scheduledTask == null) {
             synchronized (ProducerTopicManager.class) {
@@ -74,7 +77,8 @@ public class ProducerTopicManager {
         log.info("ProducerTopicManager started......");
     }
 
-    public void shutdown() {
+    @Override
+    protected void componentStop() {
         if (scheduledTask != null) {
             scheduledTask.cancel(false);
         }
@@ -88,5 +92,6 @@ public class ProducerTopicManager {
     public EventMeshServicePubTopicInfo getEventMeshServicePubTopicInfo(String producerGroup) {
         return eventMeshServicePubTopicInfoMap.get(producerGroup);
     }
+
 
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/lifecircle/AbstractEventMeshComponent.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/lifecircle/AbstractEventMeshComponent.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.lifecircle;
+
+
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class AbstractEventMeshComponent implements EventMeshLifeCycle {
+
+    protected final AtomicBoolean inited = new AtomicBoolean(false);
+    protected final AtomicBoolean started = new AtomicBoolean(false);
+    protected final AtomicBoolean shutdown = new AtomicBoolean(false);
+    protected final List<EventMeshLifeCycle> bindLifeCycleComponents = new CopyOnWriteArrayList<>();
+
+    public void bindLifeCycle(EventMeshLifeCycle meshLifeCircle) {
+        bindLifeCycleComponents.add(meshLifeCircle);
+    }
+
+
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/lifecircle/EventMeshComponent.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/lifecircle/EventMeshComponent.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.lifecircle;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class EventMeshComponent extends AbstractEventMeshComponent {
+
+
+    public void init() throws Exception {
+        if (shouldSkip()) {
+            return;
+        }
+        if (!inited.compareAndSet(false, true)) {
+            return;
+        }
+        componentInit();
+        for (EventMeshLifeCycle component : bindLifeCycleComponents) {
+            component.init();
+        }
+        postBindInited();
+    }
+
+    protected abstract void componentInit() throws Exception;
+
+
+    protected void postBindInited() throws Exception {
+    }
+
+
+    public void start() throws Exception {
+        if (shouldSkip()) {
+            return;
+        }
+        if (!started.compareAndSet(false, true)) {
+            return;
+        }
+        componentStart();
+        for (EventMeshLifeCycle component : bindLifeCycleComponents) {
+            component.start();
+        }
+        postBindStarted();
+    }
+
+    protected abstract void componentStart() throws Exception;
+
+
+    protected void postBindStarted() throws Exception {
+    }
+
+    public void shutdown() throws Exception {
+        if (shouldSkip()) {
+            return;
+        }
+        inited.compareAndSet(true, false);
+        started.compareAndSet(true, false);
+        if (!shutdown.compareAndSet(false, true)) {
+            return;
+        }
+        componentStop();
+        for (int index = bindLifeCycleComponents.size() - 1; index >= 0; index--) {
+            bindLifeCycleComponents.get(index).shutdown();
+        }
+        postBindStopped();
+    }
+
+    protected abstract void componentStop() throws Exception;
+
+    protected void postBindStopped() throws Exception {
+    }
+
+    protected boolean shouldSkip() {
+        return false;
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/lifecircle/EventMeshLifeCycle.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/lifecircle/EventMeshLifeCycle.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.lifecircle;
+
+/**
+ * Life cycle transition
+ */
+public interface EventMeshLifeCycle {
+
+    void init() throws Exception;
+
+    void start() throws Exception;
+
+    void shutdown() throws Exception;
+}
+

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/lifecircle/EventMeshSwitchableComponent.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/lifecircle/EventMeshSwitchableComponent.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.lifecircle;
+
+import org.apache.eventmesh.common.config.CommonConfiguration;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class EventMeshSwitchableComponent extends EventMeshComponent {
+
+    protected static CommonConfiguration configuration;
+
+    protected abstract boolean shouldTurn(CommonConfiguration configuration);
+
+    @Override
+    protected boolean shouldSkip() {
+        return !shouldTurn(configuration);
+    }
+
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/storage/StorageResource.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/storage/StorageResource.java
@@ -18,24 +18,20 @@
 package org.apache.eventmesh.runtime.storage;
 
 import org.apache.eventmesh.api.storage.StorageResourceService;
+import org.apache.eventmesh.runtime.lifecircle.EventMeshComponent;
 import org.apache.eventmesh.spi.EventMeshExtensionFactory;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class StorageResource {
+public class StorageResource extends EventMeshComponent {
 
     private static final Map<String, StorageResource> STORAGE_RESOURCE_CACHE = new HashMap<>(16);
 
     private StorageResourceService storageResourceService;
-
-    private final AtomicBoolean inited = new AtomicBoolean(false);
-
-    private final AtomicBoolean released = new AtomicBoolean(false);
 
     private StorageResource() {
 
@@ -58,18 +54,19 @@ public class StorageResource {
         return storageResource;
     }
 
-    public void init() throws Exception {
-        if (!inited.compareAndSet(false, true)) {
-            return;
-        }
+    @Override
+    protected void componentInit() throws Exception {
         storageResourceService.init();
     }
 
-    public void release() throws Exception {
-        if (!released.compareAndSet(false, true)) {
-            return;
-        }
-        inited.compareAndSet(true, false);
+    @Override
+    protected void componentStart() throws Exception {
+        log.debug("StorageResource Component Starting...");
+    }
+
+    @Override
+    protected void componentStop() throws Exception {
         storageResourceService.release();
     }
+
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/trace/Trace.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/trace/Trace.java
@@ -17,13 +17,14 @@
 
 package org.apache.eventmesh.runtime.trace;
 
+import org.apache.eventmesh.common.config.CommonConfiguration;
+import org.apache.eventmesh.runtime.lifecircle.EventMeshSwitchableComponent;
 import org.apache.eventmesh.trace.api.EventMeshTraceService;
 import org.apache.eventmesh.trace.api.TracePluginFactory;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.cloudevents.CloudEvent;
 import io.netty.channel.ChannelHandlerContext;
@@ -35,11 +36,9 @@ import io.opentelemetry.context.Context;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class Trace {
+public class Trace extends EventMeshSwitchableComponent {
 
     private static final Map<String, Trace> TRACE_CACHE = new HashMap<>(16);
-
-    private final AtomicBoolean inited = new AtomicBoolean(false);
 
     private EventMeshTraceService eventMeshTraceService;
 
@@ -60,11 +59,24 @@ public class Trace {
 
     }
 
-    public void init() throws Exception {
-        if (!inited.compareAndSet(false, true)) {
-            return;
-        }
+    @Override
+    protected boolean shouldTurn(CommonConfiguration configuration) {
+        return configuration.isEventMeshServerTraceEnable();
+    }
+
+    @Override
+    protected void componentInit() throws Exception {
         eventMeshTraceService.init();
+    }
+
+    @Override
+    protected void componentStart() throws Exception {
+        log.debug("Trace Component Starting...");
+    }
+
+    @Override
+    protected void componentStop() throws Exception {
+        eventMeshTraceService.shutdown();
     }
 
     public Span createSpan(String spanName, SpanKind spanKind, long startTime, TimeUnit timeUnit,
@@ -208,9 +220,4 @@ public class Trace {
         }
     }
 
-    public void shutdown() throws Exception {
-        if (useTrace && inited.compareAndSet(true, false)) {
-            eventMeshTraceService.shutdown();
-        }
-    }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/eventmesh/issues/4781

########
UnMergeable！！！ its demo
########

Motivation
I found that Events have a large number of components that need to be collectively converted to a certain life cycle at a certain time,
Starting from the top level EventMeshServer, it needs to manage a series of internal related components, such as Acl MetaStorage, while its own life cycle changes, so I want to design an interface that allows these components to have the same method to be invoked at different times of life cycle states. In a way similar to the observer, I managed and bound components at the time of their own life cycle changes, so I implemented this PR, and now the implementation is the top-level, as well as the internal management of components, For example, ACLs are SPI loaded and cannot be modified, but other fixed implementations such as ProducerTopicManager also have many internal lifecycle components that should be modified later and associated with the topmost component
我发现Event有大量需要在某一特定时间共同转换到某一生命周期的组件，从最上层的 EventMeshServer 开始，他需要在自己生命周期变化的同时管理内部关联的一系列组件，如 Acl MetaStorage等，所以我想设计一个接口，让这些组件在不同的生命周期状态的时刻有同样的方法可以被调用，在通过类似观察者的方式，在自己生命周期变化的时刻管理和自己绑定的组件，所以我实现了这个PR，目前实现的是最顶层的，还有组件内部的管理，如 Acl 之类是 SPI 加载的，这种不能修改，但是像其他ProducerTopicManager之类的固定实现，内部也有很多同生命周期的组件，这些后续也应该被修改，并且能关联到最顶层的组件

Modifications
New org/apache/eventmesh/runtime/lifecircle EventMeshLifeCycle. Java is responsible for defining the eventmesh state transition method
New org/apache/eventmesh/runtime/lifecircle AbstractEventMeshComponent. Java implementation EventMeshLifeCycle define life cycle changes involved in the state and the binding of other components
New org/apache/eventmesh/runtime/lifecircle EventMeshComponent. Java eventmesh without switch control components, the implementation of state transition method, state huan rear method
New org/apache/eventmesh/runtime/lifecircle EventMeshSwitchableComponent. Java eventmesh with switch components, in EventMeshComponent increased switch function

Top-level component modification
EventMeshServer
-Acl Components with switches
-MetaStorage Components with switches
-Trace Components with switches
-StorageResource component
-ProducerTopicManager component
-EventMeshAdminBootstrap Component with a switch
-EventMeshGrpcBootstrap component

新增 org/apache/eventmesh/runtime/lifecircle/EventMeshLifeCycle.java 负责定义EventMesh中状态转换方法
新增 org/apache/eventmesh/runtime/lifecircle/AbstractEventMeshComponent.java 实现 EventMeshLifeCycle 定义生命周期变化中涉及的状态和绑定的其他组件
新增 org/apache/eventmesh/runtime/lifecircle/EventMeshComponent.java 没有开关控制的EventMesh组件，具体实现状态转换时的方法，状态装欢后置方法
新增 org/apache/eventmesh/runtime/lifecircle/EventMeshSwitchableComponent.java 带有开关的EventMesh组件，在EventMeshComponent增加了开关功能

顶层组件修改
EventMeshServer
-Acl 带有开关的组件
-MetaStorage 带有开关的组件
-Trace 带有开关的组件
-StorageResource 组件
-ProducerTopicManager 组件
-EventMeshAdminBootstrap 带有开关的组件
-EventMeshGrpcBootstrap 组件