### PR TITLE
[ISSUE #4787]integration connector

### DIFF
--- a/eventmesh-connectors/eventmesh-connector-file/src/main/java/org/apache/eventmesh/connector/file/server/FileConnectServer.java
+++ b/eventmesh-connectors/eventmesh-connector-file/src/main/java/org/apache/eventmesh/connector/file/server/FileConnectServer.java
@@ -21,12 +21,14 @@ import org.apache.eventmesh.connector.file.config.FileServerConfig;
 import org.apache.eventmesh.connector.file.sink.connector.FileSinkConnector;
 import org.apache.eventmesh.connector.file.source.connector.FileSourceConnector;
 import org.apache.eventmesh.openconnect.Application;
+import org.apache.eventmesh.openconnect.api.integration.EmbeddableConnector;
 import org.apache.eventmesh.openconnect.util.ConfigUtil;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class FileConnectServer {
+
+public class FileConnectServer implements EmbeddableConnector {
 
     public static void main(String[] args) throws Exception {
 

--- a/eventmesh-connectors/eventmesh-connector-file/src/main/resources/META-INF/eventmesh/org.apache.eventmesh.openconnect.EmbeddableConnector
+++ b/eventmesh-connectors/eventmesh-connector-file/src/main/resources/META-INF/eventmesh/org.apache.eventmesh.openconnect.EmbeddableConnector
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+file=org.apache.eventmesh.connector.file.server.FileConnectServer

--- a/eventmesh-openconnect/eventmesh-openconnect-java/src/main/java/org/apache/eventmesh/openconnect/api/integration/EmbeddableConnector.java
+++ b/eventmesh-openconnect/eventmesh-openconnect-java/src/main/java/org/apache/eventmesh/openconnect/api/integration/EmbeddableConnector.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.openconnect.api.integration;
+
+import org.apache.eventmesh.spi.EventMeshExtensionType;
+import org.apache.eventmesh.spi.EventMeshSPI;
+
+
+/**
+ *Embeddable Connector worker interface
+ */
+@EventMeshSPI(eventMeshExtensionType = EventMeshExtensionType.INNER_CONNECTOR)
+public interface EmbeddableConnector {
+}

--- a/eventmesh-openconnect/eventmesh-openconnect-java/src/main/java/org/apache/eventmesh/openconnect/api/integration/IInnerPubSubService.java
+++ b/eventmesh-openconnect/eventmesh-openconnect-java/src/main/java/org/apache/eventmesh/openconnect/api/integration/IInnerPubSubService.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.eventmesh.openconnect.api.integration;
 
 public interface IInnerPubSubService {

--- a/eventmesh-openconnect/eventmesh-openconnect-java/src/main/java/org/apache/eventmesh/openconnect/api/integration/IInnerPubSubService.java
+++ b/eventmesh-openconnect/eventmesh-openconnect-java/src/main/java/org/apache/eventmesh/openconnect/api/integration/IInnerPubSubService.java
@@ -1,0 +1,4 @@
+package org.apache.eventmesh.openconnect.api.integration;
+
+public interface IInnerPubSubService {
+}

--- a/eventmesh-openconnect/eventmesh-openconnect-java/src/main/java/org/apache/eventmesh/openconnect/api/integration/IntegrationCloudEventTCPClientAdapter.java
+++ b/eventmesh-openconnect/eventmesh-openconnect-java/src/main/java/org/apache/eventmesh/openconnect/api/integration/IntegrationCloudEventTCPClientAdapter.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.openconnect.api.integration;
+
+import org.apache.eventmesh.client.tcp.EventMeshTCPClient;
+import org.apache.eventmesh.client.tcp.EventMeshTCPPubClient;
+import org.apache.eventmesh.client.tcp.EventMeshTCPSubClient;
+import org.apache.eventmesh.client.tcp.common.AsyncRRCallback;
+import org.apache.eventmesh.client.tcp.common.ReceiveMsgHook;
+import org.apache.eventmesh.common.exception.EventMeshException;
+import org.apache.eventmesh.common.protocol.SubscriptionMode;
+import org.apache.eventmesh.common.protocol.SubscriptionType;
+import org.apache.eventmesh.common.protocol.tcp.Package;
+import org.apache.eventmesh.common.protocol.tcp.UserAgent;
+
+import io.cloudevents.CloudEvent;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class IntegrationCloudEventTCPClientAdapter implements EventMeshTCPClient<CloudEvent> {
+
+    private final UserAgent userAgent;
+    private final String meshIp;
+    private final int port;
+    IInnerPubSubService innerPubSubService;
+    private ReceiveMsgHook<CloudEvent> callBack;
+
+    public IntegrationCloudEventTCPClientAdapter(UserAgent userAgent, String meshIp, int port,IInnerPubSubService innerPubSubService) {
+        this.userAgent = userAgent;
+        this.meshIp = meshIp;
+        this.port = port;
+        this.innerPubSubService = innerPubSubService;
+    }
+
+    @Override
+    public Package publish(CloudEvent msg, long timeout) throws EventMeshException {
+        //TODO sourceWay
+        return null;
+    }
+
+    @Override
+    public void subscribe(String topic, SubscriptionMode subscriptionMode, SubscriptionType subscriptionType) throws EventMeshException {
+        if (null != callBack){
+            //TODO sinkWay
+        }
+
+    }
+
+    @Override
+    public void registerSubBusiHandler(ReceiveMsgHook<CloudEvent> handler) throws EventMeshException {
+        callBack = handler;
+    }
+
+    @Override
+    public EventMeshTCPPubClient<CloudEvent> getPubClient() {
+        throw new EventMeshException("INTEGRATION Mode Dosent have PubClient");
+    }
+
+    @Override
+    public EventMeshTCPSubClient<CloudEvent> getSubClient() {
+        throw new EventMeshException("INTEGRATION Mode Dosent have SubClient");
+    }
+
+    /*
+    *  From here on down all methods are meaningless for integration so it doesn't need to be implemented
+    * */
+    public void logDoNothing(){
+        log.info("INTEGRATION Mode TCPClient do nothing");
+    }
+
+    @Override
+    public void init() throws EventMeshException {
+        logDoNothing();
+    }
+
+    @Override
+    public Package rr(CloudEvent msg, long timeout) throws EventMeshException {
+        logDoNothing();
+        return null;
+    }
+
+    @Override
+    public void asyncRR(CloudEvent msg, AsyncRRCallback callback, long timeout) throws EventMeshException {
+        logDoNothing();
+    }
+
+    @Override
+    public void broadcast(CloudEvent msg, long timeout) throws EventMeshException {
+        logDoNothing();
+    }
+
+    @Override
+    public void listen() throws EventMeshException {
+        logDoNothing();
+    }
+
+    @Override
+    public void unsubscribe() throws EventMeshException {
+        logDoNothing();
+    }
+
+    @Override
+    public void registerPubBusiHandler(ReceiveMsgHook<CloudEvent> handler) throws EventMeshException {
+        logDoNothing();
+    }
+
+
+
+    @Override
+    public void close() throws Exception {
+        logDoNothing();
+    }
+}

--- a/eventmesh-runtime/build.gradle
+++ b/eventmesh-runtime/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation project(":eventmesh-meta:eventmesh-meta-api")
     implementation project(":eventmesh-meta:eventmesh-meta-nacos")
     implementation project(":eventmesh-protocol-plugin:eventmesh-protocol-api")
+    implementation project(":eventmesh-openconnect:eventmesh-openconnect-java")
 
     implementation "io.grpc:grpc-core"
     implementation "io.grpc:grpc-protobuf"

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshServer.java
@@ -29,6 +29,7 @@ import org.apache.eventmesh.runtime.acl.Acl;
 import org.apache.eventmesh.runtime.common.ServiceState;
 import org.apache.eventmesh.runtime.constants.EventMeshConstants;
 import org.apache.eventmesh.runtime.core.protocol.http.producer.ProducerTopicManager;
+import org.apache.eventmesh.runtime.core.protocol.inner.InnerLocalServer;
 import org.apache.eventmesh.runtime.meta.MetaStorage;
 import org.apache.eventmesh.runtime.storage.StorageResource;
 import org.apache.eventmesh.runtime.trace.Trace;
@@ -72,6 +73,8 @@ public class EventMeshServer {
 
     private EventMeshHTTPServer eventMeshHTTPServer = null;
 
+    private InnerLocalServer innerServer = null;
+
     public EventMeshServer() {
 
         // Initialize configuration
@@ -84,6 +87,7 @@ public class EventMeshServer {
         trace = Trace.getInstance(this.configuration.getEventMeshTracePluginType(), this.configuration.isEventMeshServerTraceEnable());
         this.storageResource = StorageResource.getInstance(this.configuration.getEventMeshStoragePluginType());
 
+        this.innerServer = new InnerLocalServer(this);
         // Initialize BOOTSTRAP_LIST based on protocols provided in configuration
         final List<String> provideServerProtocols = configuration.getEventMeshProvideServerProtocols();
         for (String provideServerProtocol : provideServerProtocols) {
@@ -168,6 +172,7 @@ public class EventMeshServer {
             adminBootstrap.start();
         }
         producerTopicManager.start();
+        innerServer.start();
         serviceState = ServiceState.RUNNING;
         log.info(SERVER_STATE_MSG, serviceState);
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/configuration/EventMeshInnerConfiguration.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/configuration/EventMeshInnerConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.configuration;
+
+import org.apache.eventmesh.common.config.CommonConfiguration;
+import org.apache.eventmesh.common.config.Config;
+import org.apache.eventmesh.common.config.ConfigFiled;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+@Config(prefix = "eventMesh.server")
+public class EventMeshInnerConfiguration extends CommonConfiguration {
+
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/configuration/EventMeshInnerConfiguration.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/configuration/EventMeshInnerConfiguration.java
@@ -19,9 +19,7 @@ package org.apache.eventmesh.runtime.configuration;
 
 import org.apache.eventmesh.common.config.CommonConfiguration;
 import org.apache.eventmesh.common.config.Config;
-import org.apache.eventmesh.common.config.ConfigFiled;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/constants/EventMeshConstants.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/constants/EventMeshConstants.java
@@ -31,6 +31,8 @@ public class EventMeshConstants {
 
     public static final String PROTOCOL_GRPC = "grpc";
 
+    public static final String PROTOCOL_INNER = "inner";
+
     public static final String DEFAULT_CHARSET = Constants.DEFAULT_CHARSET.name();
 
     public static final String IP_PORT_SEPARATOR = ":";

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/inner/InnerLocalServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/inner/InnerLocalServer.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.core.protocol.inner;
+
+
+import org.apache.eventmesh.common.config.ConfigService;
+import org.apache.eventmesh.openconnect.Application;
+import org.apache.eventmesh.openconnect.api.integration.EmbeddableConnector;
+import org.apache.eventmesh.openconnect.api.integration.IInnerPubSubService;
+import org.apache.eventmesh.runtime.boot.EventMeshServer;
+import org.apache.eventmesh.runtime.configuration.EventMeshInnerConfiguration;
+import org.apache.eventmesh.spi.EventMeshExtensionFactory;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class InnerLocalServer {
+
+    EventMeshServer eventMeshServer;
+    EventMeshInnerConfiguration configuration;
+    IInnerPubSubService innerPubSubService;
+
+    List<EmbeddableConnector> extensions;
+
+    public InnerLocalServer(EventMeshServer eventMeshServer) {
+        this.eventMeshServer = eventMeshServer;
+        ConfigService configService = ConfigService.getInstance();
+        this.configuration = configService.buildConfigInstance(EventMeshInnerConfiguration.class);
+        extensions = EventMeshExtensionFactory.getExtensions(EmbeddableConnector.class);
+        if (extensions.size() > 0) {
+            innerPubSubService = new InnerPubSubService();
+            Application.bindInnerPubSubService(innerPubSubService);
+        }
+    }
+
+
+    public void init() throws Exception {
+    }
+
+    public void start() throws Exception {
+        extensions.forEach(embeddableConnector -> {
+            try {
+                Method main = embeddableConnector.getClass().getMethod("main", String[].class);
+                main.invoke(null, (Object) new String[0]);
+            } catch (Exception e) {
+                log.error("An embeddable plug-in was introduced but failed to start named {}", embeddableConnector.getClass().getName());
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public void shutdown() throws Exception {
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/inner/InnerPubSubService.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/inner/InnerPubSubService.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.core.protocol.inner;
+
+import org.apache.eventmesh.openconnect.api.integration.IInnerPubSubService;
+import org.apache.eventmesh.runtime.core.protocol.inner.processor.PublishProcessor;
+import org.apache.eventmesh.runtime.core.protocol.inner.processor.SubscribeProcessor;
+
+public class InnerPubSubService implements IInnerPubSubService {
+
+    PublishProcessor publishProcessor;
+
+    SubscribeProcessor subscribeProcessor;
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/inner/processor/PublishProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/inner/processor/PublishProcessor.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.core.protocol.inner.processor;
+
+public class PublishProcessor {
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/inner/processor/SubscribeProcessor.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/core/protocol/inner/processor/SubscribeProcessor.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.core.protocol.inner.processor;
+
+public class SubscribeProcessor {
+}

--- a/eventmesh-spi/src/main/java/org/apache/eventmesh/spi/EventMeshExtensionType.java
+++ b/eventmesh-spi/src/main/java/org/apache/eventmesh/spi/EventMeshExtensionType.java
@@ -24,6 +24,10 @@ public enum EventMeshExtensionType {
 
     UNKNOWN("unknown"),
     CONNECTOR("connector"),
+
+    INNER_CONNECTOR("inner_connector"),
+
+
     STORAGE("storage"),
     META("metaStorage"),
     SECURITY("security"),


### PR DESCRIPTION
Fixes https://github.com/apache/eventmesh/issues/4787

########
UnMergeable！！！ its demo ，不能合并这只是用于讨论
########

Motivation

Integrate connector with minimal modification

Very simple integration using connecter

Modifications

Integrating 'connecter' means that 'connecter' has to have another running mode, and integrating into 'runtime' has some problems to solve
集成 `connecter` ，意味着 `connecter` 要有另一种运行模式，集成到 `runtime` 中有一些问题需要解决

--------------------------------------------------------------------------------------------------------------------------------
The first problem that needs to be solved is that the main method is not called, but `connecter` is a plug-in module, and it is troublesome to hard-code main once for each plug-in. So the method I think of is that all the `connecter` module's startup class inherits a `EmbeddableConnector` interface, and uses the `Eventmesh-SPI` to load, so that the changes are brought
`EmbeddableConnector`
All startup classes in `Connector` (in this case, `FileConnectServer`)
All files referred to by `SPI` in `Connector`
首先需要解决的问题就是 `main` 方法没有被调用，但是 `connecter` 是插件化的模块，为每一个插件都硬编码一次 `main` 这样很麻烦，所以我想到的方法是所有 `connecter` 模块的启动类都继承一个`EmbeddableConnector` 接口,使用 `Eventmesh` 的 `SPI` 进行加载，这样带来的修改就有
`EmbeddableConnector`
所有 `Connector` 中的启动类（这个例子中的启动类是 `FileConnectServer` ）
所有 `Connector` 中 `SPI` 涉及的文件

--------------------------------------------------------------------------------------------------------------------------------
Second, the original interaction between `connector` and `runtime` uses `tcp protocol,` and the purpose of integration is to reduce serialization and communication consumption. Therefore, interaction needs to be realized in other ways. The method I think is to use the form of service. connector itself only has two roles, `sink` and `source`, which are publish and subscribe in terms of function, so this service needs to use publish and subscribe functions. Meanwhile, in order to preserve the original structure and design to the greatest extent, the connector uses a `tcp adapter` (the adapter does not implement network communication in the middle). Instead, the service is called.) So the design changes are
IInnerPubSubService Indicates the interface of the service
InnerPubSubService implementation
IntegrationCloudEventTCPClientAdapter TCP adapter
Application must have a static variable holding the service
The SinkWorker passes the service to the tcp adapter
SourceWorker transfers the service tcp adapter
其次需要解决的就是原有 `connector` 和 `runtime` 之间的交互使用的是 `tcp协议` 而集成的目的就是减少序列化和通信消耗，所以需要通过其他方式对交互进行实现，我想到的方法是使用服务的形式， `connector` 本身其实只有两种角色，`sink` 和` source` ，从功能来说就是发布和订阅，那么这个服务就需要用发布和订阅的功能即可，同时为了最大程度保留原有结构和设计，使用tcp适配器（适配器中间不在实现网络通信，而是对服务进行调用）所以设计的修改有
IInnerPubSubService 服务的接口
InnerPubSubService 服务的实现
IntegrationCloudEventTCPClientAdapter tcp适配器
Application 要有静态变量持有服务
SinkWorker 传递服务给tcp适配器
SourceWorker 传递服务tcp适配器

--------------------------------------------------------------------------------------------------------------------------------
Unfinished changes:
The implementation of InnerPubSubService
未完成的修改：
`InnerPubSubService` 的具体实现

--------------------------------------------------------------------------------------------------------------------------------
达成的效果：
只要 `gradle` 引用了对应的 `connector`  插件就会自动处理 内嵌 `connector` 相关逻辑 
Results achieved:
The built-in `connector` logic is automatically handled whenever `gradle` references the corresponding ` connector` plug-in

