### PR TITLE
[ISSUE #4805] Rethrow exception in gRPC SDK when publish error occurs

### DIFF
--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/grpc/producer/EventMeshMessageProducer.java
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/grpc/producer/EventMeshMessageProducer.java
@@ -21,6 +21,7 @@ import org.apache.eventmesh.client.grpc.config.EventMeshGrpcClientConfig;
 import org.apache.eventmesh.client.grpc.util.EventMeshCloudEventBuilder;
 import org.apache.eventmesh.common.EventMeshMessage;
 import org.apache.eventmesh.common.enums.EventMeshProtocolType;
+import org.apache.eventmesh.common.exception.EventMeshException;
 import org.apache.eventmesh.common.protocol.grpc.cloudevents.CloudEvent;
 import org.apache.eventmesh.common.protocol.grpc.cloudevents.CloudEventBatch;
 import org.apache.eventmesh.common.protocol.grpc.cloudevents.PublisherServiceGrpc.PublisherServiceBlockingStub;
@@ -49,7 +50,7 @@ public class EventMeshMessageProducer implements GrpcProducer<EventMeshMessage> 
     }
 
     @Override
-    public Response publish(EventMeshMessage message) {
+    public Response publish(EventMeshMessage message) throws EventMeshException {
 
         if (null == message) {
             return null;
@@ -68,12 +69,12 @@ public class EventMeshMessageProducer implements GrpcProducer<EventMeshMessage> 
             return parsedResponse;
         } catch (Exception e) {
             log.error("Error in publishing message {}", message, e);
+            throw new EventMeshException("Error in publishing message {}", e);
         }
-        return null;
     }
 
     @Override
-    public Response publish(List<EventMeshMessage> messages) {
+    public Response publish(List<EventMeshMessage> messages) throws EventMeshException {
 
         if (CollectionUtils.isEmpty(messages)) {
             return null;
@@ -90,12 +91,12 @@ public class EventMeshMessageProducer implements GrpcProducer<EventMeshMessage> 
             return parsedResponse;
         } catch (Exception e) {
             log.error("Error in BatchPublish message {}", messages, e);
+            throw new EventMeshException("Error in BatchPublish message {}", e);
         }
-        return null;
     }
 
     @Override
-    public EventMeshMessage requestReply(EventMeshMessage message, long timeout) {
+    public EventMeshMessage requestReply(EventMeshMessage message, long timeout) throws EventMeshException {
         log.info("RequestReply message:{}", message);
 
         final CloudEvent cloudEvent = EventMeshCloudEventBuilder.buildEventMeshCloudEvent(message, clientConfig, PROTOCOL_TYPE);
@@ -105,7 +106,7 @@ public class EventMeshMessageProducer implements GrpcProducer<EventMeshMessage> 
             return EventMeshCloudEventBuilder.buildMessageFromEventMeshCloudEvent(reply, PROTOCOL_TYPE);
         } catch (Exception e) {
             log.error("Error in RequestReply message {}", message, e);
+            throw new EventMeshException("Error in RequestReply message {}", e);
         }
-        return null;
     }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
-->

Fixes #4805

### Motivation

Please see https://github.com/apache/eventmesh/issues/4805.

### Modifications

Add a new `throws new EventMeshException` statement in the catch block, just like the `org.apache.eventmesh.client.http.AbstractProducerHttpClient#publish` and the `org.apache.eventmesh.client.tcp.impl.eventmeshmessage.EventMeshMessageTCPPubClient#publish` did.

In `eventmesh-sdk-java`, this exception is not handled by the caller of the `publish(EventMeshMessage message)` method. If the exception is rethrown, the user must catch this exception manually.

### Documentation

- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
