### PR TITLE
[ISSUE #4834] Add protocol exclusive fields filter for `/v2/configuration` endpoint

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/JsonUtils.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/utils/JsonUtils.java
@@ -58,7 +58,7 @@ public class JsonUtils {
             return null;
         }
         Object obj = OBJECT_MAPPER.convertValue(map, beanClass);
-        return (T) obj;
+        return beanClass.cast(obj);
     }
     
     /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/AbstractHttpHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/AbstractHttpHandler.java
@@ -35,7 +35,9 @@ import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONWriter;
 
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Data
 public abstract class AbstractHttpHandler implements HttpHandler {
 
@@ -92,25 +94,31 @@ public abstract class AbstractHttpHandler implements HttpHandler {
 
     @Override
     public void handle(HttpRequest httpRequest, ChannelHandlerContext ctx) throws Exception {
-        switch (HttpMethod.valueOf(httpRequest.method().name())) {
-            case OPTIONS:
-                preflight(ctx);
-                break;
-            case GET:
-                get(httpRequest, ctx);
-                break;
-            case POST:
-                post(httpRequest, ctx);
-                break;
-            case PUT:
-                put(httpRequest, ctx);
-                break;
-            case DELETE:
-                delete(httpRequest, ctx);
-                break;
-            default:
-                // do nothing
-                break;
+        try {
+            switch (HttpMethod.valueOf(httpRequest.method().name())) {
+                case OPTIONS:
+                    preflight(ctx);
+                    break;
+                case GET:
+                    get(httpRequest, ctx);
+                    break;
+                case POST:
+                    post(httpRequest, ctx);
+                    break;
+                case PUT:
+                    put(httpRequest, ctx);
+                    break;
+                case DELETE:
+                    delete(httpRequest, ctx);
+                    break;
+                default: // do nothing
+            }
+        } catch (IllegalArgumentException e) {
+            StackTraceElement element = e.getStackTrace()[0];
+            String className = element.getClassName();
+            String handlerName = className.substring(className.lastIndexOf(".") + 1);
+            log.warn("Admin handler {}:{} - {}", handlerName, element.getLineNumber(), e.getMessage());
+            writeBadRequest(ctx, e.getMessage());
         }
     }
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/AdminHandlerManager.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/AdminHandlerManager.java
@@ -58,6 +58,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class AdminHandlerManager {
 
+    private EventMeshServer eventMeshServer;
+
     private EventMeshTCPServer eventMeshTCPServer;
 
     private EventMeshHTTPServer eventMeshHTTPServer;
@@ -71,9 +73,10 @@ public class AdminHandlerManager {
     private final Map<String, HttpHandler> httpHandlerMap = new ConcurrentHashMap<>();
 
     public AdminHandlerManager(EventMeshServer eventMeshServer) {
+        this.eventMeshServer = eventMeshServer;
+        this.eventMeshTCPServer = eventMeshServer.getEventMeshTCPServer();
         this.eventMeshGrpcServer = eventMeshServer.getEventMeshGrpcServer();
         this.eventMeshHTTPServer = eventMeshServer.getEventMeshHTTPServer();
-        this.eventMeshTCPServer = eventMeshServer.getEventMeshTCPServer();
         this.eventMeshMetaStorage = eventMeshServer.getMetaStorage();
         this.adminWebHookConfigOperationManage = eventMeshTCPServer.getAdminWebHookConfigOperationManage();
     }
@@ -112,6 +115,7 @@ public class AdminHandlerManager {
 
         // v2 endpoints
         initHandler(new ConfigurationHandler(
+            eventMeshServer.getConfiguration(),
             eventMeshTCPServer.getEventMeshTCPConfiguration(),
             eventMeshHTTPServer.getEventMeshHttpConfiguration(),
             eventMeshGrpcServer.getEventMeshGrpcConfiguration()));

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/v2/ConfigurationHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/handler/v2/ConfigurationHandler.java
@@ -188,8 +188,8 @@ public class ConfigurationHandler extends AbstractHttpHandler {
                 return field != null;
             } catch (NoSuchFieldException e) {
                 log.error("Failed to get field {} from object {}", name, object, e);
-                return true;
             }
+            return true;
         }
 
         /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/response/v2/GetConfigurationResponse.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/response/v2/GetConfigurationResponse.java
@@ -17,6 +17,7 @@
 
 package org.apache.eventmesh.runtime.admin.response.v2;
 
+import org.apache.eventmesh.common.config.CommonConfiguration;
 import org.apache.eventmesh.runtime.configuration.EventMeshGrpcConfiguration;
 import org.apache.eventmesh.runtime.configuration.EventMeshHTTPConfiguration;
 import org.apache.eventmesh.runtime.configuration.EventMeshTCPConfiguration;
@@ -30,7 +31,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class GetConfigurationResponse {
 
+    private CommonConfiguration commonConfiguration;
     private EventMeshTCPConfiguration eventMeshTCPConfiguration;
     private EventMeshHTTPConfiguration eventMeshHTTPConfiguration;
     private EventMeshGrpcConfiguration eventMeshGrpcConfiguration;
+    private String eventMeshVersion;
 }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
-->

Fixes #4834

### Motivation

Since `EventMeshTCPConfiguration`, `EventMeshHTTPConfiguration` and `EventMeshGrpcConfiguration` are subclasses of `CommonConfiguration`, their serialized JsonString would contain superclass fields, which enlarges the response body and brings in difficulty in getting `CommonConfiguration` fields.

### Modifications

- Add a PropertyFilter to remove superclass fields from the JsonString of `EventMeshTCPConfiguration`, `EventMeshHTTPConfiguration` and `EventMeshGrpcConfiguration`, then add `CommonConfiguration` into the response body.
- Add `configs` param which accepts two values, `exclusive` and `all`.
- Add unified exception handling
- The actual version number will be returned after merging https://github.com/apache/eventmesh/pull/4055.

### Documentation

- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (JavaDocs)
