### PR TITLE
change the null reference to empty object in UrlMappingPattern.java

### DIFF
--- a/eventmesh-admin/eventmesh-admin-rocketmq/src/main/java/org/apache/eventmesh/admin/rocketmq/util/UrlMappingPattern.java
+++ b/eventmesh-admin/eventmesh-admin-rocketmq/src/main/java/org/apache/eventmesh/admin/rocketmq/util/UrlMappingPattern.java
@@ -65,7 +65,7 @@ public class UrlMappingPattern {
         if (matcher.matches()) {
             return extractParameters(matcher);
         }
-        return null;
+        return Collections.emptyMap();
     }
 
     public boolean matches(String url) {


### PR DESCRIPTION
### Motivation
change the null reference to empty object in UrlMappingPattern.java    issue#4136
### Modifications
change return null to a empty map
### Documentation
No
- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
