### PR TITLE
[ISSUE #4963] Updating version of pinpoint libraries to 3.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -749,7 +749,7 @@ subprojects {
             dependency "javax.annotation:javax.annotation-api:1.3.2"
             dependency "com.alibaba.fastjson2:fastjson2:2.0.51"
 
-            dependency "software.amazon.awssdk:s3:2.25.55"
+            dependency "software.amazon.awssdk:s3:2.25.64"
             dependency "com.github.rholder:guava-retrying:2.0.0"
 
             dependency "org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.2"

--- a/eventmesh-trace-plugin/eventmesh-trace-pinpoint/build.gradle
+++ b/eventmesh-trace-plugin/eventmesh-trace-pinpoint/build.gradle
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-def pinpointVersion = "2.4.1"
+def pinpointVersion = "3.0.0"
 
 dependencies {
     implementation project(":eventmesh-trace-plugin:eventmesh-trace-api")

--- a/eventmesh-trace-plugin/eventmesh-trace-pinpoint/src/main/java/org/apache/eventmesh/trace/pinpoint/exporter/PinpointSpanExporter.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-pinpoint/src/main/java/org/apache/eventmesh/trace/pinpoint/exporter/PinpointSpanExporter.java
@@ -26,6 +26,7 @@ import org.apache.eventmesh.common.Constants;
 import org.apache.eventmesh.common.utils.IPUtils;
 import org.apache.eventmesh.common.utils.JsonUtils;
 import org.apache.eventmesh.trace.api.common.EventMeshTraceConstants;
+
 import org.mapstruct.factory.Mappers;
 import org.apache.commons.collections4.CollectionUtils;
 

--- a/eventmesh-trace-plugin/eventmesh-trace-pinpoint/src/main/java/org/apache/eventmesh/trace/pinpoint/exporter/PinpointSpanExporter.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-pinpoint/src/main/java/org/apache/eventmesh/trace/pinpoint/exporter/PinpointSpanExporter.java
@@ -27,7 +27,6 @@ import org.apache.eventmesh.common.utils.IPUtils;
 import org.apache.eventmesh.common.utils.JsonUtils;
 import org.apache.eventmesh.trace.api.common.EventMeshTraceConstants;
 
-import org.mapstruct.factory.Mappers;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.Collection;
@@ -40,6 +39,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+
+import org.mapstruct.factory.Mappers;
 
 import io.grpc.NameResolverProvider;
 import io.opentelemetry.api.common.Attributes;

--- a/eventmesh-trace-plugin/eventmesh-trace-pinpoint/src/test/java/org/apache/eventmesh/trace/pinpoint/exporter/PinpointSpanExporterTest.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-pinpoint/src/test/java/org/apache/eventmesh/trace/pinpoint/exporter/PinpointSpanExporterTest.java
@@ -15,170 +15,170 @@
  * limitations under the License.
  */
 
- package org.apache.eventmesh.trace.pinpoint.exporter;
+package org.apache.eventmesh.trace.pinpoint.exporter;
 
- import org.apache.eventmesh.common.utils.RandomStringUtils;
- import org.apache.eventmesh.trace.api.TracePluginFactory;
- import org.apache.eventmesh.trace.pinpoint.PinpointTraceService;
- import org.apache.eventmesh.trace.pinpoint.config.PinpointConfiguration;
+import org.apache.eventmesh.common.utils.RandomStringUtils;
+import org.apache.eventmesh.trace.api.TracePluginFactory;
+import org.apache.eventmesh.trace.pinpoint.PinpointTraceService;
+import org.apache.eventmesh.trace.pinpoint.config.PinpointConfiguration;
  
-  import java.util.ArrayList;
- import java.util.Collection;
- import java.util.List;
- import java.util.UUID;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
  
- import org.junit.jupiter.api.Assertions;
- import org.junit.jupiter.api.BeforeEach;
- import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
  
- import io.opentelemetry.api.common.Attributes;
- import io.opentelemetry.api.trace.SpanContext;
- import io.opentelemetry.api.trace.SpanKind;
- import io.opentelemetry.api.trace.TraceFlags;
- import io.opentelemetry.api.trace.TraceState;
- import io.opentelemetry.sdk.common.CompletableResultCode;
- import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
- import io.opentelemetry.sdk.resources.Resource;
- import io.opentelemetry.sdk.trace.data.EventData;
- import io.opentelemetry.sdk.trace.data.LinkData;
- import io.opentelemetry.sdk.trace.data.SpanData;
- import io.opentelemetry.sdk.trace.data.StatusData;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
  
- public class PinpointSpanExporterTest {
- 
-     private PinpointSpanExporter exporter;
-     public static final String AGENT_ID = "test";
- 
-     @BeforeEach
-     public void setup() {
-         PinpointTraceService pinpointTrace =
-             (PinpointTraceService) TracePluginFactory.getEventMeshTraceService("pinpoint");
- 
-         PinpointConfiguration config = pinpointTrace.getClientConfiguration();
- 
-         this.exporter = new PinpointSpanExporter(
-             config.getAgentId(),
-             config.getAgentName(),
-             config.getApplicationName(),
-             config.getGrpcTransportConfig());
-     }
- 
-     @Test
-     public void exportTest() {
-         Collection<SpanData> spans = new ArrayList<>();
-         Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
- 
-         spans.add(null);
-         Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
- 
-         spans.clear();
-         spans.add(new SpanDateTest());
-         Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
+public class PinpointSpanExporterTest {
 
-         spans.clear();
-         spans.add(new SpanDateTest());
-         spans.add(new ChildSpanDateTest());
-         Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
-     }
- 
-     @Test
-     public void flushTest() {
-         Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.flush());
-     }
- 
-     @Test
-     public void shutdownTest() {
-         Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.shutdown());
-     }
- 
-     /**
-      * for test
-      */
-     private static class SpanDateTest implements SpanData {
- 
-         @Override
-         public SpanContext getSpanContext() {
-             return new SpanContextTest();
-         }
- 
-         @Override
-         public SpanContext getParentSpanContext() {
-             return null;
-         }
- 
-         @Override
-         public Resource getResource() {
-             return null;
-         }
- 
-         @Override
-         public InstrumentationLibraryInfo getInstrumentationLibraryInfo() {
-             return null;
-         }
- 
-         @Override
-         public String getName() {
-             return this.getClass().getName();
-         }
- 
-         @Override
-         public SpanKind getKind() {
-             return SpanKind.INTERNAL;
-         }
- 
-         @Override
-         public long getStartEpochNanos() {
-             return System.nanoTime();
-         }
- 
-         @Override
-         public Attributes getAttributes() {
-             return null;
-         }
- 
-         @Override
-         public List<EventData> getEvents() {
-             return null;
-         }
- 
-         @Override
-         public List<LinkData> getLinks() {
-             return null;
-         }
- 
-         @Override
-         public StatusData getStatus() {
-             return StatusData.ok();
-         }
- 
-         @Override
-         public long getEndEpochNanos() {
-             return System.nanoTime();
-         }
- 
-         @Override
-         public boolean hasEnded() {
-             return true;
-         }
- 
-         @Override
-         public int getTotalRecordedEvents() {
-             return 0;
-         }
- 
-         @Override
-         public int getTotalRecordedLinks() {
-             return 0;
-         }
- 
-         @Override
-         public int getTotalAttributeCount() {
-             return 0;
-         }
-     }
+    private PinpointSpanExporter exporter;
+    public static final String AGENT_ID = "test";
 
-     private static class ChildSpanDateTest implements SpanData {
- 
+    @BeforeEach
+    public void setup() {
+        PinpointTraceService pinpointTrace =
+            (PinpointTraceService) TracePluginFactory.getEventMeshTraceService("pinpoint");
+
+        PinpointConfiguration config = pinpointTrace.getClientConfiguration();
+
+        this.exporter = new PinpointSpanExporter(
+            config.getAgentId(),
+            config.getAgentName(),
+            config.getApplicationName(),
+            config.getGrpcTransportConfig());
+    }
+
+    @Test
+    public void exportTest() {
+        Collection<SpanData> spans = new ArrayList<>();
+        Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
+
+        spans.add(null);
+        Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
+
+        spans.clear();
+        spans.add(new SpanDateTest());
+        Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
+
+        spans.clear();
+        spans.add(new SpanDateTest());
+        spans.add(new ChildSpanDateTest());
+        Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
+    }
+
+    @Test
+    public void flushTest() {
+        Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.flush());
+    }
+
+    @Test
+    public void shutdownTest() {
+        Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.shutdown());
+    }
+
+    /**
+     * for test
+    */
+    private static class SpanDateTest implements SpanData {
+
+        @Override
+        public SpanContext getSpanContext() {
+            return new SpanContextTest();
+        }
+
+        @Override
+        public SpanContext getParentSpanContext() {
+            return null;
+        }
+
+        @Override
+        public Resource getResource() {
+            return null;
+        }
+
+        @Override
+        public InstrumentationLibraryInfo getInstrumentationLibraryInfo() {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return this.getClass().getName();
+        }
+
+        @Override
+        public SpanKind getKind() {
+            return SpanKind.INTERNAL;
+        }
+
+        @Override
+        public long getStartEpochNanos() {
+            return System.nanoTime();
+        }
+
+        @Override
+        public Attributes getAttributes() {
+            return null;
+        }
+
+        @Override
+        public List<EventData> getEvents() {
+            return null;
+        }
+
+        @Override
+        public List<LinkData> getLinks() {
+            return null;
+        }
+
+        @Override
+        public StatusData getStatus() {
+            return StatusData.ok();
+        }
+
+        @Override
+        public long getEndEpochNanos() {
+            return System.nanoTime();
+        }
+
+        @Override
+        public boolean hasEnded() {
+            return true;
+        }
+
+        @Override
+        public int getTotalRecordedEvents() {
+            return 0;
+        }
+
+        @Override
+        public int getTotalRecordedLinks() {
+            return 0;
+        }
+
+        @Override
+        public int getTotalAttributeCount() {
+            return 0;
+        }
+    }
+
+    private static class ChildSpanDateTest implements SpanData {
+
         @Override
         public SpanContext getSpanContext() {
             return new SpanContextTest();
@@ -259,33 +259,32 @@
             return 0;
         }
     }
- 
-     private static class SpanContextTest implements SpanContext {
- 
-         @Override
-         public String getTraceId() {
-             return UUID.randomUUID().toString();
-         }
- 
-         @Override
-         public String getSpanId() {
-             return RandomStringUtils.generateNum(16);
-         }
- 
-         @Override
-         public TraceFlags getTraceFlags() {
-             return null;
-         }
- 
-         @Override
-         public TraceState getTraceState() {
-             return TraceState.getDefault();
-         }
- 
-         @Override
-         public boolean isRemote() {
-             return false;
-         }
-     }
- }
- 
+
+    private static class SpanContextTest implements SpanContext {
+
+        @Override
+        public String getTraceId() {
+            return UUID.randomUUID().toString();
+        }
+
+        @Override
+        public String getSpanId() {
+            return RandomStringUtils.generateNum(16);
+        }
+
+        @Override
+        public TraceFlags getTraceFlags() {
+            return null;
+        }
+
+        @Override
+        public TraceState getTraceState() {
+            return TraceState.getDefault();
+        }
+
+        @Override
+        public boolean isRemote() {
+            return false;
+        }
+    }
+}

--- a/eventmesh-trace-plugin/eventmesh-trace-pinpoint/src/test/java/org/apache/eventmesh/trace/pinpoint/exporter/PinpointSpanExporterTest.java
+++ b/eventmesh-trace-plugin/eventmesh-trace-pinpoint/src/test/java/org/apache/eventmesh/trace/pinpoint/exporter/PinpointSpanExporterTest.java
@@ -15,81 +15,170 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.trace.pinpoint.exporter;
+ package org.apache.eventmesh.trace.pinpoint.exporter;
 
-import org.apache.eventmesh.common.utils.RandomStringUtils;
-import org.apache.eventmesh.trace.api.TracePluginFactory;
-import org.apache.eventmesh.trace.pinpoint.PinpointTraceService;
-import org.apache.eventmesh.trace.pinpoint.config.PinpointConfiguration;
+ import org.apache.eventmesh.common.utils.RandomStringUtils;
+ import org.apache.eventmesh.trace.api.TracePluginFactory;
+ import org.apache.eventmesh.trace.pinpoint.PinpointTraceService;
+ import org.apache.eventmesh.trace.pinpoint.config.PinpointConfiguration;
+ 
+  import java.util.ArrayList;
+ import java.util.Collection;
+ import java.util.List;
+ import java.util.UUID;
+ 
+ import org.junit.jupiter.api.Assertions;
+ import org.junit.jupiter.api.BeforeEach;
+ import org.junit.jupiter.api.Test;
+ 
+ import io.opentelemetry.api.common.Attributes;
+ import io.opentelemetry.api.trace.SpanContext;
+ import io.opentelemetry.api.trace.SpanKind;
+ import io.opentelemetry.api.trace.TraceFlags;
+ import io.opentelemetry.api.trace.TraceState;
+ import io.opentelemetry.sdk.common.CompletableResultCode;
+ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+ import io.opentelemetry.sdk.resources.Resource;
+ import io.opentelemetry.sdk.trace.data.EventData;
+ import io.opentelemetry.sdk.trace.data.LinkData;
+ import io.opentelemetry.sdk.trace.data.SpanData;
+ import io.opentelemetry.sdk.trace.data.StatusData;
+ 
+ public class PinpointSpanExporterTest {
+ 
+     private PinpointSpanExporter exporter;
+     public static final String AGENT_ID = "test";
+ 
+     @BeforeEach
+     public void setup() {
+         PinpointTraceService pinpointTrace =
+             (PinpointTraceService) TracePluginFactory.getEventMeshTraceService("pinpoint");
+ 
+         PinpointConfiguration config = pinpointTrace.getClientConfiguration();
+ 
+         this.exporter = new PinpointSpanExporter(
+             config.getAgentId(),
+             config.getAgentName(),
+             config.getApplicationName(),
+             config.getGrpcTransportConfig());
+     }
+ 
+     @Test
+     public void exportTest() {
+         Collection<SpanData> spans = new ArrayList<>();
+         Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
+ 
+         spans.add(null);
+         Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
+ 
+         spans.clear();
+         spans.add(new SpanDateTest());
+         Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.UUID;
+         spans.clear();
+         spans.add(new SpanDateTest());
+         spans.add(new ChildSpanDateTest());
+         Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
+     }
+ 
+     @Test
+     public void flushTest() {
+         Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.flush());
+     }
+ 
+     @Test
+     public void shutdownTest() {
+         Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.shutdown());
+     }
+ 
+     /**
+      * for test
+      */
+     private static class SpanDateTest implements SpanData {
+ 
+         @Override
+         public SpanContext getSpanContext() {
+             return new SpanContextTest();
+         }
+ 
+         @Override
+         public SpanContext getParentSpanContext() {
+             return null;
+         }
+ 
+         @Override
+         public Resource getResource() {
+             return null;
+         }
+ 
+         @Override
+         public InstrumentationLibraryInfo getInstrumentationLibraryInfo() {
+             return null;
+         }
+ 
+         @Override
+         public String getName() {
+             return this.getClass().getName();
+         }
+ 
+         @Override
+         public SpanKind getKind() {
+             return SpanKind.INTERNAL;
+         }
+ 
+         @Override
+         public long getStartEpochNanos() {
+             return System.nanoTime();
+         }
+ 
+         @Override
+         public Attributes getAttributes() {
+             return null;
+         }
+ 
+         @Override
+         public List<EventData> getEvents() {
+             return null;
+         }
+ 
+         @Override
+         public List<LinkData> getLinks() {
+             return null;
+         }
+ 
+         @Override
+         public StatusData getStatus() {
+             return StatusData.ok();
+         }
+ 
+         @Override
+         public long getEndEpochNanos() {
+             return System.nanoTime();
+         }
+ 
+         @Override
+         public boolean hasEnded() {
+             return true;
+         }
+ 
+         @Override
+         public int getTotalRecordedEvents() {
+             return 0;
+         }
+ 
+         @Override
+         public int getTotalRecordedLinks() {
+             return 0;
+         }
+ 
+         @Override
+         public int getTotalAttributeCount() {
+             return 0;
+         }
+     }
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.trace.SpanContext;
-import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.api.trace.TraceFlags;
-import io.opentelemetry.api.trace.TraceState;
-import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.sdk.trace.data.EventData;
-import io.opentelemetry.sdk.trace.data.LinkData;
-import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.sdk.trace.data.StatusData;
-
-public class PinpointSpanExporterTest {
-
-    private PinpointSpanExporter exporter;
-
-    @BeforeEach
-    public void setup() {
-        PinpointTraceService pinpointTrace =
-            (PinpointTraceService) TracePluginFactory.getEventMeshTraceService("pinpoint");
-
-        PinpointConfiguration config = pinpointTrace.getClientConfiguration();
-
-        this.exporter = new PinpointSpanExporter(
-            config.getAgentId(),
-            config.getAgentName(),
-            config.getApplicationName(),
-            config.getGrpcTransportConfig());
-    }
-
-    @Test
-    public void exportTest() {
-        Collection<SpanData> spans = new ArrayList<>();
-        Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
-
-        spans.add(null);
-        Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
-
-        spans.clear();
-        spans.add(new SpanDateTest());
-        Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.export(spans));
-    }
-
-    @Test
-    public void flushTest() {
-        Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.flush());
-    }
-
-    @Test
-    public void shutdownTest() {
-        Assertions.assertEquals(CompletableResultCode.ofSuccess(), exporter.shutdown());
-    }
-
-    /**
-     * for test
-     */
-    private static class SpanDateTest implements SpanData {
-
+     private static class ChildSpanDateTest implements SpanData {
+ 
         @Override
         public SpanContext getSpanContext() {
             return new SpanContextTest();
@@ -97,7 +186,7 @@ public class PinpointSpanExporterTest {
 
         @Override
         public SpanContext getParentSpanContext() {
-            return null;
+            return new SpanContextTest();
         }
 
         @Override
@@ -170,32 +259,33 @@ public class PinpointSpanExporterTest {
             return 0;
         }
     }
-
-    private static class SpanContextTest implements SpanContext {
-
-        @Override
-        public String getTraceId() {
-            return UUID.randomUUID().toString();
-        }
-
-        @Override
-        public String getSpanId() {
-            return RandomStringUtils.generateNum(16);
-        }
-
-        @Override
-        public TraceFlags getTraceFlags() {
-            return null;
-        }
-
-        @Override
-        public TraceState getTraceState() {
-            return TraceState.getDefault();
-        }
-
-        @Override
-        public boolean isRemote() {
-            return false;
-        }
-    }
-}
+ 
+     private static class SpanContextTest implements SpanContext {
+ 
+         @Override
+         public String getTraceId() {
+             return UUID.randomUUID().toString();
+         }
+ 
+         @Override
+         public String getSpanId() {
+             return RandomStringUtils.generateNum(16);
+         }
+ 
+         @Override
+         public TraceFlags getTraceFlags() {
+             return null;
+         }
+ 
+         @Override
+         public TraceState getTraceState() {
+             return TraceState.getDefault();
+         }
+ 
+         @Override
+         public boolean isRemote() {
+             return false;
+         }
+     }
+ }
+ 


### PR DESCRIPTION
Fixes #4963

### Motivation

Upgrading version of the Pinpoint libraries to the latest version (some deprecated functionality had been removed in the 3.0.0 release so updates were necessary.

### Modifications
- Updated the libraries to 3.0.0 version of the pinpoint-profiler libraries in support of the associated trace plugin.
- Added case to unit test to validate that parent span information was passed correctly.

### Documentation

- Does this pull request introduce a new feature? No
- If yes, how is the feature documented? NA
- If a feature is not applicable for documentation, explain why? Library upgrade, no docs required.
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
