### PR TITLE
[ISSUE #5105] Fix the retry mechanism of the HttpSinkConnector

### DIFF
--- a/eventmesh-connectors/eventmesh-connector-http/src/main/java/org/apache/eventmesh/connector/http/sink/data/MultiHttpRequestContext.java
+++ b/eventmesh-connectors/eventmesh-connector-http/src/main/java/org/apache/eventmesh/connector/http/sink/data/MultiHttpRequestContext.java
@@ -34,10 +34,9 @@ public class MultiHttpRequestContext {
 
     /**
      * The last failed event.
-     * If there are no retries or retries are not enabled, it will be null.
      * If retries occur but still fail, it will be logged, and only the last one will be retained.
      */
-    private HttpRetryEvent lastFailedEvent;
+    private HttpAttemptEvent lastFailedEvent;
 
     public MultiHttpRequestContext(int remainingEvents) {
         this.remainingRequests = new AtomicInteger(remainingEvents);
@@ -50,15 +49,24 @@ public class MultiHttpRequestContext {
         remainingRequests.decrementAndGet();
     }
 
+    /**
+     * Check if all requests have been processed.
+     *
+     * @return true if all requests have been processed, false otherwise.
+     */
+    public boolean isAllRequestsProcessed() {
+        return remainingRequests.get() == 0;
+    }
+
     public int getRemainingRequests() {
         return remainingRequests.get();
     }
 
-    public HttpRetryEvent getLastFailedEvent() {
+    public HttpAttemptEvent getLastFailedEvent() {
         return lastFailedEvent;
     }
 
-    public void setLastFailedEvent(HttpRetryEvent lastFailedEvent) {
+    public void setLastFailedEvent(HttpAttemptEvent lastFailedEvent) {
         this.lastFailedEvent = lastFailedEvent;
     }
 }

--- a/eventmesh-connectors/eventmesh-connector-http/src/main/java/org/apache/eventmesh/connector/http/sink/handler/AbstractHttpSinkHandler.java
+++ b/eventmesh-connectors/eventmesh-connector-http/src/main/java/org/apache/eventmesh/connector/http/sink/handler/AbstractHttpSinkHandler.java
@@ -18,8 +18,8 @@
 package org.apache.eventmesh.connector.http.sink.handler;
 
 import org.apache.eventmesh.common.config.connector.http.SinkConnectorConfig;
+import org.apache.eventmesh.connector.http.sink.data.HttpAttemptEvent;
 import org.apache.eventmesh.connector.http.sink.data.HttpConnectRecord;
-import org.apache.eventmesh.connector.http.sink.data.HttpRetryEvent;
 import org.apache.eventmesh.connector.http.sink.data.MultiHttpRequestContext;
 import org.apache.eventmesh.openconnect.offsetmgmt.api.data.ConnectRecord;
 
@@ -75,10 +75,9 @@ public abstract class AbstractHttpSinkHandler implements HttpSinkHandler {
                 this.sinkConnectorConfig.getWebhookConfig().isActivate() ? "webhook" : "common");
             HttpConnectRecord httpConnectRecord = HttpConnectRecord.convertConnectRecord(record, type);
 
-            // add retry event to attributes
-            HttpRetryEvent retryEvent = new HttpRetryEvent();
-            retryEvent.setMaxRetries(sinkConnectorConfig.getRetryConfig().getMaxRetries());
-            attributes.put(HttpRetryEvent.PREFIX + httpConnectRecord.getHttpRecordId(), retryEvent);
+            // add AttemptEvent to the attributes
+            HttpAttemptEvent attemptEvent = new HttpAttemptEvent(this.sinkConnectorConfig.getRetryConfig().getMaxRetries() + 1);
+            attributes.put(HttpAttemptEvent.PREFIX + httpConnectRecord.getHttpRecordId(), attemptEvent);
 
             // deliver the record
             deliver(url, httpConnectRecord, attributes, record);

--- a/eventmesh-connectors/eventmesh-connector-http/src/test/java/org/apache/eventmesh/connector/http/sink/HttpSinkConnectorTest.java
+++ b/eventmesh-connectors/eventmesh-connector-http/src/test/java/org/apache/eventmesh/connector/http/sink/HttpSinkConnectorTest.java
@@ -83,14 +83,12 @@ public class HttpSinkConnectorTest {
                 httpRequest -> {
                     // Increase the number of requests received
                     counter.incrementAndGet();
-                    JSONObject requestBody = JSON.parseObject(httpRequest.getBodyAsString());
                     return HttpResponse.response()
                         .withContentType(MediaType.APPLICATION_JSON)
                         .withStatusCode(HttpStatus.SC_OK)
                         .withBody(new JSONObject()
                             .fluentPut("code", 0)
                             .fluentPut("message", "success")
-                            .fluentPut("data", requestBody.getJSONObject("data").get("data"))
                             .toJSONString()
                         ); // .withDelay(TimeUnit.SECONDS, 10);
                 }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
-->

Fixes #5105 

### Motivation

Due to the lack of communication between the retry callback and the response callback mechanism, the result after a retry failure is not handled correctly.

### Modifications

Move all data processing originally performed in the retry callback to the response callback handling of Vert.x.

### Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- If a feature is not applicable for documentation, explain why?
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
