### PR TITLE
[ISSUE #4990] Add unit test for HttpConvertsUtils.java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -794,7 +794,7 @@ subprojects {
             dependency "javax.annotation:javax.annotation-api:1.3.2"
             dependency "com.alibaba.fastjson2:fastjson2:2.0.52"
 
-            dependency "software.amazon.awssdk:s3:2.27.17"
+            dependency "software.amazon.awssdk:s3:2.28.12"
             dependency "com.github.rholder:guava-retrying:2.0.0"
 
             dependency "com.alibaba:druid-spring-boot-starter:1.2.23"

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/stubs/HeaderStub.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/stubs/HeaderStub.java
@@ -14,7 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.eventmesh.common.stubs;
+
 import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.http.header.Header;
 import org.apache.eventmesh.common.utils.HttpConvertsUtils;

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/stubs/HeaderStub.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/stubs/HeaderStub.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+package org.apache.eventmesh.common.stubs;
 import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
 import org.apache.eventmesh.common.protocol.http.header.Header;
 import org.apache.eventmesh.common.utils.HttpConvertsUtils;

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/stubs/HeaderStub.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/stubs/HeaderStub.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
+import org.apache.eventmesh.common.protocol.http.header.Header;
+import org.apache.eventmesh.common.utils.HttpConvertsUtils;
+
+import java.util.Map;
+
+public class HeaderStub extends Header {
+
+    public String code;
+    public String eventmeshenv;
+
+    @Override
+    public Map<String, Object> toMap() {
+        return new HttpConvertsUtils().httpMapConverts(this, new ProtocolKey(), new ProtocolKey.EventMeshInstanceKey());
+    }
+}

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/HttpConvertsUtilsTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/HttpConvertsUtilsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.common.utils;
+
+import org.apache.eventmesh.common.protocol.http.common.ProtocolKey;
+import org.apache.eventmesh.common.protocol.http.common.ProtocolKey.EventMeshInstanceKey;
+import org.apache.eventmesh.common.protocol.http.header.Header;
+import org.apache.eventmesh.common.stubs.HeaderStub;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class HttpConvertsUtilsTest {
+
+    private final HeaderStub headerStub = new HeaderStub();
+    private final ProtocolKey mockedProtocolKey = new ProtocolKey();
+    private final EventMeshInstanceKey mockedEventMeshProtocolKey = new EventMeshInstanceKey();
+
+    @Test
+    void httpMapConverts() {
+        Map<String, Object> httpMapConverts = new HttpConvertsUtils().httpMapConverts(headerStub, mockedProtocolKey);
+        Assertions.assertEquals(httpMapConverts.get(headerStub.code), headerStub.code);
+    }
+
+    @Test
+    void testHttpMapConverts() {
+        Map<String, Object> httpMapConverts = new HttpConvertsUtils().httpMapConverts(headerStub, mockedProtocolKey, mockedEventMeshProtocolKey);
+        Assertions.assertEquals(httpMapConverts.get(headerStub.code), headerStub.code);
+        Assertions.assertEquals(httpMapConverts.get(headerStub.eventmeshenv), headerStub.eventmeshenv);
+    }
+
+    @Test
+    void httpHeaderConverts() {
+        HashMap<String, Object> headerParams = new HashMap<>();
+        String code = "test";
+        headerParams.put("code", code);
+        Header header = new HttpConvertsUtils().httpHeaderConverts(headerStub, headerParams);
+        Assertions.assertEquals(code, header.toMap().get("code"));
+    }
+
+    @Test
+    void testHttpHeaderConverts() {
+        HashMap<String, Object> headerParams = new HashMap<>();
+        String env = "test";
+        headerParams.put("eventmeshenv", env);
+        Header header = new HttpConvertsUtils().httpHeaderConverts(headerStub, headerParams, mockedEventMeshProtocolKey);
+        Assertions.assertEquals(env, header.toMap().get("eventmeshenv"));
+    }
+}

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/ThreadUtilsTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/utils/ThreadUtilsTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.eventmesh.common.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+class ThreadUtilsTest {
+
+    @Test
+    void testRandomPauseBetweenMinAndMax() {
+
+        long min = 1000;
+        long max = 5000;
+
+        long start = System.currentTimeMillis();
+        ThreadUtils.randomPause(min, max, TimeUnit.MILLISECONDS);
+        long end = System.currentTimeMillis();
+
+        long pause = end - start;
+
+        assertTrue(pause >= min && pause <= max, "Pause time should be between min and max");
+    }
+
+    @Test
+    void testRandomPauseWithInterruption() {
+
+        Thread.currentThread().interrupt();
+        ThreadUtils.randomPause(1000, 2000, TimeUnit.MILLISECONDS);
+        assertTrue(Thread.currentThread().isInterrupted());
+    }
+
+    @Test
+    void testDeprecatedSleep() {
+
+        ThreadUtils.sleep(1000);
+        assertTrue(true, "Method should execute without any exception");
+    }
+
+    @Test
+    void testSleepWithTimeOutAndTimeUnit() throws InterruptedException {
+
+        ThreadUtils.sleepWithThrowException(5000, TimeUnit.MILLISECONDS);
+        assertTrue(true, "Method should execute without any exception");
+    }
+
+    @Test
+    void testSleepWithNullTimeUnit() throws InterruptedException {
+
+        ThreadUtils.sleepWithThrowException(5000, null);
+        assertTrue(true, "Method should not throw any exception with null TimeUnit");
+    }
+
+    @Test
+    void testSleepWithThrowExceptionInterruption() {
+        Thread.currentThread().interrupt();
+
+        assertThrows(InterruptedException.class, () -> {
+            ThreadUtils.sleepWithThrowException(5000, TimeUnit.MILLISECONDS);
+        });
+    }
+
+    @Test
+    void testGetPIDWithRealProcessId() {
+
+        long pid = ThreadUtils.getPID();
+        assertTrue(pid > 0);
+
+        long cashedPId = ThreadUtils.getPID();
+        assertEquals(pid, cashedPId);
+    }
+
+    @Test
+    void testGetPIDWithMultiThread() throws InterruptedException {
+
+        final long[] pid1 = new long[1];
+        final long[] pid2 = new long[1];
+
+        Thread thread1 = new Thread(() -> {
+            pid1[0] = ThreadUtils.getPID();
+            assertTrue(pid1[0] > 0);
+        });
+
+        Thread thread2 = new Thread(() -> {
+            pid2[0] = ThreadUtils.getPID();
+            assertTrue(pid2[0] > 0);
+        });
+
+        thread1.start();
+        thread2.start();
+
+        thread1.join();
+        thread2.join();
+
+        assertEquals(pid1[0], pid2[0]);
+    }
+}

--- a/eventmesh-connectors/eventmesh-connector-rabbitmq/build.gradle
+++ b/eventmesh-connectors/eventmesh-connector-rabbitmq/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     api project(":eventmesh-openconnect:eventmesh-openconnect-java")
     implementation project(":eventmesh-common")
     // rabbitmq
-    implementation 'com.rabbitmq:amqp-client:5.21.0'
+    implementation 'com.rabbitmq:amqp-client:5.22.0'
 
     implementation 'io.cloudevents:cloudevents-json-jackson'
 

--- a/eventmesh-storage-plugin/eventmesh-storage-rabbitmq/build.gradle
+++ b/eventmesh-storage-plugin/eventmesh-storage-rabbitmq/build.gradle
@@ -19,12 +19,12 @@ dependencies {
     implementation project(":eventmesh-storage-plugin:eventmesh-storage-api")
     implementation project(":eventmesh-common")
     // rabbitmq
-    implementation 'com.rabbitmq:amqp-client:5.21.0'
+    implementation 'com.rabbitmq:amqp-client:5.22.0'
 
     testImplementation project(":eventmesh-storage-plugin:eventmesh-storage-api")
     testImplementation project(":eventmesh-common")
     // rabbitmq
-    testImplementation 'com.rabbitmq:amqp-client:5.21.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.22.0'
 
     implementation 'io.cloudevents:cloudevents-json-jackson'
     testImplementation 'io.cloudevents:cloudevents-json-jackson'

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id 'com.gradle.develocity' version '3.17.5'
+    id 'com.gradle.develocity' version '3.18.1'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
 }
 


### PR DESCRIPTION
Fixes #4990 

### Motivation

`HttpConvertsUtils.java` at `eventmesh-common/src/test/java/org/apache/eventmesh/common/utils` do not have its unit test, and the test coverage needs to be expanded.

### Modifications

Added `HttpConvertsUtilsTest.java` located at `eventmesh-runtime/src/test/java/org/apache/eventmesh/common/util`

### Documentation

- Does this pull request introduce a new feature?   no
- If yes, how is the feature documented?   not applicable
