### PR TITLE
Publish build scans to develocity.apache.org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: GenerateGrammarSource
         run: ./gradlew clean generateGrammarSource --parallel --daemon --scan
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
@@ -72,12 +72,12 @@ jobs:
           ./gradlew clean build dist jacocoTestReport --parallel --daemon --scan
           -x spotlessJava -x generateGrammarSource -x generateDistLicense -x checkDeniedLicense
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Install plugin
         run: ./gradlew installPlugin --scan
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Upload coverage report to codecov.io
         run: bash <(curl -s https://codecov.io/bash) || echo 'Failed to upload coverage report!'

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -68,7 +68,7 @@ jobs:
         if: matrix.language == 'java'
         run: ./gradlew clean assemble compileTestJava --parallel --daemon --scan
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v3

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id 'com.gradle.develocity' version '3.18.1'
+    id 'com.gradle.develocity' version '3.18.2'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
 }
 
@@ -26,7 +26,7 @@ develocity {
     server = "https://develocity.apache.org"
     buildScan {
         uploadInBackground = !isCiServer
-        publishing.onlyIf { false }
+        publishing.onlyIf { it.isAuthenticated() }
         obfuscation {
             ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,6 +24,7 @@ def isCiServer = System.getenv().containsKey("CI")
 
 develocity {
     server = "https://develocity.apache.org"
+    projectId = "eventmesh"
     buildScan {
         uploadInBackground = !isCiServer
         publishing.onlyIf { it.isAuthenticated() }

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,7 +23,7 @@ plugins {
 def isCiServer = System.getenv().containsKey("CI")
 
 develocity {
-    server = "https://ge.apache.org"
+    server = "https://develocity.apache.org"
     buildScan {
         uploadInBackground = !isCiServer
         publishing.onlyIf { false }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Name the pull request in the form "[ISSUE #XXXX] Title of the pull request", 
    where *XXXX* should be replaced by the actual issue number.
    Skip *[ISSUE #XXXX]* if there is no associated github issue for this pull request.

  - Fill out the template below to describe the changes contributed by the pull request. 
    That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue. 
    Please do not mix up code from multiple issues.
  
  - Each commit in the pull request should have a meaningful commit message.

  - Once all items of the checklist are addressed, remove the above text and this checklist, 
    leaving only the filled out template below.

(The sections below can be removed for hotfixes of typos)
-->

<!--
(If this PR fixes a GitHub issue, please add `Fixes #<XXX>` or `Closes #<XXX>`.)
-->

Fixes #5164 

### Motivation

ge.apache.org is migrating to develocity.apache.org

### Modifications

This PR migrates the EventMesh project to publish Build Scans to the the new Develocity instance at develocity.apache.org.

Additionally, this PR sets a projectId for use by Develocity.

### Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
- If a feature is not applicable for documentation, explain why? build-related
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
