### PR TITLE
Fix #5205: Handle invalid SubscriptionMode values safely

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/SubscriptionModeConverter.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/SubscriptionModeConverter.java
@@ -25,7 +25,14 @@ public class SubscriptionModeConverter implements Converter<String, Subscription
 
     @Override
     public SubscriptionMode convert(String value) {
-        return SubscriptionMode.valueOf(value);
+       if(value==null || value.trim().isEmpty()){
+        return null;
+       }
+       try{
+        return SubscriptionMode.valueOf(value.trim().toUpperCase());
+       }catch (IllegalArgumentException e ){
+          return null;
+       }
     }
 
     @Override

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/SubscriptionModeConverter.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/protocol/SubscriptionModeConverter.java
@@ -26,12 +26,12 @@ public class SubscriptionModeConverter implements Converter<String, Subscription
     @Override
     public SubscriptionMode convert(String value) {
        if(value==null || value.trim().isEmpty()){
-        return null;
+        return SubscriptionMode.UNRECOGNIZED;
        }
        try{
         return SubscriptionMode.valueOf(value.trim().toUpperCase());
        }catch (IllegalArgumentException e ){
-          return null;
+         return SubscriptionMode.UNRECOGNIZED;
        }
     }
 

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/SubscriptionModeConverterTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/SubscriptionModeConverterTest.java
@@ -1,0 +1,42 @@
+package org.apache.eventmesh.common.protocol;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SubscriptionModeConverterTest {
+
+    private final SubscriptionModeConverter converter =
+            new SubscriptionModeConverter();
+
+    @Test
+    public void testNullValue() {
+        assertNull(converter.convert(null));
+    }
+
+    @Test
+    public void testEmptyValue() {
+        assertNull(converter.convert(""));
+    }
+
+    @Test
+    public void testInvalidValue() {
+        assertNull(converter.convert("invalid_value"));
+    }
+
+    @Test
+    public void testLowerCaseValue() {
+        assertEquals(
+                SubscriptionMode.CLUSTERING,
+                converter.convert("clustering")
+        );
+    }
+
+    @Test
+    public void testUpperCaseValue() {
+        assertEquals(
+                SubscriptionMode.BROADCASTING,
+                converter.convert("BROADCASTING")
+        );
+    }
+}

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/SubscriptionModeConverterTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/protocol/SubscriptionModeConverterTest.java
@@ -2,41 +2,45 @@ package org.apache.eventmesh.common.protocol;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SubscriptionModeConverterTest {
 
-    private final SubscriptionModeConverter converter =
-            new SubscriptionModeConverter();
+    private final SubscriptionModeConverter converter = new SubscriptionModeConverter();
+
+    @Test
+    public void testValidBroadcasting() {
+        SubscriptionMode result = converter.convert("BROADCASTING");
+        assertEquals(SubscriptionMode.BROADCASTING, result);
+    }
+
+    @Test
+    public void testValidClusteringLowerCase() {
+        SubscriptionMode result = converter.convert("clustering");
+        assertEquals(SubscriptionMode.CLUSTERING, result);
+    }
+
+    @Test
+    public void testValidWithSpaces() {
+        SubscriptionMode result = converter.convert("  broadcasting  ");
+        assertEquals(SubscriptionMode.BROADCASTING, result);
+    }
 
     @Test
     public void testNullValue() {
-        assertNull(converter.convert(null));
+        SubscriptionMode result = converter.convert(null);
+        assertEquals(SubscriptionMode.UNRECOGNIZED, result);
     }
 
     @Test
     public void testEmptyValue() {
-        assertNull(converter.convert(""));
+        SubscriptionMode result = converter.convert("");
+        assertEquals(SubscriptionMode.UNRECOGNIZED, result);
     }
 
     @Test
     public void testInvalidValue() {
-        assertNull(converter.convert("invalid_value"));
-    }
-
-    @Test
-    public void testLowerCaseValue() {
-        assertEquals(
-                SubscriptionMode.CLUSTERING,
-                converter.convert("clustering")
-        );
-    }
-
-    @Test
-    public void testUpperCaseValue() {
-        assertEquals(
-                SubscriptionMode.BROADCASTING,
-                converter.convert("BROADCASTING")
-        );
+        SubscriptionMode result = converter.convert("invalid_value");
+        assertEquals(SubscriptionMode.UNRECOGNIZED, result);
     }
 }


### PR DESCRIPTION
This PR fixes issue #5205 by improving SubscriptionModeConverter.

Changes:
- Safely handles null and empty values
- Normalizes input using trim and uppercase
- Prevents IllegalArgumentException for invalid enum values

This ensures the application does not crash on invalid input.