### PR TITLE
feat: add dynamic config hot-reload using JDK WatchService

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/ConfigMonitorService.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/ConfigMonitorService.java
@@ -23,10 +23,12 @@ import org.apache.eventmesh.common.file.FileChangeListener;
 import org.apache.eventmesh.common.file.WatchFileManager;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -36,6 +38,8 @@ import lombok.extern.slf4j.Slf4j;
 public class ConfigMonitorService {
 
     private static final Map<String, List<ConfigInfo>> CONFIG_INFO_MAP = new ConcurrentHashMap<>();
+
+    private static final Set<String> DIRECTORY_PATH_SET = ConcurrentHashMap.newKeySet();
 
     private static final FileChangeListener CONFIG_FILE_CHANGE_LISTENER = new ConfigMonitorFileChangeListener();
 
@@ -47,25 +51,44 @@ public class ConfigMonitorService {
     }
 
     public void monitor(ConfigInfo configInfo) {
+        if (configInfo == null) {
+            return;
+        }
         String filePath = configInfo.getFilePath();
         if (filePath == null) {
             log.warn("[ConfigMonitorService] filePath is null, skip monitoring: {}", configInfo);
             return;
         }
 
-        Path path = Paths.get(filePath);
+        Path path = Paths.get(filePath).toAbsolutePath().normalize();
         if (!path.toFile().exists()) {
             log.warn("[ConfigMonitorService] config file not exist, skip monitoring: {}", filePath);
             return;
         }
 
-        String normalizedPath = path.toAbsolutePath().normalize().toString();
-        CONFIG_INFO_MAP.computeIfAbsent(normalizedPath, k -> new CopyOnWriteArrayList<>()).add(configInfo);
+        String normalizedPath = path.toString();
+        List<ConfigInfo> configInfoList = CONFIG_INFO_MAP.computeIfAbsent(normalizedPath, k -> new CopyOnWriteArrayList<>());
+        if (!configInfoList.contains(configInfo)) {
+            configInfoList.add(configInfo);
+        }
         log.info("[ConfigMonitorService] monitoring config file: {}, total {} listener(s)", normalizedPath,
             CONFIG_INFO_MAP.get(normalizedPath).size());
 
-        String directoryPath = path.getParent().toString();
-        WatchFileManager.registerFileChangeListener(directoryPath, CONFIG_FILE_CHANGE_LISTENER);
+        Path parentPath = path.getParent();
+        if (parentPath == null) {
+            log.warn("[ConfigMonitorService] config file parent path is null, skip monitoring: {}", filePath);
+            return;
+        }
+
+        String directoryPath = parentPath.toString();
+        if (DIRECTORY_PATH_SET.add(directoryPath)) {
+            try {
+                WatchFileManager.registerFileChangeListener(directoryPath, CONFIG_FILE_CHANGE_LISTENER);
+            } catch (RuntimeException e) {
+                DIRECTORY_PATH_SET.remove(directoryPath);
+                throw e;
+            }
+        }
     }
 
     public static void load(ConfigInfo configInfo) {
@@ -75,16 +98,9 @@ public class ConfigMonitorService {
                 return;
             }
 
-            Field field = configInfo.getObjectField();
-            boolean isAccessible = field.isAccessible();
-            try {
-                field.setAccessible(true);
-                field.set(configInfo.getInstance(), object);
-            } finally {
-                field.setAccessible(isAccessible);
+            if (reloadConfig(configInfo, object)) {
+                configInfo.setObject(object);
             }
-
-            configInfo.setObject(object);
             log.info("config reload success: {}", object);
         } catch (Exception e) {
             log.error("config reload failed", e);
@@ -93,6 +109,47 @@ public class ConfigMonitorService {
 
     public static void clear() {
         CONFIG_INFO_MAP.clear();
+        for (String directoryPath : DIRECTORY_PATH_SET) {
+            WatchFileManager.deregisterFileChangeListener(directoryPath, CONFIG_FILE_CHANGE_LISTENER);
+        }
+        DIRECTORY_PATH_SET.clear();
+    }
+
+    private static boolean reloadConfig(ConfigInfo configInfo, Object object) throws IllegalAccessException {
+        Field field = configInfo.getObjectField();
+        if (field != null && configInfo.getInstance() != null) {
+            boolean isAccessible = field.isAccessible();
+            try {
+                field.setAccessible(true);
+                field.set(configInfo.getInstance(), object);
+            } finally {
+                field.setAccessible(isAccessible);
+            }
+            return true;
+        }
+
+        Object targetObject = configInfo.getObject();
+        if (targetObject == null) {
+            return true;
+        }
+
+        Class<?> clazz = object.getClass();
+        while (clazz != null && !Object.class.equals(clazz)) {
+            for (Field targetField : clazz.getDeclaredFields()) {
+                if (Modifier.isStatic(targetField.getModifiers())) {
+                    continue;
+                }
+                boolean isAccessible = targetField.isAccessible();
+                try {
+                    targetField.setAccessible(true);
+                    targetField.set(targetObject, targetField.get(object));
+                } finally {
+                    targetField.setAccessible(isAccessible);
+                }
+            }
+            clazz = clazz.getSuperclass();
+        }
+        return false;
     }
 
     public static boolean support(FileChangeContext changeContext) {

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/ConfigMonitorService.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/ConfigMonitorService.java
@@ -17,56 +17,113 @@
 
 package org.apache.eventmesh.common.config;
 
-import org.apache.eventmesh.common.ThreadPoolFactory;
+
+import org.apache.eventmesh.common.file.FileChangeContext;
+import org.apache.eventmesh.common.file.FileChangeListener;
+import org.apache.eventmesh.common.file.WatchFileManager;
 
 import java.lang.reflect.Field;
-import java.util.ArrayList;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ConfigMonitorService {
 
-    private static final long TIME_INTERVAL = 30 * 1000L;
+    private static final Map<String, List<ConfigInfo>> CONFIG_INFO_MAP = new ConcurrentHashMap<>();
 
-    private final List<ConfigInfo> configInfoList = new ArrayList<>();
+    private static final FileChangeListener CONFIG_FILE_CHANGE_LISTENER = new ConfigMonitorFileChangeListener();
 
-    private final ScheduledExecutorService configLoader = ThreadPoolFactory.createSingleScheduledExecutor("eventMesh-configLoader");
-
-    {
-        configLoader.scheduleAtFixedRate(this::load, TIME_INTERVAL, TIME_INTERVAL, TimeUnit.MILLISECONDS);
+    static {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            log.info("[ConfigMonitorService] shutdown, clearing {} entries", CONFIG_INFO_MAP.size());
+            CONFIG_INFO_MAP.clear();
+        }));
     }
 
     public void monitor(ConfigInfo configInfo) {
-        configInfoList.add(configInfo);
+        String filePath = configInfo.getFilePath();
+        if (filePath == null) {
+            log.warn("[ConfigMonitorService] filePath is null, skip monitoring: {}", configInfo);
+            return;
+        }
+
+        Path path = Paths.get(filePath);
+        if (!path.toFile().exists()) {
+            log.warn("[ConfigMonitorService] config file not exist, skip monitoring: {}", filePath);
+            return;
+        }
+
+        String normalizedPath = path.toAbsolutePath().normalize().toString();
+        CONFIG_INFO_MAP.computeIfAbsent(normalizedPath, k -> new CopyOnWriteArrayList<>()).add(configInfo);
+        log.info("[ConfigMonitorService] monitoring config file: {}, total {} listener(s)", normalizedPath,
+            CONFIG_INFO_MAP.get(normalizedPath).size());
+
+        String directoryPath = path.getParent().toString();
+        WatchFileManager.registerFileChangeListener(directoryPath, CONFIG_FILE_CHANGE_LISTENER);
     }
 
-    public void load() {
-        for (ConfigInfo configInfo : configInfoList) {
-            try {
-                Object object = ConfigService.getInstance().getConfig(configInfo);
-                if (configInfo.getObject().equals(object)) {
-                    continue;
-                }
-
-                Field field = configInfo.getObjectField();
-                boolean isAccessible = field.isAccessible();
-                try {
-                    field.setAccessible(true);
-                    field.set(configInfo.getInstance(), object);
-                } finally {
-                    field.setAccessible(isAccessible);
-                }
-
-                configInfo.setObject(object);
-                log.info("config reload success: {}", object);
-            } catch (Exception e) {
-                log.error("config reload failed", e);
+    public static void load(ConfigInfo configInfo) {
+        try {
+            Object object = ConfigService.getInstance().getConfig(configInfo);
+            if (java.util.Objects.equals(configInfo.getObject(), object)) {
+                return;
             }
+
+            Field field = configInfo.getObjectField();
+            boolean isAccessible = field.isAccessible();
+            try {
+                field.setAccessible(true);
+                field.set(configInfo.getInstance(), object);
+            } finally {
+                field.setAccessible(isAccessible);
+            }
+
+            configInfo.setObject(object);
+            log.info("config reload success: {}", object);
+        } catch (Exception e) {
+            log.error("config reload failed", e);
         }
     }
 
+    public static void clear() {
+        CONFIG_INFO_MAP.clear();
+    }
+
+    public static boolean support(FileChangeContext changeContext) {
+        String changedFileName = changeContext.getFileName();
+        String changedFilePath = Paths.get(
+            changeContext.getDirectoryPath(), changedFileName).toAbsolutePath().normalize().toString();
+        return CONFIG_INFO_MAP.containsKey(changedFilePath);
+    }
+
+    private static class ConfigMonitorFileChangeListener implements FileChangeListener {
+
+        @Override
+        public void onChanged(FileChangeContext changeContext) {
+            String changedFileName = changeContext.getFileName();
+            String changedFilePath = Paths.get(
+                changeContext.getDirectoryPath(), changedFileName).toAbsolutePath().normalize().toString();
+
+            List<ConfigInfo> configInfoList = CONFIG_INFO_MAP.get(changedFilePath);
+            if (configInfoList == null || configInfoList.isEmpty()) {
+                return;
+            }
+
+            for (ConfigInfo configInfo : configInfoList) {
+                configInfo.getObject(); // ensure non-null
+                load(configInfo);
+            }
+        }
+
+        @Override
+        public boolean support(FileChangeContext changeContext) {
+            return ConfigMonitorService.support(changeContext);
+        }
+    }
 }

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/ConfigMonitorService.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/ConfigMonitorService.java
@@ -22,6 +22,7 @@ import org.apache.eventmesh.common.file.FileChangeContext;
 import org.apache.eventmesh.common.file.FileChangeListener;
 import org.apache.eventmesh.common.file.WatchFileManager;
 
+import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.nio.file.Path;
@@ -36,6 +37,10 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ConfigMonitorService {
+
+    private static final int MAX_RELOAD_ATTEMPTS = 3;
+
+    private static final long RELOAD_RETRY_INTERVAL_MILLIS = 100L;
 
     private static final Map<String, List<ConfigInfo>> CONFIG_INFO_MAP = new ConcurrentHashMap<>();
 
@@ -68,7 +73,7 @@ public class ConfigMonitorService {
 
         String normalizedPath = path.toString();
         List<ConfigInfo> configInfoList = CONFIG_INFO_MAP.computeIfAbsent(normalizedPath, k -> new CopyOnWriteArrayList<>());
-        if (!configInfoList.contains(configInfo)) {
+        if (configInfoList.stream().noneMatch(registeredConfigInfo -> registeredConfigInfo == configInfo)) {
             configInfoList.add(configInfo);
         }
         log.info("[ConfigMonitorService] monitoring config file: {}, total {} listener(s)", normalizedPath,
@@ -92,18 +97,31 @@ public class ConfigMonitorService {
     }
 
     public static void load(ConfigInfo configInfo) {
+        loadOnce(configInfo);
+    }
+
+    private static boolean loadOnce(ConfigInfo configInfo) {
         try {
+            String filePath = configInfo.getFilePath();
+            File file = filePath == null ? null : Paths.get(filePath).toFile();
+            long size = file == null ? 0 : file.length();
+            long lastModified = file == null ? 0 : file.lastModified();
             Object object = ConfigService.getInstance().getConfig(configInfo);
+            if (file != null && (!file.exists() || size != file.length() || lastModified != file.lastModified())) {
+                return false;
+            }
             if (java.util.Objects.equals(configInfo.getObject(), object)) {
-                return;
+                return true;
             }
 
             if (reloadConfig(configInfo, object)) {
                 configInfo.setObject(object);
             }
             log.info("config reload success: {}", object);
+            return true;
         } catch (Exception e) {
             log.error("config reload failed", e);
+            return false;
         }
     }
 
@@ -154,9 +172,39 @@ public class ConfigMonitorService {
 
     public static boolean support(FileChangeContext changeContext) {
         String changedFileName = changeContext.getFileName();
+        if (changedFileName == null) {
+            return true;
+        }
         String changedFilePath = Paths.get(
             changeContext.getDirectoryPath(), changedFileName).toAbsolutePath().normalize().toString();
         return CONFIG_INFO_MAP.containsKey(changedFilePath);
+    }
+
+    private static void reloadAfterChange(String changedFilePath, List<ConfigInfo> configInfoList) {
+        if (configInfoList == null || configInfoList.isEmpty()) {
+            return;
+        }
+
+        for (ConfigInfo configInfo : configInfoList) {
+            for (int attempt = 0; attempt < MAX_RELOAD_ATTEMPTS; attempt++) {
+                if (isFileStable(changedFilePath) && loadOnce(configInfo)) {
+                    break;
+                }
+            }
+        }
+    }
+
+    private static boolean isFileStable(String filePath) {
+        File file = Paths.get(filePath).toFile();
+        long size = file.length();
+        long lastModified = file.lastModified();
+        try {
+            Thread.sleep(RELOAD_RETRY_INTERVAL_MILLIS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+        return file.exists() && size == file.length() && lastModified == file.lastModified();
     }
 
     private static class ConfigMonitorFileChangeListener implements FileChangeListener {
@@ -164,18 +212,21 @@ public class ConfigMonitorService {
         @Override
         public void onChanged(FileChangeContext changeContext) {
             String changedFileName = changeContext.getFileName();
+            if (changedFileName == null) {
+                Path changedDirectoryPath = Paths.get(changeContext.getDirectoryPath()).toAbsolutePath().normalize();
+                for (Map.Entry<String, List<ConfigInfo>> entry : CONFIG_INFO_MAP.entrySet()) {
+                    if (changedDirectoryPath.equals(Paths.get(entry.getKey()).getParent())) {
+                        reloadAfterChange(entry.getKey(), entry.getValue());
+                    }
+                }
+                return;
+            }
+
             String changedFilePath = Paths.get(
                 changeContext.getDirectoryPath(), changedFileName).toAbsolutePath().normalize().toString();
 
             List<ConfigInfo> configInfoList = CONFIG_INFO_MAP.get(changedFilePath);
-            if (configInfoList == null || configInfoList.isEmpty()) {
-                return;
-            }
-
-            for (ConfigInfo configInfo : configInfoList) {
-                configInfo.getObject(); // ensure non-null
-                load(configInfo);
-            }
+            reloadAfterChange(changedFilePath, configInfoList);
         }
 
         @Override

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/ConfigService.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/config/ConfigService.java
@@ -91,7 +91,12 @@ public class ConfigService {
         configInfo.setReloadMethodName(config == null ? null : config.reloadMethodName());
 
         try {
-            return this.getConfig(configInfo);
+            T configObject = this.getConfig(configInfo);
+            if (configInfo.isMonitor()) {
+                configInfo.setObject(configObject);
+                configMonitorService.monitor(configInfo);
+            }
+            return configObject;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/file/WatchFileManager.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/file/WatchFileManager.java
@@ -17,8 +17,8 @@
 
 package org.apache.eventmesh.common.file;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import lombok.extern.slf4j.Slf4j;
@@ -28,7 +28,7 @@ public class WatchFileManager {
 
     private static final AtomicBoolean CLOSED = new AtomicBoolean(false);
 
-    private static final Map<String, WatchFileTask> WATCH_FILE_TASK_MAP = new HashMap<>();
+    private static final Map<String, WatchFileTask> WATCH_FILE_TASK_MAP = new ConcurrentHashMap<>();
 
     static {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
@@ -38,13 +38,24 @@ public class WatchFileManager {
     }
 
     public static void registerFileChangeListener(String directoryPath, FileChangeListener listener) {
-        WatchFileTask task = WATCH_FILE_TASK_MAP.get(directoryPath);
-        if (task == null) {
-            task = new WatchFileTask(directoryPath);
-            task.start();
-            WATCH_FILE_TASK_MAP.put(directoryPath, task);
-        }
+        WatchFileTask task = WATCH_FILE_TASK_MAP.computeIfAbsent(directoryPath, path -> {
+            WatchFileTask watchFileTask = new WatchFileTask(path);
+            watchFileTask.start();
+            return watchFileTask;
+        });
         task.addFileChangeListener(listener);
+    }
+
+    public static void deregisterFileChangeListener(String directoryPath, FileChangeListener listener) {
+        WatchFileTask task = WATCH_FILE_TASK_MAP.get(directoryPath);
+        if (task != null) {
+            task.removeFileChangeListener(listener);
+            if (task.hasFileChangeListener()) {
+                return;
+            }
+            WATCH_FILE_TASK_MAP.remove(directoryPath, task);
+            task.shutdown();
+        }
     }
 
     public static void deregisterFileChangeListener(String directoryPath) {

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/file/WatchFileManager.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/file/WatchFileManager.java
@@ -38,32 +38,43 @@ public class WatchFileManager {
     }
 
     public static void registerFileChangeListener(String directoryPath, FileChangeListener listener) {
-        WatchFileTask task = WATCH_FILE_TASK_MAP.computeIfAbsent(directoryPath, path -> {
+        WATCH_FILE_TASK_MAP.compute(directoryPath, (path, task) -> {
+            if (task != null) {
+                synchronized (task) {
+                    if (task.isWatching()) {
+                        task.addFileChangeListener(listener);
+                        return task;
+                    }
+                }
+            }
+
             WatchFileTask watchFileTask = new WatchFileTask(path);
+            watchFileTask.addFileChangeListener(listener);
             watchFileTask.start();
             return watchFileTask;
         });
-        task.addFileChangeListener(listener);
     }
 
     public static void deregisterFileChangeListener(String directoryPath, FileChangeListener listener) {
-        WatchFileTask task = WATCH_FILE_TASK_MAP.get(directoryPath);
-        if (task != null) {
+        WATCH_FILE_TASK_MAP.computeIfPresent(directoryPath, (path, task) -> {
             task.removeFileChangeListener(listener);
             if (task.hasFileChangeListener()) {
-                return;
+                return task;
             }
-            WATCH_FILE_TASK_MAP.remove(directoryPath, task);
             task.shutdown();
-        }
+            return null;
+        });
     }
 
     public static void deregisterFileChangeListener(String directoryPath) {
-        WatchFileTask task = WATCH_FILE_TASK_MAP.get(directoryPath);
-        if (task != null) {
+        WATCH_FILE_TASK_MAP.computeIfPresent(directoryPath, (path, task) -> {
             task.shutdown();
-            WATCH_FILE_TASK_MAP.remove(directoryPath);
-        }
+            return null;
+        });
+    }
+
+    static void removeWatchFileTask(String directoryPath, WatchFileTask task) {
+        WATCH_FILE_TASK_MAP.remove(directoryPath, task);
     }
 
     private static void shutdown() {

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/file/WatchFileTask.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/file/WatchFileTask.java
@@ -26,8 +26,8 @@ import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,7 +38,7 @@ public class WatchFileTask extends Thread {
 
     private final transient WatchService watchService;
 
-    private final transient List<FileChangeListener> fileChangeListeners = new ArrayList<>();
+    private final transient List<FileChangeListener> fileChangeListeners = new CopyOnWriteArrayList<>();
 
     private transient volatile boolean watch = true;
 
@@ -46,6 +46,7 @@ public class WatchFileTask extends Thread {
 
     public WatchFileTask(String directoryPath) {
         this.directoryPath = directoryPath;
+        setDaemon(true);
         final Path path = Paths.get(directoryPath);
         if (!path.toFile().exists()) {
             throw new IllegalArgumentException("file directory not exist: " + directoryPath);
@@ -74,9 +75,17 @@ public class WatchFileTask extends Thread {
     }
 
     public void addFileChangeListener(FileChangeListener fileChangeListener) {
-        if (fileChangeListener != null) {
+        if (fileChangeListener != null && !fileChangeListeners.contains(fileChangeListener)) {
             fileChangeListeners.add(fileChangeListener);
         }
+    }
+
+    public void removeFileChangeListener(FileChangeListener fileChangeListener) {
+        fileChangeListeners.remove(fileChangeListener);
+    }
+
+    public boolean hasFileChangeListener() {
+        return !fileChangeListeners.isEmpty();
     }
 
     public void shutdown() {
@@ -114,7 +123,9 @@ public class WatchFileTask extends Thread {
                     log.debug("[WatchFileTask] file watch is interrupted");
                 }
             } catch (Exception ex) {
-                log.error("[WatchFileTask] an exception occurred during file listening : ", ex);
+                if (watch) {
+                    log.error("[WatchFileTask] an exception occurred during file listening : ", ex);
+                }
             }
         }
     }

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/file/WatchFileTask.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/file/WatchFileTask.java
@@ -88,6 +88,10 @@ public class WatchFileTask extends Thread {
         return !fileChangeListeners.isEmpty();
     }
 
+    boolean isWatching() {
+        return watch;
+    }
+
     public void shutdown() {
         watch = false;
         try {
@@ -103,19 +107,29 @@ public class WatchFileTask extends Thread {
             try {
                 WatchKey watchKey = watchService.take();
                 List<WatchEvent<?>> events = watchKey.pollEvents();
-                watchKey.reset();
-
-                if (events.isEmpty()) {
-                    continue;
-                }
 
                 for (WatchEvent<?> event : events) {
                     WatchEvent.Kind<?> kind = event.kind();
                     if (kind.equals(StandardWatchEventKinds.OVERFLOW)) {
                         log.warn("[WatchFileTask] file overflow: {}", event.context());
-                        continue;
                     }
                     precessWatchEvent(event);
+                }
+
+                final boolean valid;
+                synchronized (this) {
+                    valid = watchKey.reset();
+                    if (!valid) {
+                        watch = false;
+                    }
+                }
+                if (!valid) {
+                    log.warn("[WatchFileTask] watch key is no longer valid: {}", directoryPath);
+                    try {
+                        shutdown();
+                    } finally {
+                        WatchFileManager.removeWatchFileTask(directoryPath, this);
+                    }
                 }
             } catch (InterruptedException ex) {
                 boolean interrupted = Thread.interrupted();
@@ -131,18 +145,19 @@ public class WatchFileTask extends Thread {
     }
 
     private void precessWatchEvent(WatchEvent<?> event) {
-        try {
-            for (FileChangeListener fileChangeListener : fileChangeListeners) {
+        final boolean overflow = event.kind().equals(StandardWatchEventKinds.OVERFLOW);
+        for (FileChangeListener fileChangeListener : fileChangeListeners) {
+            try {
                 FileChangeContext context = new FileChangeContext();
                 context.setDirectoryPath(directoryPath);
-                context.setFileName(event.context().toString());
+                context.setFileName(overflow || event.context() == null ? null : event.context().toString());
                 context.setWatchEvent(event);
                 if (fileChangeListener.support(context)) {
                     fileChangeListener.onChanged(context);
                 }
+            } catch (Exception ex) {
+                log.error("[WatchFileTask] file change event callback error : ", ex);
             }
-        } catch (Exception ex) {
-            log.error("[WatchFileTask] file change event callback error : ", ex);
         }
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/config/ConfigMonitorServiceTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/config/ConfigMonitorServiceTest.java
@@ -1,0 +1,353 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.common.config;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.eventmesh.common.file.FileChangeContext;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link ConfigMonitorService} test class.
+ *
+ * <p>Tests:
+ * <ul>
+ *   <li>Registration and unregistration of config files</li>
+ *   <li>File change triggers config hot-reload</li>
+ *   <li>Defense against null/non-existent paths</li>
+ *   <li>Static methods clear() and support()</li>
+ * </ul>
+ *
+ * <p>Strategy: JUnit5 + temp files, no external config service dependency.</p>
+ */
+public class ConfigMonitorServiceTest {
+
+    private ConfigMonitorService configMonitorService;
+
+    /**
+     * Simple config object for testing hot-reload scenarios.
+     */
+    public static class TestMonitorConfig {
+        private String name = "init";
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        // Clear static registry before each test to prevent state pollution
+        configMonitorService = new ConfigMonitorService();
+        ConfigMonitorService.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Clear registry after test
+        ConfigMonitorService.clear();
+    }
+
+    /**
+     * Tests normal registration flow of monitor().
+     *
+     * <p>Scenario: Pass existing config file path, expect successful registration with logs.</p>
+     * <p>Verification points:
+     * <ul>
+     *   <li>No exception thrown</li>
+     *   <li>Repeated registration allowed (CopyOnWriteArrayList append)</li>
+     * </ul>
+     */
+    @Test
+    @DisplayName("monitor() - 正常注册已存在的配置文件")
+    void testMonitorNormal() throws Exception {
+        Path tempFile = Files.createTempFile("test-monitor", ".properties");
+        tempFile.toFile().createNewFile();
+
+        ConfigInfo configInfo = buildConfigInfo(tempFile.toString(), new TestMonitorConfig());
+
+        // First registration
+        configMonitorService.monitor(configInfo);
+
+        // Second registration with same path - verify append mechanism (no exception)
+        configMonitorService.monitor(configInfo);
+
+        Files.deleteIfExists(tempFile);
+    }
+
+    /**
+     * Tests defense handling of null file path in monitor().
+     *
+     * <p>Scenario: filePath is null, method returns early with warning log.</p>
+     * <p>Verification: No exception, early termination.</p>
+     */
+    @Test
+    @DisplayName("monitor() - filePath 为 null 时跳过监控")
+    void testMonitorNullFilePath() {
+        ConfigInfo configInfo = new ConfigInfo();
+        configInfo.setFilePath(null);
+
+        // Should not throw exception, return directly
+        configMonitorService.monitor(configInfo);
+    }
+
+    /**
+     * Tests defense handling of non-existent file in monitor().
+     *
+     * <p>Scenario: Pass non-existent file path, method returns early with warning log.</p>
+     * <p>Verification: No exception, early termination.</p>
+     */
+    @Test
+    @DisplayName("monitor() - 文件不存在时跳过监控")
+    void testMonitorFileNotExist() {
+        ConfigInfo configInfo = new ConfigInfo();
+        // Use definitely non-existent path in system
+        configInfo.setFilePath("/this/path/does/not/exist/unknown.properties");
+
+        configMonitorService.monitor(configInfo);
+    }
+
+    /**
+     * Tests clear() removes all registered monitoring items.
+     *
+     * <p>Scenario: Register multiple files then call clear(), verify registry is empty.</p>
+     * <p>Verification: After clear(), support() returns false for all paths.</p>
+     */
+    @Test
+    @DisplayName("clear() - 清除所有已注册的监控项")
+    void testClear() throws Exception {
+        Path tempFile1 = Files.createTempFile("test-clear-1", ".properties");
+        Path tempFile2 = Files.createTempFile("test-clear-2", ".properties");
+        tempFile1.toFile().createNewFile();
+        tempFile2.toFile().createNewFile();
+
+        configMonitorService.monitor(buildConfigInfo(tempFile1.toString(), new TestMonitorConfig()));
+        configMonitorService.monitor(buildConfigInfo(tempFile2.toString(), new TestMonitorConfig()));
+
+        // Verify registration success
+        FileChangeContext ctx1 = new FileChangeContext();
+        ctx1.setDirectoryPath(tempFile1.getParent().toString());
+        ctx1.setFileName(tempFile1.getFileName().toString());
+        Assertions.assertTrue(ConfigMonitorService.support(ctx1));
+
+        // Execute clear
+        ConfigMonitorService.clear();
+
+        // Verify cleared
+        Assertions.assertFalse(ConfigMonitorService.support(ctx1));
+
+        Files.deleteIfExists(tempFile1);
+        Files.deleteIfExists(tempFile2);
+    }
+
+    /**
+     * Tests support() returns true for registered paths, false for unregistered.
+     *
+     * <p>Verification:
+     * <ul>
+     *   <li>Monitored file returns true</li>
+     *   <li>Unmonitored file returns false</li>
+     * </ul>
+     */
+    @Test
+    @DisplayName("support() - 正确判断文件是否已注册监控")
+    void testSupport() throws Exception {
+        Path tempFile = Files.createTempFile("test-support", ".properties");
+        tempFile.toFile().createNewFile();
+        String normalizedPath = tempFile.toAbsolutePath().normalize().toString();
+
+        FileChangeContext registeredCtx = new FileChangeContext();
+        registeredCtx.setDirectoryPath(tempFile.getParent().toString());
+        registeredCtx.setFileName(tempFile.getFileName().toString());
+
+        FileChangeContext unregisteredCtx = new FileChangeContext();
+        unregisteredCtx.setDirectoryPath(tempFile.getParent().toString());
+        unregisteredCtx.setFileName("not-monitored.properties");
+
+        // Before registration: both unsupported
+        Assertions.assertFalse(ConfigMonitorService.support(registeredCtx));
+        Assertions.assertFalse(ConfigMonitorService.support(unregisteredCtx));
+
+        // After registration: only registered path supported
+        configMonitorService.monitor(buildConfigInfo(normalizedPath, new TestMonitorConfig()));
+        Assertions.assertTrue(ConfigMonitorService.support(registeredCtx));
+        Assertions.assertFalse(ConfigMonitorService.support(unregisteredCtx));
+
+        Files.deleteIfExists(tempFile);
+    }
+
+    /**
+     * Tests file change triggers hot-reload via ConfigMonitorFileChangeListener.
+     *
+     * <p>Scenario: Monitor a config file, when content changes (onChanged triggered),
+     * the object reference in ConfigInfo should update to new value.</p>
+     *
+     * <p>Verification:
+     * <ul>
+     *   <li>After file change, monitored object field value updates</li>
+     *   <li>Repeated onChanged triggers don't cause exception</li>
+     * </ul>
+     */
+    @Test
+    @DisplayName("ConfigMonitorFileChangeListener.onChanged() - 文件变更触发热重载")
+    void testOnChangedTriggersReload() throws Exception {
+        // Create temp properties file with initial content
+        Path tempFile = Files.createTempFile("test-reload", ".properties");
+        String originalValue = "test-value-original";
+        String updatedValue = "test-value-updated";
+        writeProperty(tempFile, "test.key", originalValue);
+
+        TestMonitorConfig config = new TestMonitorConfig();
+        config.setName(originalValue);
+
+        ConfigInfo configInfo = buildConfigInfo(tempFile.toString(), config);
+        configMonitorService.monitor(configInfo);
+
+        // Simulate file content changed externally
+        writeProperty(tempFile, "test.key", updatedValue);
+
+        // Build change context and trigger onChanged
+        FileChangeContext changeContext = new FileChangeContext();
+        changeContext.setDirectoryPath(tempFile.getParent().toString());
+        changeContext.setFileName(tempFile.getFileName().toString());
+
+        // Get internal listener and trigger change notification
+        // Simulate WatchFileManager notification behavior via support + onChanged
+        if (ConfigMonitorService.support(changeContext)) {
+            // 通过 ConfigService 触发 load（模拟 WatchFileManager 调用路径）
+            ConfigMonitorService.load(configInfo);
+        }
+
+        // Verify object field updated (depends on ConfigService reload)
+        // Note: ConfigService.getConfig reads real file, config.getName() should reflect latest value
+        // In actual hot-reload, reload() re-reads file and injects into corresponding field
+
+        Files.deleteIfExists(tempFile);
+    }
+
+    /**
+     * Tests exception handling in load() method.
+     *
+     * <p>Scenario: When ConfigService.getConfig throws exception (e.g., file deleted),
+     * load() should catch exception and log error, not propagate to caller.</p>
+     *
+     * <p>Verification: load() completes without throwing exception, only logs error.</p>
+     */
+    @Test
+    @DisplayName("load() - 文件不存在时捕获异常不外抛")
+    void testLoadWithException() {
+        ConfigInfo configInfo = new ConfigInfo();
+        configInfo.setPath("/non/exist/path.properties");
+        configInfo.setClazz(TestMonitorConfig.class);
+        configInfo.setObject(new TestMonitorConfig());
+        configInfo.setInstance(new TestMonitorConfig());
+
+        // Even if file doesn't exist, load should not throw exception
+        ConfigMonitorService.load(configInfo);
+    }
+
+    /**
+     * Tests load() returns early when config value unchanged.
+     *
+     * <p>Scenario: When object returned by getConfig equals current configInfo.object,
+     * field write operation should be skipped, return directly.</p>
+     *
+     * <p>Verification: Method returns normally, no "config reload success" log.</p>
+     */
+    @Test
+    @DisplayName("load() - 配置未变化时跳过重载")
+    void testLoadSkipWhenSame() throws Exception {
+        Path tempFile = Files.createTempFile("test-skip-reload", ".properties");
+        writeProperty(tempFile, "test.key", "unchanged");
+        tempFile.toFile().deleteOnExit();
+
+        TestMonitorConfig config = new TestMonitorConfig();
+        config.setName("unchanged");
+
+        ConfigInfo configInfo = buildConfigInfo(tempFile.toString(), config);
+
+        // Simulate ConfigService loaded same object (equals returns true)
+        // This scenario relies on ConfigService.getConfig returning same reference, load should return early
+        ConfigMonitorService.load(configInfo);
+
+        Files.deleteIfExists(tempFile);
+    }
+
+    // ======================== Helper Methods ========================
+
+    /**
+     * Builds complete ConfigInfo object.
+     *
+     * @param filePath    config file path (absolute path)
+     * @param instance    runtime object holding config fields
+     * @return ConfigInfo instance with all necessary fields populated
+     */
+    private ConfigInfo buildConfigInfo(String filePath, Object instance) throws Exception {
+        ConfigInfo configInfo = new ConfigInfo();
+        configInfo.setFilePath(filePath);
+        configInfo.setInstance(instance);
+
+        // Find first String field in instance and set as objectField
+        // Simulates real ConfigInfo initialization in ConfigService.populateConfigForObject
+        Field objectField = findFirstField(instance.getClass(), String.class);
+        if (objectField != null) {
+            objectField.setAccessible(true);
+            configInfo.setObjectField(objectField);
+            configInfo.setObject(objectField.get(instance));
+        }
+
+        return configInfo;
+    }
+
+    /**
+     * Finds first field of targetType in clazz.
+     */
+    private Field findFirstField(Class<?> clazz, Class<?> targetType) {
+        for (Field field : clazz.getDeclaredFields()) {
+            if (field.getType().equals(targetType)) {
+                return field;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Writes single key-value pair to temp properties file.
+     */
+    private void writeProperty(Path file, String key, String value) throws Exception {
+        try (OutputStream os = new FileOutputStream(file.toFile())) {
+            java.util.Properties props = new java.util.Properties();
+            props.setProperty(key, value);
+            props.store(os, "test properties");
+        }
+    }
+}

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/config/ConfigMonitorServiceTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/config/ConfigMonitorServiceTest.java
@@ -52,7 +52,9 @@ public class ConfigMonitorServiceTest {
     /**
      * Simple config object for testing hot-reload scenarios.
      */
+    @Config(prefix = "test")
     public static class TestMonitorConfig {
+        @ConfigField(field = "key")
         private String name = "init";
 
         public String getName() {
@@ -61,6 +63,30 @@ public class ConfigMonitorServiceTest {
 
         public void setName(String name) {
             this.name = name;
+        }
+    }
+
+    public static class TestMonitorHolder {
+
+        private TestMonitorConfig config;
+
+        public TestMonitorConfig getConfig() {
+            return config;
+        }
+
+        public void setConfig(TestMonitorConfig config) {
+            this.config = config;
+        }
+    }
+
+    @Config(prefix = "test", path = "monitor-test.properties", monitor = true)
+    public static class BuildConfigMonitorConfig {
+
+        @ConfigField(field = "key")
+        private String name = "init";
+
+        public String getName() {
+            return name;
         }
     }
 
@@ -226,32 +252,49 @@ public class ConfigMonitorServiceTest {
         String updatedValue = "test-value-updated";
         writeProperty(tempFile, "test.key", originalValue);
 
+        TestMonitorHolder holder = new TestMonitorHolder();
         TestMonitorConfig config = new TestMonitorConfig();
-        config.setName(originalValue);
+        holder.setConfig(config);
 
-        ConfigInfo configInfo = buildConfigInfo(tempFile.toString(), config);
+        ConfigInfo configInfo = buildConfigInfo(tempFile.toString(), holder);
         configMonitorService.monitor(configInfo);
 
         // Simulate file content changed externally
         writeProperty(tempFile, "test.key", updatedValue);
 
-        // Build change context and trigger onChanged
-        FileChangeContext changeContext = new FileChangeContext();
-        changeContext.setDirectoryPath(tempFile.getParent().toString());
-        changeContext.setFileName(tempFile.getFileName().toString());
-
-        // Get internal listener and trigger change notification
-        // Simulate WatchFileManager notification behavior via support + onChanged
-        if (ConfigMonitorService.support(changeContext)) {
-            // 通过 ConfigService 触发 load（模拟 WatchFileManager 调用路径）
-            ConfigMonitorService.load(configInfo);
-        }
-
-        // Verify object field updated (depends on ConfigService reload)
-        // Note: ConfigService.getConfig reads real file, config.getName() should reflect latest value
-        // In actual hot-reload, reload() re-reads file and injects into corresponding field
+        waitUntil(() -> updatedValue.equals(holder.getConfig().getName()));
+        Assertions.assertEquals(updatedValue, holder.getConfig().getName());
 
         Files.deleteIfExists(tempFile);
+    }
+
+    @Test
+    @DisplayName("buildConfigInstance() - monitor=true 时文件变更更新原配置对象")
+    void testBuildConfigInstanceMonitor() throws Exception {
+        Path tempDir = Files.createTempDirectory("test-build-monitor");
+        Path tempFile = tempDir.resolve("monitor-test.properties");
+        writeProperty(tempFile, "test.key", "before");
+
+        try {
+            ConfigService.getInstance().setConfigPath(tempDir.toString());
+            BuildConfigMonitorConfig config = ConfigService.getInstance().buildConfigInstance(BuildConfigMonitorConfig.class);
+            Assertions.assertEquals("before", config.getName());
+
+            writeProperty(tempFile, "test.key", "after");
+
+            waitUntil(() -> "after".equals(config.getName()));
+            Assertions.assertEquals("after", config.getName());
+
+            writeProperty(tempFile, "test.key", "final");
+
+            waitUntil(() -> "final".equals(config.getName()));
+            Assertions.assertEquals("final", config.getName());
+        } finally {
+            ConfigService.getInstance().setConfigPath(null);
+        }
+
+        Files.deleteIfExists(tempFile);
+        Files.deleteIfExists(tempDir);
     }
 
     /**
@@ -314,11 +357,14 @@ public class ConfigMonitorServiceTest {
     private ConfigInfo buildConfigInfo(String filePath, Object instance) throws Exception {
         ConfigInfo configInfo = new ConfigInfo();
         configInfo.setFilePath(filePath);
+        configInfo.setPath(ConfigService.FILE_PATH_PREFIX + filePath);
+        configInfo.setClazz(TestMonitorConfig.class);
+        configInfo.setPrefix("test");
         configInfo.setInstance(instance);
 
-        // Find first String field in instance and set as objectField
+        // Find first TestMonitorConfig field in instance and set as objectField
         // Simulates real ConfigInfo initialization in ConfigService.populateConfigForObject
-        Field objectField = findFirstField(instance.getClass(), String.class);
+        Field objectField = findFirstField(instance.getClass(), TestMonitorConfig.class);
         if (objectField != null) {
             objectField.setAccessible(true);
             configInfo.setObjectField(objectField);
@@ -349,5 +395,21 @@ public class ConfigMonitorServiceTest {
             props.setProperty(key, value);
             props.store(os, "test properties");
         }
+    }
+
+    private void waitUntil(Check check) throws Exception {
+        long deadline = System.currentTimeMillis() + 15_000;
+        while (System.currentTimeMillis() < deadline) {
+            if (check.success()) {
+                return;
+            }
+            Thread.sleep(100);
+        }
+        Assertions.fail("condition was not met before timeout");
+    }
+
+    private interface Check {
+
+        boolean success();
     }
 }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/config/ConfigMonitorServiceTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/config/ConfigMonitorServiceTest.java
@@ -24,12 +24,16 @@ import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import lombok.EqualsAndHashCode;
 
 /**
  * {@link ConfigMonitorService} test class.
@@ -52,6 +56,7 @@ public class ConfigMonitorServiceTest {
      * Simple config object for testing hot-reload scenarios.
      */
     @Config(prefix = "test")
+    @EqualsAndHashCode
     public static class TestMonitorConfig {
         @ConfigField(field = "key")
         private String name = "init";
@@ -126,6 +131,28 @@ public class ConfigMonitorServiceTest {
         // Second registration with same path - verify append mechanism (no exception)
         configMonitorService.monitor(configInfo);
 
+        Files.deleteIfExists(tempFile);
+    }
+
+    @Test
+    @DisplayName("monitor() - reloads independent equal config instances")
+    void testMonitorEqualConfigInstances() throws Exception {
+        Path tempFile = Files.createTempFile("test-monitor-equal", ".properties");
+        writeProperty(tempFile, "test.key", "before");
+
+        TestMonitorConfig firstConfig = new TestMonitorConfig();
+        TestMonitorConfig secondConfig = new TestMonitorConfig();
+        ConfigInfo firstConfigInfo = buildConfigInfo(tempFile.toString(), firstConfig);
+        ConfigInfo secondConfigInfo = buildConfigInfo(tempFile.toString(), secondConfig);
+        firstConfigInfo.setObject(firstConfig);
+        secondConfigInfo.setObject(secondConfig);
+        Assertions.assertEquals(firstConfigInfo, secondConfigInfo);
+
+        configMonitorService.monitor(firstConfigInfo);
+        configMonitorService.monitor(secondConfigInfo);
+        writeProperty(tempFile, "test.key", "after");
+
+        waitUntil(() -> "after".equals(firstConfig.getName()) && "after".equals(secondConfig.getName()));
         Files.deleteIfExists(tempFile);
     }
 
@@ -389,16 +416,18 @@ public class ConfigMonitorServiceTest {
      * Writes single key-value pair to temp properties file.
      */
     private void writeProperty(Path file, String key, String value) throws Exception {
+        final long lastModified = Files.exists(file) ? Files.getLastModifiedTime(file).toMillis() : 0;
         try (OutputStream os = new FileOutputStream(file.toFile())) {
             java.util.Properties props = new java.util.Properties();
             props.setProperty(key, value);
             props.store(os, "test properties");
         }
+        Files.setLastModifiedTime(file, FileTime.fromMillis(Math.max(System.currentTimeMillis(), lastModified) + 2_000));
     }
 
     private void waitUntil(Check check) throws Exception {
-        long deadline = System.currentTimeMillis() + 15_000;
-        while (System.currentTimeMillis() < deadline) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(15);
+        while (System.nanoTime() < deadline) {
             if (check.success()) {
                 return;
             }

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/config/ConfigMonitorServiceTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/config/ConfigMonitorServiceTest.java
@@ -17,14 +17,13 @@
 
 package org.apache.eventmesh.common.config;
 
-import java.io.File;
+import org.apache.eventmesh.common.file.FileChangeContext;
+
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import org.apache.eventmesh.common.file.FileChangeContext;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -114,7 +113,7 @@ public class ConfigMonitorServiceTest {
      * </ul>
      */
     @Test
-    @DisplayName("monitor() - 正常注册已存在的配置文件")
+    @DisplayName("monitor() - registers an existing config file")
     void testMonitorNormal() throws Exception {
         Path tempFile = Files.createTempFile("test-monitor", ".properties");
         tempFile.toFile().createNewFile();
@@ -137,7 +136,7 @@ public class ConfigMonitorServiceTest {
      * <p>Verification: No exception, early termination.</p>
      */
     @Test
-    @DisplayName("monitor() - filePath 为 null 时跳过监控")
+    @DisplayName("monitor() - skips monitoring when filePath is null")
     void testMonitorNullFilePath() {
         ConfigInfo configInfo = new ConfigInfo();
         configInfo.setFilePath(null);
@@ -153,7 +152,7 @@ public class ConfigMonitorServiceTest {
      * <p>Verification: No exception, early termination.</p>
      */
     @Test
-    @DisplayName("monitor() - 文件不存在时跳过监控")
+    @DisplayName("monitor() - skips monitoring when the file does not exist")
     void testMonitorFileNotExist() {
         ConfigInfo configInfo = new ConfigInfo();
         // Use definitely non-existent path in system
@@ -169,7 +168,7 @@ public class ConfigMonitorServiceTest {
      * <p>Verification: After clear(), support() returns false for all paths.</p>
      */
     @Test
-    @DisplayName("clear() - 清除所有已注册的监控项")
+    @DisplayName("clear() - removes all registered monitoring entries")
     void testClear() throws Exception {
         Path tempFile1 = Files.createTempFile("test-clear-1", ".properties");
         Path tempFile2 = Files.createTempFile("test-clear-2", ".properties");
@@ -205,11 +204,11 @@ public class ConfigMonitorServiceTest {
      * </ul>
      */
     @Test
-    @DisplayName("support() - 正确判断文件是否已注册监控")
+    @DisplayName("support() - identifies whether a file is registered for monitoring")
     void testSupport() throws Exception {
         Path tempFile = Files.createTempFile("test-support", ".properties");
         tempFile.toFile().createNewFile();
-        String normalizedPath = tempFile.toAbsolutePath().normalize().toString();
+        final String normalizedPath = tempFile.toAbsolutePath().normalize().toString();
 
         FileChangeContext registeredCtx = new FileChangeContext();
         registeredCtx.setDirectoryPath(tempFile.getParent().toString());
@@ -244,12 +243,12 @@ public class ConfigMonitorServiceTest {
      * </ul>
      */
     @Test
-    @DisplayName("ConfigMonitorFileChangeListener.onChanged() - 文件变更触发热重载")
+    @DisplayName("ConfigMonitorFileChangeListener.onChanged() - reloads config after a file change")
     void testOnChangedTriggersReload() throws Exception {
         // Create temp properties file with initial content
         Path tempFile = Files.createTempFile("test-reload", ".properties");
         String originalValue = "test-value-original";
-        String updatedValue = "test-value-updated";
+        final String updatedValue = "test-value-updated";
         writeProperty(tempFile, "test.key", originalValue);
 
         TestMonitorHolder holder = new TestMonitorHolder();
@@ -269,7 +268,7 @@ public class ConfigMonitorServiceTest {
     }
 
     @Test
-    @DisplayName("buildConfigInstance() - monitor=true 时文件变更更新原配置对象")
+    @DisplayName("buildConfigInstance() - updates the original config object when monitor is enabled")
     void testBuildConfigInstanceMonitor() throws Exception {
         Path tempDir = Files.createTempDirectory("test-build-monitor");
         Path tempFile = tempDir.resolve("monitor-test.properties");
@@ -306,7 +305,7 @@ public class ConfigMonitorServiceTest {
      * <p>Verification: load() completes without throwing exception, only logs error.</p>
      */
     @Test
-    @DisplayName("load() - 文件不存在时捕获异常不外抛")
+    @DisplayName("load() - catches exceptions when the file does not exist")
     void testLoadWithException() {
         ConfigInfo configInfo = new ConfigInfo();
         configInfo.setPath("/non/exist/path.properties");
@@ -327,7 +326,7 @@ public class ConfigMonitorServiceTest {
      * <p>Verification: Method returns normally, no "config reload success" log.</p>
      */
     @Test
-    @DisplayName("load() - 配置未变化时跳过重载")
+    @DisplayName("load() - skips reload when config is unchanged")
     void testLoadSkipWhenSame() throws Exception {
         Path tempFile = Files.createTempFile("test-skip-reload", ".properties");
         writeProperty(tempFile, "test.key", "unchanged");

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/file/WatchFileManagerTest.java
@@ -23,6 +23,7 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.attribute.FileTime;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
@@ -54,10 +55,13 @@ public class WatchFileManagerTest {
             properties.load(bufferedReader);
         }
 
+        final long lastModified = Files.getLastModifiedTime(tempConfigFile.toPath()).toMillis();
         try (FileWriter fw = new FileWriter(tempConfigFile)) {
             properties.setProperty("eventMesh.server.newAdd", "newAdd");
             properties.store(fw, "newAdd");
         }
+        Files.setLastModifiedTime(tempConfigFile.toPath(),
+            FileTime.fromMillis(Math.max(System.currentTimeMillis(), lastModified) + 2_000));
 
         Mockito.verify(mockFileChangeListener, Mockito.timeout(15_000).atLeastOnce())
                 .onChanged(Mockito.argThat(isFileUnderTest(tempConfigFile.getParent(), tempConfigFile.getName())));


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>[Enhancement] Use JDK WatchService in ConfigMonitorService to Monitor Config Changes</h1><p>Fixes #3331</p><h2>Motivation</h2><p>The original <code inline="">ConfigMonitorService</code> used a scheduled polling mechanism to detect configuration file changes every 30 seconds. This approach had the following drawbacks:</p><ol><li><p><strong>High latency</strong>: after a configuration file was changed, it could take up to 30 seconds before the change was detected.</p></li><li><p><strong>Unnecessary resource usage</strong>: the scheduled task kept running periodically even when no configuration file had changed.</p></li></ol><h2>Modifications</h2><h3>Core Changes</h3><p>This PR changes the configuration monitoring mechanism from a polling-based model to an event-driven model.</p>
Item | Original Implementation | New Implementation
-- | -- | --
Monitoring mechanism | ScheduledExecutorService polling every 30 seconds | JDK WatchService event-driven monitoring
Data structures | ArrayList | ConcurrentHashMap + CopyOnWriteArrayList
Response latency | Up to 30 seconds | Near real-time
Resource usage | Periodic polling regardless of changes | Triggered only when file system events occur

<h3>New Files</h3><ul><li><p><strong><code inline="">WatchFileManager.java</code></strong>: manages file monitoring by using JDK <code inline="">WatchService</code> to monitor directories.</p></li><li><p><strong><code inline="">FileChangeListener.java</code></strong>: defines the listener interface for file change events.</p></li><li><p><strong><code inline="">FileChangeContext.java</code></strong>: provides context information for file change events.</p></li></ul><h3>Changes in <code inline="">ConfigMonitorService.java</code></h3><ul><li><p>Removed the <code inline="">ScheduledExecutorService</code> based polling mechanism.</p></li><li><p>Removed the <code inline="">TIME_INTERVAL</code> constant.</p></li><li><p>Added a <code inline="">ConcurrentHashMap</code> to store mappings between configuration file paths and listeners.</p></li><li><p>Registered file change listeners through <code inline="">WatchFileManager.registerFileChangeListener()</code>.</p></li><li><p>Implemented <code inline="">FileChangeListener</code> to handle configuration reload callbacks.</p></li></ul><h2>Solution</h2><h3>1. Replace Polling with Event-Driven Monitoring</h3><p>The new implementation uses JDK <code inline="">WatchService</code> to listen for file system events.</p><pre><code class="language-java">// Use JDK WatchService to monitor file system events.
WatchFileManager.registerFileChangeListener(directoryPath, CONFIG_FILE_CHANGE_LISTENER);
</code></pre><p>This relies on the underlying operating system’s file notification mechanism, avoiding unnecessary periodic polling.</p><h3>2. Match the Changed File Path</h3><p><code inline="">ConfigMonitorService</code> implements <code inline="">FileChangeListener</code> and only handles changes for registered configuration files.</p><pre><code class="language-java">// Only handle monitored configuration files.
List&lt;ConfigInfo&gt; configInfoList = CONFIG_INFO_MAP.get(changedFilePath);
if (configInfoList != null) {
    for (ConfigInfo configInfo : configInfoList) {
        load(configInfo);
    }
}
</code></pre><h3>3. Improve Resource Management</h3><p>All monitoring resources are cleaned up automatically when the JVM exits.</p><pre><code class="language-java">// Automatically clean up resources when the JVM shuts down.
static {
    Runtime.getRuntime().addShutdownHook(new Thread(() -&gt; {
        log.info("[ConfigMonitorService] shutdown, clearing {} entries", CONFIG_INFO_MAP.size());
        CONFIG_INFO_MAP.clear();
    }));
}
</code></pre><h2>Benefits</h2><ul><li><p>Configuration changes can be detected in near real time.</p></li><li><p>Periodic polling is removed, reducing unnecessary resource consumption.</p></li><li><p>The new implementation is more scalable when multiple configuration files are monitored.</p></li><li><p>Thread-safe data structures are used to improve concurrent access safety.</p></li></ul></body></html><!--EndFragment-->
</body>
</html>