### PR TITLE
[ISSUE 5224] Fix docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,26 @@
 dist/
 build/
+
+# VCS
+.git/
+.gitignore
+
+# Non-Java SDKs (not included in Gradle build)
+eventmesh-sdks/eventmesh-sdk-rust/
+eventmesh-sdks/eventmesh-sdk-go/
+eventmesh-sdks/eventmesh-sdk-c/
+
+# Rust / Node build artifacts
+**/target/
+**/node_modules/
+
+# IDE
+.idea/
+.vscode/
+*.iml
+
+# Docs & misc
+docs/
+*.md
+LICENSE
+NOTICE

--- a/.dockerignore
+++ b/.dockerignore
@@ -22,5 +22,3 @@ eventmesh-sdks/eventmesh-sdk-c/
 # Docs & misc
 docs/
 *.md
-LICENSE
-NOTICE

--- a/docker/Dockerfile_jdk11
+++ b/docker/Dockerfile_jdk11
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM eclipse-temurin:11-jdk as builder
+FROM eclipse-temurin:11-jdk AS builder
 WORKDIR /build
 COPY . .
 RUN ./gradlew clean build dist --parallel --daemon
@@ -29,9 +29,9 @@ COPY --from=builder /build/dist ./
 
 EXPOSE 10000 10105 10106 10205
 
-ENV DOCKER true
-ENV EVENTMESH_HOME /data/app/eventmesh
-ENV EVENTMESH_LOG_HOME /data/app/eventmesh/logs
-ENV CONFPATH /data/app/eventmesh/conf
+ENV DOCKER=true
+ENV EVENTMESH_HOME=/data/app/eventmesh
+ENV EVENTMESH_LOG_HOME=/data/app/eventmesh/logs
+ENV CONFPATH=/data/app/eventmesh/conf
 
 CMD ["bash", "bin/start.sh"]

--- a/docker/Dockerfile_jdk11
+++ b/docker/Dockerfile_jdk11
@@ -15,13 +15,13 @@
 # limitations under the License.
 #
 
-FROM openjdk:11-jdk as builder
+FROM eclipse-temurin:11-jdk as builder
 WORKDIR /build
 COPY . .
 RUN ./gradlew clean build dist --parallel --daemon
 RUN ./gradlew installPlugin
 
-FROM openjdk:11-jdk
+FROM eclipse-temurin:11-jdk
 RUN apt-get update && apt-get install -y locales procps
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 --quiet
 WORKDIR /data/app/eventmesh

--- a/docker/Dockerfile_jdk8
+++ b/docker/Dockerfile_jdk8
@@ -15,12 +15,12 @@
 # limitations under the License.
 #
 
-FROM eclipse-temurin:11-jdk as builder_11
+FROM eclipse-temurin:11-jdk AS builder_11
 WORKDIR /build
 COPY . .
 RUN ./gradlew clean generateGrammarSource --parallel --daemon
 
-FROM eclipse-temurin:8-jdk as builder_8
+FROM eclipse-temurin:8-jdk AS builder_8
 WORKDIR /build
 COPY --from=builder_11 /build ./
 RUN ./gradlew clean build dist -x spotlessJava -x generateGrammarSource --parallel --daemon
@@ -34,9 +34,9 @@ COPY --from=builder_8 /build/dist ./
 
 EXPOSE 10000 10105 10106 10205
 
-ENV DOCKER true
-ENV EVENTMESH_HOME /data/app/eventmesh
-ENV EVENTMESH_LOG_HOME /data/app/eventmesh/logs
-ENV CONFPATH /data/app/eventmesh/conf
+ENV DOCKER=true
+ENV EVENTMESH_HOME=/data/app/eventmesh
+ENV EVENTMESH_LOG_HOME=/data/app/eventmesh/logs
+ENV CONFPATH=/data/app/eventmesh/conf
 
 CMD ["bash", "bin/start.sh"]

--- a/docker/Dockerfile_jdk8
+++ b/docker/Dockerfile_jdk8
@@ -15,18 +15,18 @@
 # limitations under the License.
 #
 
-FROM openjdk:11-jdk as builder_11
+FROM eclipse-temurin:11-jdk as builder_11
 WORKDIR /build
 COPY . .
 RUN ./gradlew clean generateGrammarSource --parallel --daemon
 
-FROM openjdk:8-jdk as builder_8
+FROM eclipse-temurin:8-jdk as builder_8
 WORKDIR /build
 COPY --from=builder_11 /build ./
 RUN ./gradlew clean build dist -x spotlessJava -x generateGrammarSource --parallel --daemon
 RUN ./gradlew installPlugin
 
-FROM openjdk:8-jdk
+FROM eclipse-temurin:8-jdk
 RUN apt-get update && apt-get install -y locales procps
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 --quiet
 WORKDIR /data/app/eventmesh

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,14 +15,6 @@
  * limitations under the License.
  */
 
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        mavenCentral()
-        maven { url "https://maven.aliyun.com/repository/gradle-plugin" }
-    }
-}
-
 plugins {
     id 'com.gradle.develocity' version '3.18.2'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,14 @@
  * limitations under the License.
  */
 
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+        maven { url "https://maven.aliyun.com/repository/gradle-plugin" }
+    }
+}
+
 plugins {
     id 'com.gradle.develocity' version '3.18.2'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'


### PR DESCRIPTION
Fixes #5224

https://github.com/apache/eventmesh/actions/runs/20596142447
> buildx failed with: ERROR: failed to build: failed to solve: openjdk:11-jdk: failed to resolve source metadata for docker.io/library/openjdk:11-jdk: docker.io/library/openjdk:11-jdk: not found

### Motivation

https://github.com/docker-library/openjdk/issues/505

### Modifications

Use eclipse temurin as base image instead. 
Fix warnings output by docker build. 
Exclude sdk/ rust / node build artifacts to speed up copy.

### Documentation

- Does this pull request introduce a new feature? no
