### PR TITLE
feat(state): control-plane store SPI + deprecate zombie code (#5301 Sub-PR A)

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/ClusterCoordinator.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/ClusterCoordinator.java
@@ -35,7 +35,10 @@ import lombok.extern.slf4j.Slf4j;
  * on A.</p>
  */
 /**
- * Routes a CloudEvent to the right instance per the cluster subscription view. Reserved for the deferred `PARTITION_OWNED_PULL` delivery topology (issue #5309); not wired in the current `LOCAL_STICKY_PULL` default. Will be removed once the topology lands.
+ * Routes a CloudEvent to the right instance per the cluster subscription view.
+ * Reserved for the deferred {@code PARTITION_OWNED_PULL} delivery topology
+ * (issue #5309); not wired in the current {@code LOCAL_STICKY_PULL} default.
+ * Will be removed once the topology lands.
  */
 @Deprecated(forRemoval = true)
 @Slf4j

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/ClusterCoordinator.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/ClusterCoordinator.java
@@ -34,6 +34,10 @@ import lombok.extern.slf4j.Slf4j;
  * makes "subscribe on A, pull-and-dispatch on B (the partition owner)" still reach the subscriber
  * on A.</p>
  */
+/**
+ * Routes a CloudEvent to the right instance per the cluster subscription view. Reserved for the deferred `PARTITION_OWNED_PULL` delivery topology (issue #5309); not wired in the current `LOCAL_STICKY_PULL` default. Will be removed once the topology lands.
+ */
+@Deprecated(forRemoval = true)
 @Slf4j
 public class ClusterCoordinator {
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/ClusterSubscriptionStore.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/ClusterSubscriptionStore.java
@@ -17,6 +17,7 @@
 
 package org.apache.eventmesh.runtime.cluster;
 
+import org.apache.eventmesh.runtime.state.SubscriptionStore;
 import org.apache.eventmesh.runtime.subscription.DistributionMode;
 
 import java.util.ArrayList;
@@ -38,7 +39,7 @@ import lombok.extern.slf4j.Slf4j;
  * "subscribe on A, pull on B" still deliver.</p>
  */
 @Slf4j
-public class ClusterSubscriptionStore {
+public class ClusterSubscriptionStore implements SubscriptionStore {
 
     public static final String SUB_PREFIX = "/em/subs/";
 
@@ -69,10 +70,11 @@ public class ClusterSubscriptionStore {
         applyChange(k, sub.encode(), false);
     }
 
-    public void remove(String topic, String clientId) {
+    public boolean remove(String topic, String clientId) {
         String k = key(topic, clientId);
-        meta.delete(k);
+        boolean removed = meta.delete(k);
         applyChange(k, null, true);
+        return removed;
     }
 
     /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/MetaBackedOffsetStore.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/MetaBackedOffsetStore.java
@@ -41,7 +41,10 @@ import lombok.extern.slf4j.Slf4j;
  * reads/writes, so the runtime degrades to local-only without losing progress (§13.2.9).</p>
  */
 /**
- * Two-tier offset store: local RocksDB plus an async remote copy in MetaStore. Reserved for the deferred `PARTITION_OWNED_PULL` delivery topology (issue #5309); not wired in the current `LOCAL_STICKY_PULL` default. Will be removed once the topology lands.
+ * Two-tier offset store: local RocksDB plus an async remote copy in MetaStore.
+ * Reserved for the deferred {@code PARTITION_OWNED_PULL} delivery topology
+ * (issue #5309); not wired in the current {@code LOCAL_STICKY_PULL} default.
+ * Will be removed once the topology lands.
  */
 @Deprecated(forRemoval = true)
 @Slf4j

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/MetaBackedOffsetStore.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/MetaBackedOffsetStore.java
@@ -40,6 +40,10 @@ import lombok.extern.slf4j.Slf4j;
  * <p>When Meta is unavailable the flusher logs and keeps the dirty set; local RocksDB still serves
  * reads/writes, so the runtime degrades to local-only without losing progress (§13.2.9).</p>
  */
+/**
+ * Two-tier offset store: local RocksDB plus an async remote copy in MetaStore. Reserved for the deferred `PARTITION_OWNED_PULL` delivery topology (issue #5309); not wired in the current `LOCAL_STICKY_PULL` default. Will be removed once the topology lands.
+ */
+@Deprecated(forRemoval = true)
 @Slf4j
 public class MetaBackedOffsetStore implements OffsetStore {
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/PartitionOwnership.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/PartitionOwnership.java
@@ -56,6 +56,10 @@ import lombok.extern.slf4j.Slf4j;
  * Remote offset (§13.2.4, G5) is not yet here — the local offset store remains the source of truth
  * for delivery progress.</p>
  */
+/**
+ * Partition ownership state machine for the <em>deferred</em> {@code PARTITION_OWNED_PULL} delivery topology. Reserved for the deferred `PARTITION_OWNED_PULL` delivery topology (issue #5309); not wired in the current `LOCAL_STICKY_PULL` default. Will be removed once the topology lands.
+ */
+@Deprecated(forRemoval = true)
 @Slf4j
 public class PartitionOwnership {
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/PartitionOwnership.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/PartitionOwnership.java
@@ -57,7 +57,10 @@ import lombok.extern.slf4j.Slf4j;
  * for delivery progress.</p>
  */
 /**
- * Partition ownership state machine for the <em>deferred</em> {@code PARTITION_OWNED_PULL} delivery topology. Reserved for the deferred `PARTITION_OWNED_PULL` delivery topology (issue #5309); not wired in the current `LOCAL_STICKY_PULL` default. Will be removed once the topology lands.
+ * Partition ownership state machine for the <em>deferred</em> {@code PARTITION_OWNED_PULL}
+ * delivery topology. Reserved for the deferred {@code PARTITION_OWNED_PULL} delivery topology
+ * (issue #5309); not wired in the current {@code LOCAL_STICKY_PULL} default.
+ * Will be removed once the topology lands.
  */
 @Deprecated(forRemoval = true)
 @Slf4j

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/session/AgentRegistrar.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/session/AgentRegistrar.java
@@ -68,7 +68,7 @@ public class AgentRegistrar {
         String parent = pickShard();
         ensure(parent);
         ensure(clientParent);
-        registry.register(agentId, parent, capabilities, capacity);
+        registry.registerAgent(agentId, parent, capabilities, capacity);
         log.info("agent registered: agentId={} parent={} capabilities={} capacity={}", agentId, parent, capabilities, capacity);
         return new RegisterResult(parent, clientParent);
     }
@@ -90,7 +90,7 @@ public class AgentRegistrar {
 
     /** Flip to READY (after subscribe). {@code false} if the agent isn't registered. */
     public boolean ready(String agentId) {
-        boolean ok = registry.markReady(agentId);
+        boolean ok = registry.markAgentReady(agentId);
         log.info("agent ready: agentId={} ok={}", agentId, ok);
         return ok;
     }
@@ -101,7 +101,7 @@ public class AgentRegistrar {
     }
 
     public void unregister(String agentId) {
-        registry.unregister(agentId);
+        registry.unregisterAgent(agentId);
         log.info("agent unregistered: agentId={}", agentId);
     }
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/session/SessionRegistry.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/session/SessionRegistry.java
@@ -18,6 +18,7 @@
 package org.apache.eventmesh.runtime.session;
 
 import org.apache.eventmesh.runtime.cluster.MetaStore;
+import org.apache.eventmesh.runtime.state.SessionStore;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,7 +50,7 @@ import lombok.extern.slf4j.Slf4j;
  * {@code heartbeatTtlMs} window: {@link #readyAgents()} drops agents whose {@code hb} is stale.</p>
  */
 @Slf4j
-public class SessionRegistry {
+public class SessionRegistry implements SessionStore {
 
     public static final String AGENT_PREFIX = "/em/agents/";
     public static final String BINDING_PREFIX = "/em/bindings/";
@@ -83,7 +84,7 @@ public class SessionRegistry {
     // -------------------- agents --------------------
 
     /** Register a new agent in {@link AgentStatus#PENDING} (flipped to READY after subscribe, §5.2). */
-    public void register(String agentId, String parent, List<String> capabilities, int capacity) {
+    public void registerAgent(String agentId, String parent, List<String> capabilities, int capacity) {
         AgentRecord r = AgentRecord.builder()
             .agentId(agentId).parent(parent).capabilities(capabilities).capacity(capacity)
             .load(0).status(AgentStatus.PENDING.name()).hb(clock.getAsLong()).build();
@@ -92,7 +93,7 @@ public class SessionRegistry {
     }
 
     /** Flip a PENDING agent to READY (after it has subscribed to its channel). {@code false} if unknown. */
-    public boolean markReady(String agentId) {
+    public boolean markAgentReady(String agentId) {
         AgentRecord r = agent(agentId);
         if (r == null) {
             return false;
@@ -123,7 +124,7 @@ public class SessionRegistry {
         return true;
     }
 
-    public void unregister(String agentId) {
+    public void unregisterAgent(String agentId) {
         agentCache.remove(agentId);
         meta.delete(AGENT_PREFIX + agentId);
         removeBindingsForAgent(agentId);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/state/DeadLetterStore.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/state/DeadLetterStore.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.state;
+
+/**
+ * Durable ledger of dead-lettered deliveries (issue #5301 §DeadLetterStore, Sub-PR C).
+ *
+ * <p>Three-tier model: the message body itself is published to the downstream DLQ topic (e.g.
+ * {@code <topic>_DLQ}) by {@code DeadLetterSink}; the runtime needs a small, durable record
+ * of <em>which deliveryIds are confirmed dead</em> so the dispatcher can retire them safely and
+ * so a hard restart does not re-route the same delivery.</p>
+ *
+ * <p>The Meta-backed implementation stores one record per deliveryId at
+ * {@code /em/dlq/<deliveryId>} = {@code "<dlqTopic>:<dlqOffset>"} using a CAS write: the first
+ * recorder wins (so a concurrent retry cannot double-record). A read-side helper
+ * {@link #isDeadLettered(String)} lets the dispatcher skip the {@code retire} step for any
+ * delivery that is already on the ledger.</p>
+ *
+ * <p>This interface is the durable counterpart of {@code DeadLetterSink} (which handles the
+ * actual message egress). Both are part of the delivery state machine, but they are kept
+ * separate so a sink failure (downstream MQ unavailable) does not lose the durable record
+ * and a record-store failure does not block the downstream write.</p>
+ */
+public interface DeadLetterStore {
+
+    /**
+     * Record a deliveryId as dead-lettered. Idempotent: a second call with the same
+     * {@code deliveryId} is a no-op and returns {@code true} (already recorded).
+     *
+     * @param deliveryId the delivery that exhausted its retry budget
+     * @param dlqTopic   the DLQ topic the body was published to
+     * @param dlqOffset  the offset within {@code dlqTopic} (or -1 if the sink does not surface one)
+     * @return true if the record was newly written (first time) or already present; false only
+     *         on backend failure
+     */
+    boolean recordDeadLetter(String deliveryId, String dlqTopic, long dlqOffset);
+
+    /**
+     * @return true if {@code deliveryId} is on the ledger (regardless of who recorded it)
+     */
+    boolean isDeadLettered(String deliveryId);
+
+    /**
+     * Force any buffered writes to durable storage.
+     */
+    void flush();
+
+    /**
+     * Release resources. After close the store must not be used.
+     */
+    void close();
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/state/SessionStore.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/state/SessionStore.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.state;
+
+import java.util.List;
+
+/**
+ * Cluster-shared session control-plane (issue #5301 §SessionStore).
+ *
+ * <p>Wraps the streaming-session design from {@code org.apache.eventmesh.runtime.session}. It
+ * holds three independent collections on the underlying {@code MetaStore}:</p>
+ *
+ * <ul>
+ *   <li><b>agent registry</b> — {@code /em/agents/<agentId>} (capabilities, capacity, parent, load, status, heartbeat)</li>
+ *   <li><b>client bindings</b> — {@code /em/bindings/<clientId>} (client→agent affinity)</li>
+ *   <li><b>session metadata</b> — {@code /em/sessions/<sessionId>}</li>
+ * </ul>
+ *
+ * <p>The default implementation is {@code SessionRegistry} (Meta-backed with local cache). This
+ * interface extracts the contract so future implementations (in-process test fake, an alternate
+ * store) can be swapped without changing the matchmaker, router, or admin callers.</p>
+ *
+ * <p>Liveness is enforced by a heartbeat TTL window: callers that have not refreshed their
+ * heartbeat within the window are excluded from {@link #readyAgents()}.</p>
+ *
+ * <p>The record types {@code AgentRecord}, {@code AgentBinding}, {@code SessionMeta} live in
+ * {@code org.apache.eventmesh.runtime.session} (the implementation package) and are referenced
+ * by the interface so that {@code SessionRegistry} can {@code implement} it directly without an
+ * adapter. Test fakes in other packages can supply their own record types if needed.</p>
+ */
+public interface SessionStore {
+
+    /**
+     * Register a new agent in {@code PENDING} state (will be flipped to {@code READY} after
+     * the agent subscribes to its channel).
+     */
+    void registerAgent(String agentId, String parent, java.util.List<String> capabilities, int capacity);
+
+    /**
+     * Flip a {@code PENDING} agent to {@code READY} (after it has subscribed to its channel).
+     *
+     * @return false if the agent is not registered
+     */
+    boolean markAgentReady(String agentId);
+
+    /**
+     * Refresh heartbeat and reported load. {@code false} if the agent isn't registered.
+     */
+    boolean heartbeat(String agentId, int activeSessions);
+
+    /**
+     * Remove an agent and every client binding pointing at it (so a dying agent doesn't leave
+     * orphaned client bindings).
+     */
+    void unregisterAgent(String agentId);
+
+    /**
+     * @return the agent record, or {@code null} if not registered
+     */
+    org.apache.eventmesh.runtime.session.AgentRecord agent(String agentId);
+
+    /**
+     * All agents eligible for matchmaking: {@code READY} status, fresh heartbeat, not at capacity.
+     */
+    List<org.apache.eventmesh.runtime.session.AgentRecord> readyAgents();
+
+    /**
+     * Bind a client to an agent (affinity).
+     */
+    void bind(String clientId, String agentId);
+
+    /**
+     * @return the binding record, or {@code null} if no binding
+     */
+    org.apache.eventmesh.runtime.session.SessionRegistry.AgentBinding binding(String clientId);
+
+    /**
+     * @return true if a binding was removed
+     */
+    boolean unbind(String clientId);
+
+    /**
+     * Record a mode-1 streaming-call session.
+     */
+    void putSession(String sessionId, String clientId, String agentId);
+
+    /**
+     * @return the session record, or {@code null} if no session
+     */
+    org.apache.eventmesh.runtime.session.SessionRegistry.SessionMeta session(String sessionId);
+
+    /**
+     * Refresh a session's last-active timestamp (called on each {@code STREAM_REQ}). No-op if
+     * the session is gone.
+     */
+    void touchSession(String sessionId);
+
+    /**
+     * Remove every session idle for longer than {@code sessionTtlMs}. Returns the expired
+     * sessionIds so the caller can tear down data-path state.
+     */
+    List<String> expireStaleSessions(long sessionTtlMs);
+
+    /**
+     * @return true if the session existed and was removed
+     */
+    boolean removeSession(String sessionId);
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/state/SubscriptionStore.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/state/SubscriptionStore.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.state;
+
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+import org.apache.eventmesh.runtime.subscription.DistributionMode;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Cluster-shared subscription registry (issue #5301 §SubscriptionStore).
+ *
+ * <p>Subscriptions live under {@code /em/subs/<topic>/<clientId>}. Every instance watches that
+ * prefix so a message pulled on the partition-owner instance can be dispatched to a subscriber
+ * that registered on a different instance — this is what makes "subscribe on A, pull on B"
+ * deliver in the {@code LOCAL_STICKY_PULL} topology.</p>
+ *
+ * <p>The default implementation is Meta-backed ({@code ClusterSubscriptionStore} in
+ * {@code org.apache.eventmesh.runtime.cluster}). Tests use an in-process implementation that
+ * keeps state in a {@code ConcurrentHashMap}. The two implementations are equivalent in their
+ * public contract; this interface is the seam for swapping.</p>
+ *
+ * <p>Subscription state is updated via plain {@code put} (not CAS): the latest write wins, and
+ * subscribers are expected to send keep-alive heartbeats so a stale entry from a dead client is
+ * overwritten by a reconnect. See issue #5301 for the wider design context.</p>
+ */
+public interface SubscriptionStore {
+
+    /**
+     * Register (or update) a subscription cluster-wide.
+     *
+     * @param topic       the topic the subscriber is interested in
+     * @param clientId    the subscriber's identifier
+     * @param instanceId  the instance the subscriber currently lives on
+     * @param mode        the distribution mode for the matching events
+     * @param filterSpec  CloudEvents filter spec; {@code null} or empty means "match everything"
+     */
+    void put(String topic, String clientId, String instanceId, DistributionMode mode, String filterSpec);
+
+    /**
+     * Remove a subscription cluster-wide.
+     *
+     * @return true if a subscription was removed
+     */
+    boolean remove(String topic, String clientId);
+
+    /**
+     * All subscribers (across instances) on a topic whose filter matches {@code event}, after
+     * applying the distribution mode. Simple per-topic round-robin for {@code LOAD_BALANCE} is
+     * the caller's responsibility.
+     */
+    List<org.apache.eventmesh.runtime.cluster.ClusterSub> targetsFor(String topic, EventMeshFrame event);
+
+    /**
+     * Which instance a clientId currently lives on (for routing decisions on the partition-owner
+     * instance). Returns {@code null} if the client is not subscribed cluster-wide.
+     */
+    String instanceOf(String clientId);
+
+    /**
+     * All topics with at least one registered subscription.
+     */
+    Set<String> topics();
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/state/TaskStore.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/state/TaskStore.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.state;
+
+import java.util.List;
+
+/**
+ * A2A task state, persisted via Meta (issue #5301 §TaskStore, Sub-PR C).
+ *
+ * <p>Reintroduces the A2A task model lost when #5274 reverted #5260. The store is the
+ * <b>only</b> writer to {@code /em/tasks/<taskId>}; A2A handlers ({@code /a2a/tasks/send},
+ * {@code /a2a/tasks/sendSubscribe}, the SSE {@code /a2a/tasks/{id}/stream} endpoint) read
+ * through it.</p>
+ *
+ * <p>The state model: a {@code TaskRecord = { taskId, agentId, clientId, status, createdAt,
+ * updatedAt, input, output? }} where {@code status ∈ {PENDING, RUNNING, COMPLETED, FAILED,
+ * CANCELED}}. Status transitions are last-writer-wins on a per-task basis, with a task epoch
+ * (set at {@link #createTask}) preventing stale writes from a previous Runtime instance from
+ * overwriting a fresh status (issue #5291 idempotency-style).</p>
+ *
+ * <p>The Runtime dispatcher is the <b>sole</b> transport — A2A requests arrive via the
+ * {@code a2a} distribution mode on {@code SubscriptionManager} and are routed through the
+ * existing dispatcher, not a parallel gateway. This is the property the original #5259 design
+ * missed and the reason #5274 reverted it.</p>
+ */
+public interface TaskStore {
+
+    /** Task lifecycle states. */
+    enum Status {
+        PENDING, RUNNING, COMPLETED, FAILED, CANCELED
+    }
+
+    /**
+     * A persisted A2A task.
+     */
+    final class TaskRecord {
+        public final String taskId;
+        public final String agentId;
+        public final String clientId;
+        public volatile Status status;
+        public final long createdAtMs;
+        public volatile long updatedAtMs;
+        /** Opaque JSON or wire-format input the caller submitted. */
+        public final String input;
+        /** Opaque output; null until {@link #updateStatus} transitions to {@code COMPLETED} or {@code FAILED}. */
+        public volatile String output;
+        /** Monotonic per-task epoch; set at creation, never reset, used to reject stale writes. */
+        public final long taskEpoch;
+
+        public TaskRecord(String taskId, String agentId, String clientId, Status status,
+                          long createdAtMs, long updatedAtMs, String input, String output, long taskEpoch) {
+            this.taskId = taskId;
+            this.agentId = agentId;
+            this.clientId = clientId;
+            this.status = status;
+            this.createdAtMs = createdAtMs;
+            this.updatedAtMs = updatedAtMs;
+            this.input = input;
+            this.output = output;
+            this.taskEpoch = taskEpoch;
+        }
+    }
+
+    /**
+     * Create a new task in {@link Status#PENDING} state. {@code taskId} must be unique; a
+     * duplicate returns {@code null} (caller should retry with a fresh id).
+     */
+    TaskRecord createTask(String taskId, String agentId, String clientId, String input);
+
+    /**
+     * @return the task record, or {@code null} if no such task
+     */
+    TaskRecord getTask(String taskId);
+
+    /**
+     * Transition a task to a new status. The write is rejected (returns {@code false}) if
+     * the stored {@code taskEpoch} does not match {@code expectedTaskEpoch}; callers should
+     * re-read and retry on epoch mismatch.
+     *
+     * @return true on successful status update
+     */
+    boolean updateStatus(String taskId, long expectedTaskEpoch, Status newStatus, String output);
+
+    /**
+     * All tasks for an agent filtered by status (any status if {@code statusFilter} is null).
+     */
+    List<TaskRecord> listByAgent(String agentId, Status statusFilter);
+
+    /**
+     * Remove every task idle for longer than {@code olderThanMs}. Returns the expired
+     * taskIds so the caller can release any associated resources.
+     */
+    List<String> expireStale(long olderThanMs);
+
+    /**
+     * Force any buffered writes to durable storage.
+     */
+    void flush();
+
+    /**
+     * Release resources. After close the store must not be used.
+     */
+    void close();
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/state/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/state/package-info.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.state;
+
+/**
+ * Root package for the unified state control-plane (issue #5301).
+ *
+ * <p>Six stores live in this package (or its siblings in the existing module layout):</p>
+ *
+ * <ul>
+ *   <li>{@link org.apache.eventmesh.runtime.offset.OffsetStore} — per-subscriber distribution offset (RocksDB local, Meta async flush)</li>
+ *   <li>{@link org.apache.eventmesh.runtime.state.SubscriptionStore} — cluster-shared subscription registry (Meta prefix-watch)</li>
+ *   <li>{@link org.apache.eventmesh.runtime.state.SessionStore} — cluster-shared agent/session/binding registry (Meta prefix-watch)</li>
+ *   <li>{@link org.apache.eventmesh.runtime.state.DeadLetterStore} — durable ledger of dead-lettered deliveries (Meta CAS)</li>
+ *   <li>{@link org.apache.eventmesh.runtime.state.TaskStore} — A2A task state, persisted via Meta (issue #5301 Sub-PR C)</li>
+ *   <li>{@code DeliveryStateStore} — in-flight delivery state, persistent via RocksDB (issue #5301 Sub-PR B)</li>
+ * </ul>
+ *
+ * <p>Sub-PR A (this package's initial commit) introduces the 4 interfaces that did not exist as
+ * public contracts ({@code SubscriptionStore}, {@code SessionStore}, {@code DeadLetterStore},
+ * {@code TaskStore}). The other two ({@code OffsetStore}, {@code DeliveryStateStore}) are added
+ * by their respective sub-PRs.</p>
+ */

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/session/MatchmakerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/session/MatchmakerTest.java
@@ -43,8 +43,8 @@ class MatchmakerTest {
     }
 
     private void reg(String agentId, List<String> caps, int capacity) {
-        registry.register(agentId, "agent-parent-0", caps, capacity);
-        registry.markReady(agentId);
+        registry.registerAgent(agentId, "agent-parent-0", caps, capacity);
+        registry.markAgentReady(agentId);
     }
 
     @Test
@@ -132,7 +132,7 @@ class MatchmakerTest {
         matchmaker.open("c1", null); // binds c1→a1
         reg("a2", List.of("m1"), 10);
 
-        registry.unregister("a1"); // a1 dies → c1's binding now orphaned
+        registry.unregisterAgent("a1"); // a1 dies → c1's binding now orphaned
 
         // open() must drop the dead binding and matchmake a live agent (a2), not leak the binding
         assertThat(matchmaker.open("c1", null).agentId()).isEqualTo("a2");

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/session/SessionRegistryAtomicityTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/session/SessionRegistryAtomicityTest.java
@@ -39,9 +39,9 @@ class SessionRegistryAtomicityTest {
         AtomicLong clock = new AtomicLong(1000L);
         SessionRegistry reg = new SessionRegistry(new InMemoryMetaStore(), 30_000L, clock::get);
 
-        reg.register("a1", "parent-0", List.of("model-x"), 100);
+        reg.registerAgent("a1", "parent-0", List.of("model-x"), 100);
         clock.set(2000L);
-        assertTrue(reg.markReady("a1"));
+        assertTrue(reg.markAgentReady("a1"));
 
         AgentRecord r = reg.agent("a1");
         assertNotNull(r);
@@ -54,7 +54,7 @@ class SessionRegistryAtomicityTest {
         AtomicLong clock = new AtomicLong(1000L);
         SessionRegistry reg = new SessionRegistry(new InMemoryMetaStore(), 30_000L, clock::get);
 
-        reg.register("a1", "parent-0", List.of("model-x"), 100);
+        reg.registerAgent("a1", "parent-0", List.of("model-x"), 100);
         clock.set(2000L);
         assertTrue(reg.heartbeat("a1", 5));
 

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/session/SessionRegistryTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/session/SessionRegistryTest.java
@@ -40,13 +40,13 @@ class SessionRegistryTest {
         AtomicLong now = new AtomicLong(1_000_000L);
         SessionRegistry reg = new SessionRegistry(new InMemoryMetaStore(), 30_000L, now::get);
 
-        reg.register("a1", "agent-parent-0", CAPS, 10);
+        reg.registerAgent("a1", "agent-parent-0", CAPS, 10);
         assertThat(reg.agent("a1").getStatus()).isEqualTo(AgentStatus.PENDING.name());
         assertThat(reg.readyAgents()).isEmpty(); // PENDING, not yet routable
 
-        assertThat(reg.markReady("a1")).isTrue();
+        assertThat(reg.markAgentReady("a1")).isTrue();
         assertThat(reg.agent("a1").getStatus()).isEqualTo(AgentStatus.READY.name());
-        assertThat(reg.markReady("nope")).isFalse();
+        assertThat(reg.markAgentReady("nope")).isFalse();
 
         assertThat(reg.readyAgents()).extracting(AgentRecord::getAgentId).containsExactly("a1");
     }
@@ -55,8 +55,8 @@ class SessionRegistryTest {
     void heartbeatRefreshesHbAndLoad() {
         AtomicLong now = new AtomicLong(1_000_000L);
         SessionRegistry reg = new SessionRegistry(new InMemoryMetaStore(), 30_000L, now::get);
-        reg.register("a1", "agent-parent-0", CAPS, 10);
-        reg.markReady("a1");
+        reg.registerAgent("a1", "agent-parent-0", CAPS, 10);
+        reg.markAgentReady("a1");
 
         now.addAndGet(5_000L);
         assertThat(reg.heartbeat("a1", 3)).isTrue();
@@ -72,10 +72,10 @@ class SessionRegistryTest {
     void staleHeartbeatExcludedFromReady() {
         AtomicLong now = new AtomicLong(1_000_000L);
         SessionRegistry reg = new SessionRegistry(new InMemoryMetaStore(), 30_000L, now::get);
-        reg.register("a1", "agent-parent-0", CAPS, 10);
-        reg.markReady("a1");
-        reg.register("a2", "agent-parent-0", CAPS, 10);
-        reg.markReady("a2");
+        reg.registerAgent("a1", "agent-parent-0", CAPS, 10);
+        reg.markAgentReady("a1");
+        reg.registerAgent("a2", "agent-parent-0", CAPS, 10);
+        reg.markAgentReady("a2");
 
         now.addAndGet(31_000L); // age a1's heartbeat past the TTL
         reg.heartbeat("a2", 0); // a2 fresh again
@@ -87,8 +87,8 @@ class SessionRegistryTest {
     void atCapacityExcludedFromReady() {
         AtomicLong now = new AtomicLong(1_000_000L);
         SessionRegistry reg = new SessionRegistry(new InMemoryMetaStore(), 30_000L, now::get);
-        reg.register("a1", "agent-parent-0", CAPS, 2);
-        reg.markReady("a1");
+        reg.registerAgent("a1", "agent-parent-0", CAPS, 2);
+        reg.markAgentReady("a1");
         reg.heartbeat("a1", 2); // load == capacity
 
         assertThat(reg.readyAgents()).isEmpty();
@@ -97,11 +97,11 @@ class SessionRegistryTest {
     @Test
     void unregisterRemoves() {
         SessionRegistry reg = new SessionRegistry(new InMemoryMetaStore(), 30_000L);
-        reg.register("a1", "agent-parent-0", CAPS, 10);
-        reg.markReady("a1");
+        reg.registerAgent("a1", "agent-parent-0", CAPS, 10);
+        reg.markAgentReady("a1");
         assertThat(reg.agent("a1")).isNotNull();
 
-        reg.unregister("a1");
+        reg.unregisterAgent("a1");
         assertThat(reg.agent("a1")).isNull();
         assertThat(reg.readyAgents()).isEmpty();
     }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/DeadLetterStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/DeadLetterStoreTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
 import org.apache.eventmesh.runtime.cluster.MetaStore;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/DeadLetterStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/DeadLetterStoreTest.java
@@ -17,13 +17,12 @@
 
 package org.apache.eventmesh.runtime.state;
 
-import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
-import org.apache.eventmesh.runtime.cluster.MetaStore;
-
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
+import org.apache.eventmesh.runtime.cluster.MetaStore;
+import org.junit.jupiter.api.Test;
 
 /**
  * Sub-PR A baseline: the {@link DeadLetterStore} interface is the durable ledger of confirmed
@@ -69,10 +68,14 @@ class DeadLetterStoreTest {
         }
 
         @Override
-        public void flush() { /* no buffered writes */ }
+        public void flush() {
+            /* no buffered writes */
+        }
 
         @Override
-        public void close() { /* nothing to release */ }
+        public void close() {
+            /* nothing to release */
+        }
     }
 
     @Test

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/DeadLetterStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/DeadLetterStoreTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.state;
+
+import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
+import org.apache.eventmesh.runtime.cluster.MetaStore;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Sub-PR A baseline: the {@link DeadLetterStore} interface is the durable ledger of confirmed
+ * dead-lettered deliveries. This test verifies the idempotent Meta-backed record (the production
+ * implementation is built in Sub-PR C; this test only asserts the contract that any
+ * implementation must satisfy against the in-process {@link InMemoryMetaStore} semantics).
+ *
+ * <p>The test uses a tiny inline implementation backed by {@code InMemoryMetaStore} so that
+ * Sub-PR A does not pre-commit the production backing.</p>
+ */
+class DeadLetterStoreTest {
+
+    /**
+     * Minimal in-process implementation sufficient for the contract test. The production
+     * implementation (Sub-PR C) replaces this with a Meta CAS-backed ledger under
+     * {@code /em/dlq/<deliveryId>}.
+     */
+    static final class InProcessDeadLetterStore implements DeadLetterStore {
+        private final MetaStore meta;
+        private static final String PREFIX = "/em/dlq/";
+
+        InProcessDeadLetterStore(MetaStore meta) {
+            this.meta = meta;
+        }
+
+        private static String key(String deliveryId) {
+            return PREFIX + deliveryId;
+        }
+
+        @Override
+        public boolean recordDeadLetter(String deliveryId, String dlqTopic, long dlqOffset) {
+            String value = dlqTopic + ":" + dlqOffset;
+            // First-write-wins: try putIfAbsent; on already-present key, treat as success.
+            if (meta.get(key(deliveryId)) != null) {
+                return true;
+            }
+            return meta.putIfAbsent(key(deliveryId), value);
+        }
+
+        @Override
+        public boolean isDeadLettered(String deliveryId) {
+            return meta.get(key(deliveryId)) != null;
+        }
+
+        @Override
+        public void flush() { /* no buffered writes */ }
+
+        @Override
+        public void close() { /* nothing to release */ }
+    }
+
+    @Test
+    void recordOnceThenCheckIsDeadLettered() {
+        DeadLetterStore store = new InProcessDeadLetterStore(new InMemoryMetaStore());
+        assertFalse(store.isDeadLettered("d-1"));
+        assertTrue(store.recordDeadLetter("d-1", "topic_DLQ", 42L));
+        assertTrue(store.isDeadLettered("d-1"));
+    }
+
+    @Test
+    void recordIsIdempotent() {
+        DeadLetterStore store = new InProcessDeadLetterStore(new InMemoryMetaStore());
+        assertTrue(store.recordDeadLetter("d-1", "topic_DLQ", 1L));
+        assertTrue(store.recordDeadLetter("d-1", "topic_DLQ", 999L),
+            "second recordDeadLetter for the same deliveryId must return true (idempotent)");
+    }
+}

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/SessionStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/SessionStoreTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.state;
+
+import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
+import org.apache.eventmesh.runtime.session.AgentRecord;
+import org.apache.eventmesh.runtime.session.SessionRegistry;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Sub-PR A baseline: the {@link SessionStore} interface is the contract for the agent / binding /
+ * session control-plane. This test verifies that {@link SessionRegistry} implements it and that
+ * the round-trip + heartbeat-TTL semantics are preserved against an in-process Meta.
+ */
+class SessionStoreTest {
+
+    @Test
+    void sessionRegistryImplementsInterface() {
+        SessionStore store = new SessionRegistry(new InMemoryMetaStore(), 60_000L);
+        assertNotNull(store, "Meta-backed SessionStore must construct");
+    }
+
+    @Test
+    void registerAgentMarkReadyAndBind() {
+        SessionStore store = new SessionRegistry(new InMemoryMetaStore(), 60_000L);
+        store.registerAgent("a1", "parent-x", Arrays.asList("cap-1", "cap-2"), 4);
+        assertFalse(store.readyAgents().stream().anyMatch(a ->
+            ((AgentRecord) a).getAgentId().equals("a1")),
+            "PENDING agent must not appear in readyAgents()");
+
+        assertTrue(store.markAgentReady("a1"));
+        List<AgentRecord> ready = store.readyAgents();
+        assertEquals(1, ready.size());
+        assertEquals("a1", ready.get(0).getAgentId());
+
+        store.bind("client-c", "a1");
+        SessionRegistry.AgentBinding binding = store.binding("client-c");
+        assertNotNull(binding);
+        assertEquals("a1", binding.getAgentId());
+    }
+
+    @Test
+    void markAgentReadyReturnsFalseForUnknownAgent() {
+        SessionStore store = new SessionRegistry(new InMemoryMetaStore(), 60_000L);
+        assertFalse(store.markAgentReady("nope"));
+    }
+
+    @Test
+    void heartbeatRefreshesLiveness() {
+        // Mutable clock so we can simulate heartbeat TTL expiry without sleeping.
+        long[] now = new long[]{1_000L};
+        SessionStore store = new SessionRegistry(new InMemoryMetaStore(), 5_000L, () -> now[0]);
+        store.registerAgent("a1", null, List.of(), 4);
+        store.markAgentReady("a1");
+        assertEquals(1, store.readyAgents().size(), "fresh heartbeat must keep the agent ready");
+
+        // Jump the clock past the TTL window.
+        now[0] += 10_000;
+        assertEquals(0, store.readyAgents().size(), "stale heartbeat must drop the agent");
+
+        // Heartbeat refreshes liveness.
+        assertTrue(store.heartbeat("a1", 0));
+        assertEquals(1, store.readyAgents().size());
+    }
+
+    @Test
+    void putSessionAndTouch() {
+        SessionStore store = new SessionRegistry(new InMemoryMetaStore(), 60_000L);
+        store.putSession("s1", "c1", "a1");
+        assertNotNull(store.session("s1"));
+        store.touchSession("s1"); // no-op; should not throw
+        assertNotNull(store.session("s1"));
+        assertNull(store.session("nope"));
+    }
+
+    @Test
+    void expireStaleSessionsRemovesIdle() {
+        long[] now = new long[]{1_000L};
+        SessionStore store = new SessionRegistry(new InMemoryMetaStore(), 60_000L, () -> now[0]);
+        store.putSession("old", "c1", "a1");
+        // Move the clock forward and force the session to be idle past the TTL.
+        now[0] += 120_000;
+        List<String> expired = store.expireStaleSessions(60_000L);
+        assertEquals(1, expired.size());
+        assertEquals("old", expired.get(0));
+        assertNull(store.session("old"));
+    }
+}

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/SessionStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/SessionStoreTest.java
@@ -26,8 +26,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
 import org.apache.eventmesh.runtime.session.AgentRecord;
 import org.apache.eventmesh.runtime.session.SessionRegistry;
+
 import java.util.Arrays;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/SessionStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/SessionStoreTest.java
@@ -17,20 +17,18 @@
 
 package org.apache.eventmesh.runtime.state;
 
-import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
-import org.apache.eventmesh.runtime.session.AgentRecord;
-import org.apache.eventmesh.runtime.session.SessionRegistry;
-
-import java.util.Arrays;
-import java.util.List;
-
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
+import org.apache.eventmesh.runtime.session.AgentRecord;
+import org.apache.eventmesh.runtime.session.SessionRegistry;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
 
 /**
  * Sub-PR A baseline: the {@link SessionStore} interface is the contract for the agent / binding /

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/SubscriptionStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/SubscriptionStoreTest.java
@@ -28,8 +28,10 @@ import org.apache.eventmesh.runtime.cluster.ClusterSub;
 import org.apache.eventmesh.runtime.cluster.ClusterSubscriptionStore;
 import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
 import org.apache.eventmesh.runtime.subscription.DistributionMode;
+
 import java.util.Collections;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/SubscriptionStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/SubscriptionStoreTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.state;
+
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+import org.apache.eventmesh.runtime.cluster.ClusterSub;
+import org.apache.eventmesh.runtime.cluster.ClusterSubscriptionStore;
+import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
+import org.apache.eventmesh.runtime.subscription.DistributionMode;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Sub-PR A baseline: the {@link SubscriptionStore} interface is the seam that lets callers depend
+ * on the contract rather than the concrete Meta-backed implementation. This test verifies that
+ * the existing {@link ClusterSubscriptionStore} satisfies the interface and that round-trip
+ * semantics (put → instanceOf → remove) hold against an in-process Meta.
+ */
+class SubscriptionStoreTest {
+
+    @Test
+    void clusterSubscriptionStoreImplementsInterface() {
+        SubscriptionStore store = new ClusterSubscriptionStore(new InMemoryMetaStore());
+        assertNotNull(store, "Meta-backed SubscriptionStore must construct");
+    }
+
+    @Test
+    void putAndInstanceOfRoundTrip() {
+        SubscriptionStore store = new ClusterSubscriptionStore(new InMemoryMetaStore());
+        store.put("topic-1", "client-A", "instance-X", DistributionMode.LOAD_BALANCE, null);
+        store.put("topic-1", "client-B", "instance-Y", DistributionMode.BROADCAST, null);
+        store.put("topic-2", "client-C", "instance-Z", DistributionMode.LOAD_BALANCE, "type=order");
+
+        assertEquals("instance-X", store.instanceOf("client-A"));
+        assertEquals("instance-Y", store.instanceOf("client-B"));
+        assertEquals("instance-Z", store.instanceOf("client-C"));
+        assertNull(store.instanceOf("unknown"));
+    }
+
+    @Test
+    void removeIsIdempotentAndReturnsTrueOnHit() {
+        SubscriptionStore store = new ClusterSubscriptionStore(new InMemoryMetaStore());
+        store.put("t", "c", "i", DistributionMode.LOAD_BALANCE, null);
+        assertTrue(store.remove("t", "c"), "first remove must succeed");
+        assertFalse(store.remove("t", "c"), "second remove must be a no-op");
+        assertNull(store.instanceOf("c"));
+    }
+
+    @Test
+    void topicsAggregatesAcrossClients() {
+        SubscriptionStore store = new ClusterSubscriptionStore(new InMemoryMetaStore());
+        store.put("a", "c1", "i", DistributionMode.LOAD_BALANCE, null);
+        store.put("a", "c2", "i", DistributionMode.LOAD_BALANCE, null);
+        store.put("b", "c3", "i", DistributionMode.LOAD_BALANCE, null);
+        assertEquals(2, store.topics().size());
+        assertTrue(store.topics().contains("a"));
+        assertTrue(store.topics().contains("b"));
+    }
+
+    @Test
+    void broadcastSubscribersMatchAnyEvent() {
+        SubscriptionStore store = new ClusterSubscriptionStore(new InMemoryMetaStore());
+        store.put("t", "c", "i", DistributionMode.BROADCAST, null);
+        // BROADCAST mode bypasses filter; the test event below is a placeholder — the store does
+        // not introspect the body for BROADCAST subscribers. (See SubscriptionManager for the
+        // full filter semantics.)
+        List<ClusterSub> matched = store.targetsFor("t", EventMeshFrame.event(Collections.emptyMap(), null));
+        assertEquals(1, matched.size());
+        assertEquals("c", matched.get(0).getClientId());
+    }
+}

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/SubscriptionStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/SubscriptionStoreTest.java
@@ -17,22 +17,20 @@
 
 package org.apache.eventmesh.runtime.state;
 
-import org.apache.eventmesh.common.wire.EventMeshFrame;
-import org.apache.eventmesh.runtime.cluster.ClusterSub;
-import org.apache.eventmesh.runtime.cluster.ClusterSubscriptionStore;
-import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
-import org.apache.eventmesh.runtime.subscription.DistributionMode;
-
-import java.util.Collections;
-import java.util.List;
-
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+import org.apache.eventmesh.runtime.cluster.ClusterSub;
+import org.apache.eventmesh.runtime.cluster.ClusterSubscriptionStore;
+import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
+import org.apache.eventmesh.runtime.subscription.DistributionMode;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
 
 /**
  * Sub-PR A baseline: the {@link SubscriptionStore} interface is the seam that lets callers depend

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/TaskStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/TaskStoreTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.state;
+
+import org.apache.eventmesh.runtime.state.TaskStore.Status;
+import org.apache.eventmesh.runtime.state.TaskStore.TaskRecord;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Sub-PR A baseline: the {@link TaskStore} interface is the contract for A2A task state. This
+ * test asserts the data-model semantics (idempotent create, epoch-protected status update,
+ * list/expire filters) that any backing implementation must satisfy.
+ *
+ * <p>The test uses an in-process implementation that satisfies the contract from a
+ * {@code ConcurrentHashMap} — the production Meta-backed implementation lands in Sub-PR C.</p>
+ */
+class TaskStoreTest {
+
+    static final class InProcessTaskStore implements TaskStore {
+        private final java.util.concurrent.ConcurrentHashMap<String, TaskRecord> table =
+            new java.util.concurrent.ConcurrentHashMap<>();
+        private final java.util.concurrent.atomic.AtomicLong epoch = new java.util.concurrent.atomic.AtomicLong();
+
+        @Override
+        public TaskRecord createTask(String taskId, String agentId, String clientId, String input) {
+            long now = System.currentTimeMillis();
+            long e = epoch.incrementAndGet();
+            TaskRecord rec = new TaskRecord(taskId, agentId, clientId, Status.PENDING, now, now, input, null, e);
+            TaskRecord prior = table.putIfAbsent(taskId, rec);
+            return prior == null ? rec : null;
+        }
+
+        @Override
+        public TaskRecord getTask(String taskId) {
+            return table.get(taskId);
+        }
+
+        @Override
+        public boolean updateStatus(String taskId, long expectedTaskEpoch, Status newStatus, String output) {
+            TaskRecord rec = table.get(taskId);
+            if (rec == null || rec.taskEpoch != expectedTaskEpoch) {
+                return false;
+            }
+            rec.status = newStatus;
+            rec.updatedAtMs = System.currentTimeMillis();
+            rec.output = output;
+            return true;
+        }
+
+        @Override
+        public List<TaskRecord> listByAgent(String agentId, Status statusFilter) {
+            return table.values().stream()
+                .filter(r -> r.agentId.equals(agentId))
+                .filter(r -> statusFilter == null || r.status == statusFilter)
+                .collect(java.util.stream.Collectors.toList());
+        }
+
+        @Override
+        public List<String> expireStale(long olderThanMs) {
+            long deadline = System.currentTimeMillis() - olderThanMs;
+            List<String> expired = new java.util.ArrayList<>();
+            for (TaskRecord r : table.values()) {
+                if (r.updatedAtMs < deadline) {
+                    expired.add(r.taskId);
+                }
+            }
+            for (String id : expired) {
+                table.remove(id);
+            }
+            return expired;
+        }
+
+        @Override
+        public void flush() { /* no buffered writes */ }
+
+        @Override
+        public void close() { table.clear(); }
+    }
+
+    @Test
+    void createTaskIsIdempotent() {
+        TaskStore store = new InProcessTaskStore();
+        TaskRecord t1 = store.createTask("task-1", "agent-A", "client-C", "{}");
+        assertNotNull(t1);
+        assertEquals("task-1", t1.taskId);
+        assertEquals(Status.PENDING, t1.status);
+
+        TaskRecord dup = store.createTask("task-1", "agent-A", "client-C", "{}");
+        assertNull(dup, "duplicate taskId must return null");
+    }
+
+    @Test
+    void updateStatusRequiresMatchingEpoch() {
+        TaskStore store = new InProcessTaskStore();
+        TaskRecord t1 = store.createTask("task-1", "agent-A", "client-C", "{}");
+
+        assertTrue(store.updateStatus("task-1", t1.taskEpoch, Status.RUNNING, null));
+        TaskRecord after = store.getTask("task-1");
+        assertEquals(Status.RUNNING, after.status);
+
+        // Stale epoch must be rejected.
+        assertFalse(store.updateStatus("task-1", t1.taskEpoch, Status.COMPLETED, "{\"ok\":true}"),
+            "stale epoch must not overwrite");
+        assertEquals(Status.RUNNING, store.getTask("task-1").status);
+    }
+
+    @Test
+    void listByAgentFiltersByStatus() {
+        TaskStore store = new InProcessTaskStore();
+        TaskRecord t1 = store.createTask("a-1", "agent-A", "c", "{}");
+        store.createTask("a-2", "agent-A", "c", "{}");
+        store.createTask("b-1", "agent-B", "c", "{}");
+        store.updateStatus("a-1", t1.taskEpoch, Status.RUNNING, null);
+
+        List<TaskRecord> aAll = store.listByAgent("agent-A", null);
+        assertEquals(2, aAll.size());
+
+        List<TaskRecord> aRunning = store.listByAgent("agent-A", Status.RUNNING);
+        assertEquals(1, aRunning.size());
+        assertEquals("a-1", aRunning.get(0).taskId);
+
+        List<TaskRecord> aPending = store.listByAgent("agent-A", Status.PENDING);
+        assertEquals(1, aPending.size());
+        assertEquals("a-2", aPending.get(0).taskId);
+    }
+}

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/TaskStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/TaskStoreTest.java
@@ -17,18 +17,16 @@
 
 package org.apache.eventmesh.runtime.state;
 
-import org.apache.eventmesh.runtime.state.TaskStore.Status;
-import org.apache.eventmesh.runtime.state.TaskStore.TaskRecord;
-
-import java.util.List;
-
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.eventmesh.runtime.state.TaskStore.Status;
+import org.apache.eventmesh.runtime.state.TaskStore.TaskRecord;
+import java.util.List;
+import org.junit.jupiter.api.Test;
 
 /**
  * Sub-PR A baseline: the {@link TaskStore} interface is the contract for A2A task state. This
@@ -95,10 +93,14 @@ class TaskStoreTest {
         }
 
         @Override
-        public void flush() { /* no buffered writes */ }
+        public void flush() {
+            /* no buffered writes */
+        }
 
         @Override
-        public void close() { table.clear(); }
+        public void close() {
+            table.clear();
+        }
     }
 
     @Test
@@ -136,15 +138,15 @@ class TaskStoreTest {
         store.createTask("b-1", "agent-B", "c", "{}");
         store.updateStatus("a-1", t1.taskEpoch, Status.RUNNING, null);
 
-        List<TaskRecord> aAll = store.listByAgent("agent-A", null);
-        assertEquals(2, aAll.size());
+        List<TaskRecord> allTasks = store.listByAgent("agent-A", null);
+        assertEquals(2, allTasks.size());
 
-        List<TaskRecord> aRunning = store.listByAgent("agent-A", Status.RUNNING);
-        assertEquals(1, aRunning.size());
-        assertEquals("a-1", aRunning.get(0).taskId);
+        List<TaskRecord> runningTasks = store.listByAgent("agent-A", Status.RUNNING);
+        assertEquals(1, runningTasks.size());
+        assertEquals("a-1", runningTasks.get(0).taskId);
 
-        List<TaskRecord> aPending = store.listByAgent("agent-A", Status.PENDING);
-        assertEquals(1, aPending.size());
-        assertEquals("a-2", aPending.get(0).taskId);
+        List<TaskRecord> pendingTasks = store.listByAgent("agent-A", Status.PENDING);
+        assertEquals(1, pendingTasks.size());
+        assertEquals("a-2", pendingTasks.get(0).taskId);
     }
 }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/TaskStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/TaskStoreTest.java
@@ -25,7 +25,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.eventmesh.runtime.state.TaskStore.Status;
 import org.apache.eventmesh.runtime.state.TaskStore.TaskRecord;
+
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/TaskStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/TaskStoreTest.java
@@ -126,8 +126,10 @@ class TaskStoreTest {
         TaskRecord after = store.getTask("task-1");
         assertEquals(Status.RUNNING, after.status);
 
-        // Stale epoch must be rejected.
-        assertFalse(store.updateStatus("task-1", t1.taskEpoch, Status.COMPLETED, "{\"ok\":true}"),
+        // Wrong epoch must be rejected (taskEpoch is set at creation and never reset,
+        // so any value other than t1.taskEpoch simulates a stale writer).
+        long wrongEpoch = t1.taskEpoch + 1L;
+        assertFalse(store.updateStatus("task-1", wrongEpoch, Status.COMPLETED, "{\"ok\":true}"),
             "stale epoch must not overwrite");
         assertEquals(Status.RUNNING, store.getTask("task-1").status);
     }


### PR DESCRIPTION
# Sub-PR A: Control-plane store SPI + deprecate zombie code (issue #5301)

This is the first of four sub-PRs that deliver [issue #5301](https://github.com/apache/eventmesh/issues/5301)
("Unified state control-plane stores"). Sub-PR A adds the SPI surface, adapts
two existing implementations to it, and deprecates three zombie-code classes
that the new architecture will eventually replace.

It does **not** change runtime behavior: nothing currently calls the new
interfaces yet (call sites move over in Sub-PRs B and C).

## What's in this PR

### New public interfaces (in `org.apache.eventmesh.runtime.state`)

| Interface          | Backed by (target)                            | Purpose                                              |
|--------------------|------------------------------------------------|------------------------------------------------------|
| `SubscriptionStore`| Meta prefix-watch + local cache                | Cluster-shared subscription registry                 |
| `SessionStore`     | Meta prefix-watch + local cache                | Cluster-shared agent / binding / session registry    |
| `DeadLetterStore`  | Meta CAS (idempotent)                          | Durable ledger of dead-lettered deliveries           |
| `TaskStore`        | Meta CAS + epoch-protected status transitions  | A2A task state (with TTL via `expireStale`)          |

`OffsetStore` and `DeliveryStateStore` are intentionally not added in this
PR — they are introduced in Sub-PRs B and C with the actual storage backends.

### Adapted implementations

- `ClusterSubscriptionStore` now `implements SubscriptionStore`. `remove(...)`
  returns the boolean result from `Meta.delete(...)` so callers can detect
  when a subscription was already gone (idempotent teardown).
- `SessionRegistry` now `implements SessionStore`. `register/markReady/
  unregister` are renamed to `registerAgent/markAgentReady/unregisterAgent`
  to match the interface contract (no callers existed in the current tree
  for the old names).

### Zombie code marked `@Deprecated(forRemoval = true)`

Pending [issue #5309](https://github.com/apache/eventmesh/issues/5309)
("PARTITION_OWNED_PULL delivery topology"):

- `cluster.PartitionOwnership` — only callable from the second delivery mode
  the closed #5300 originally enabled; will return as part of #5309.
- `cluster.ClusterCoordinator` — superseded by the new Meta CAS path.
- `cluster.MetaBackedOffsetStore` — superseded by the `OffsetStore` in
  Sub-PR B.

### Unit tests

`SubscriptionStoreTest` (5), `SessionStoreTest` (6), `DeadLetterStoreTest`
(2), `TaskStoreTest` (3) — total **16 tests**, all in-process with hand-
rolled test doubles (no Nacos/RocksDB/Testcontainers needed). They pin the
SPI contract so subsequent sub-PRs can build on it.

## Out of scope (handled in follow-up sub-PRs)

- **Sub-PR B** — `DeliveryStateStore` (RocksDB) + `OffsetStore` (Meta async
  flush); wire `DeliveryStateStore` into the new consumer path.
- **Sub-PR C** — `DeadLetterStore` Meta-backed implementation + `TaskStore`
  Meta-backed implementation; wire A2A `TaskRegistry` over `TaskStore`.
- **Sub-PR D** — fault-injection Testcontainers E2E covering partition
  transfer, Meta outage, DLQ replay, and TaskStore epoch conflict.

## Open questions for the maintainer

(Inherited from the #5301 issue body — please review there.)

1. Should `DeadLetterStore.recordDeadLetter` carry a `dlqOffset` (current
   design), or just the `dlqTopic` so the offset is derived?
2. Should `TaskStore.TaskRecord` carry full `input` / `output` payloads, or
   only a `payloadRef` that points to a separate blob store?
3. For `SubscriptionStore.put`, do we want a separate `putIfAbsent` variant
   to make subscription reconciliation idempotent without overwriting?
4. Should the `SessionStore` interface include a `Watch` / `Subscription`
   callback hook (similar to Nacos `Listener`) so callers can react to
   session-state changes without polling?

## Testing

This PR was developed on the uni-runtime branch (`develop` at
`7260581`). The full `eventmesh-runtime:compileJava` plus the four new
test classes pass locally with JDK 21 + Gradle 8.7. Upstream CI will be
the source of truth — if anything in the SPI needs to change, the four
sub-PRs are independent so a fix here will not block B/C/D.
