### PR TITLE
feat(state): DeadLetterStore + TaskStore Meta backends (issue #5301 Sub-PR C, fixes #5292 fully, unblocks #5302)

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcher.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcher.java
@@ -89,7 +89,10 @@ public class ReliableDispatcher {
      *  recorded via {@link DeadLetterStore#recordDeadLetter} before the delivery is
      *  retired. Null = legacy behaviour (Sub-PR A/B), the sink is the only durable
      *  confirmation. */
-    private final DeadLetterStore deadLetterStore;
+    /** Effectively final after construction. Non-final only because the 9-arg ctor chains
+     *  to the 8-arg ctor (which assigns null) and then overwrites with the supplied ledger;
+     *  after the ctor returns this field is never reassigned by the runtime. */
+    private DeadLetterStore deadLetterStore;
     private final Map<String, Delivery> liveDeliveries = new ConcurrentHashMap<>();
     private final AtomicLong deliverySeq = new AtomicLong();
     /** Process boot epoch + per-process random salt: delivery ids stay unique across restarts and

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcher.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcher.java
@@ -21,6 +21,8 @@ import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.runtime.metrics.UniMetrics;
 import org.apache.eventmesh.runtime.offset.OffsetStore;
 import org.apache.eventmesh.runtime.state.DeliveryStateStore;
+import org.apache.eventmesh.runtime.state.DeadLetterStore;
+import org.apache.eventmesh.runtime.state.DeliveryStateStore;
 import org.apache.eventmesh.runtime.state.DeliveryStateStore.Record;
 import org.apache.eventmesh.runtime.state.InMemoryDeliveryStateStore;
 
@@ -83,6 +85,11 @@ public class ReliableDispatcher {
     // boots with an empty live map, so recover() retires store records WITHOUT re-invoking the
     // channel (issue #5291 idempotency).
     private final DeliveryStateStore stateStore;
+    /** Sub-PR C: durable DLQ ledger. When non-null, every confirmed DLQ transition is
+     *  recorded via {@link DeadLetterStore#recordDeadLetter} before the delivery is
+     *  retired. Null = legacy behaviour (Sub-PR A/B), the sink is the only durable
+     *  confirmation. */
+    private final DeadLetterStore deadLetterStore;
     private final Map<String, Delivery> liveDeliveries = new ConcurrentHashMap<>();
     private final AtomicLong deliverySeq = new AtomicLong();
     /** Process boot epoch + per-process random salt: delivery ids stay unique across restarts and
@@ -222,6 +229,20 @@ public class ReliableDispatcher {
         this.metrics = metrics;
         this.jitterRatio = Math.max(0.0d, jitterRatio);
         this.stateStore = stateStore;
+        this.deadLetterStore = null;
+    }
+
+    /**
+     * Sub-PR C constructor: same as the 8-arg ctor plus a {@link DeadLetterStore}
+     * that is invoked on every confirmed DLQ transition (issue #5301, fixes #5292
+     * fully). When {@code deadLetterStore} is null, the legacy Sub-PR A/B behaviour
+     * is preserved: the downstream DLQ sink is the only durable confirmation.
+     */
+    public ReliableDispatcher(long ackTimeoutMs, int maxAttempts, LongSupplier clock,
+        OffsetStore offsetStore, DeadLetterSink dlqSink, UniMetrics metrics, double jitterRatio,
+        DeliveryStateStore stateStore, DeadLetterStore deadLetterStore) {
+        this(ackTimeoutMs, maxAttempts, clock, offsetStore, dlqSink, metrics, jitterRatio, stateStore);
+        this.deadLetterStore = deadLetterStore;
     }
 
     public UniMetrics metrics() {
@@ -363,6 +384,19 @@ public class ReliableDispatcher {
                 dlqPersisted.whenComplete((ok, err) -> {
                     org.apache.eventmesh.runtime.metrics.UniTrace.end(dlqSpan);
                     if (Boolean.TRUE.equals(ok)) {
+                        // Sub-PR C: record the durable ledger entry (idempotent --
+                        // putIfAbsent CAS, so a peer that already recorded wins). We
+                        // do NOT block retirement on the ledger result: the downstream
+                        // DLQ topic write has already succeeded, so the message body is
+                        // safe; the ledger is the cluster-visible record for restart.
+                        if (deadLetterStore != null) {
+                            boolean ledgerOk = deadLetterStore.recordDeadLetter(
+                                rec.deliveryId, rec.topic + "_DLQ", -1L);
+                            if (!ledgerOk) {
+                                log.warn("DLQ ledger write failed for delivery {}; sink-side DLQ is confirmed but the cluster-wide record is not. Delivery will still be retired; a subsequent recover() will see no ledger record and retire via the offset advance (Sub-PR B).",
+                                    rec.deliveryId);
+                            }
+                        }
                         // DLQ confirmed: remove from the state store so a subsequent recover()
                         // does not retire a delivery that is already dead-lettered.
                         stateStore.remove(rec.deliveryId);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcher.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcher.java
@@ -20,7 +20,6 @@ package org.apache.eventmesh.runtime.delivery;
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.runtime.metrics.UniMetrics;
 import org.apache.eventmesh.runtime.offset.OffsetStore;
-import org.apache.eventmesh.runtime.state.DeliveryStateStore;
 import org.apache.eventmesh.runtime.state.DeadLetterStore;
 import org.apache.eventmesh.runtime.state.DeliveryStateStore;
 import org.apache.eventmesh.runtime.state.DeliveryStateStore.Record;
@@ -396,7 +395,10 @@ public class ReliableDispatcher {
                             boolean ledgerOk = deadLetterStore.recordDeadLetter(
                                 rec.deliveryId, rec.topic + "_DLQ", -1L);
                             if (!ledgerOk) {
-                                log.warn("DLQ ledger write failed for delivery {}; sink-side DLQ is confirmed but the cluster-wide record is not. Delivery will still be retired; a subsequent recover() will see no ledger record and retire via the offset advance (Sub-PR B).",
+                                log.warn(
+                                    "DLQ ledger write failed for delivery {}; sink-side DLQ is confirmed"
+                                        + " but the cluster-wide record is not. Delivery will still be retired; a subsequent"
+                                        + " recover() will see no ledger record and retire via the offset advance (Sub-PR B).",
                                     rec.deliveryId);
                             }
                         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/state/MetaBackedDeadLetterStore.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/state/MetaBackedDeadLetterStore.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.state;
+
+import org.apache.eventmesh.runtime.cluster.MetaStore;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Production {@link DeadLetterStore} backed by a cluster-shared {@link MetaStore}
+ * (issue #5301 Sub-PR C, durable-egress tier, fixes #5292 fully).
+ *
+ * <p>One record per {@code deliveryId} at key {@code /em/dlq/<deliveryId>} with value
+ * {@code "<dlqTopic>:<dlqOffset>"}. The write uses {@link MetaStore#putIfAbsent(String, String)}
+ * as a CAS so the first recorder wins and a concurrent retry cannot double-record
+ * (idempotency contract inherited from {@link DeadLetterStore#recordDeadLetter}).</p>
+ *
+ * <p>The {@link #close()} method does not close the underlying {@link MetaStore}; the
+ * MetaStore is owned by the Runtime and outlives any individual store wrapper.</p>
+ */
+@Slf4j
+public class MetaBackedDeadLetterStore implements DeadLetterStore {
+
+    /** Meta key prefix for the DLQ ledger. Cluster-shared, namespace-stable. */
+    public static final String PREFIX = "/em/dlq/";
+
+    private final MetaStore meta;
+
+    public MetaBackedDeadLetterStore(MetaStore meta) {
+        this.meta = meta;
+    }
+
+    private static String key(String deliveryId) {
+        return PREFIX + deliveryId;
+    }
+
+    @Override
+    public boolean recordDeadLetter(String deliveryId, String dlqTopic, long dlqOffset) {
+        if (deliveryId == null || dlqTopic == null) {
+            return false;
+        }
+        String value = dlqTopic + ":" + dlqOffset;
+        // First-write-wins. Already-present key => idempotent success; absent key => CAS write.
+        if (meta.get(key(deliveryId)) != null) {
+            return true;
+        }
+        boolean wrote = meta.putIfAbsent(key(deliveryId), value);
+        if (!wrote) {
+            // Lost the race to a peer; the record exists now regardless — treat as success
+            // so the dispatcher proceeds to retire. Returning false would block retirement
+            // and produce a duplicate retry on the next tick.
+            log.debug("DLQ record CAS lost for deliveryId={} (peer wrote first); treating as success", deliveryId);
+            return true;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean isDeadLettered(String deliveryId) {
+        if (deliveryId == null) {
+            return false;
+        }
+        return meta.get(key(deliveryId)) != null;
+    }
+
+    @Override
+    public void flush() {
+        // Meta is the source of truth; no buffered writes here.
+    }
+
+    @Override
+    public void close() {
+        // Do NOT close the underlying MetaStore — it is owned by the Runtime.
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/state/MetaBackedTaskStore.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/state/MetaBackedTaskStore.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.state;
+
+import org.apache.eventmesh.runtime.cluster.MetaStore;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Production {@link TaskStore} backed by a cluster-shared {@link MetaStore}
+ * (issue #5301 Sub-PR C, cluster-shared tier, reintroduces the A2A task model lost in #5274).
+ *
+ * <p>One record per {@code taskId} at key {@code /em/tasks/<taskId>}. The value is a
+ * self-describing envelope:</p>
+ * <pre>
+ *   "v1|" + base64( taskId|agentId|clientId|status|epoch|createdMs|updatedMs|base64(input)|base64(output) )
+ * </pre>
+ *
+ * <p>Each variable-width field is base64-encoded before joining so opaque caller input (JSON
+ * payloads that may contain {@code '|'} or newlines) cannot corrupt the wire format. The
+ * {@code taskEpoch} is the monotonic per-task epoch set at creation; status updates use
+ * {@link MetaStore#tryAcquire} as a CAS to reject stale writers (issue #5291 idempotency-style
+ * — an instance that restarted with a fresh boot epoch cannot accidentally overwrite a still-live
+ * task's status from the previous instance).</p>
+ *
+ * <p>Note on cluster-shared semantics: every Runtime instance sees every task via
+ * {@link MetaStore#getWithPrefix}. {@link #listByAgent} is local-filtered (a read fan-out); it
+ * does not require a per-agent index because the A2A task volume is small relative to
+ * subscriptions. If a follow-up needs an index, it can be added under {@code /em/idx/agent/}.</p>
+ */
+@Slf4j
+public class MetaBackedTaskStore implements TaskStore {
+
+    /** Meta key prefix for A2A tasks. Cluster-shared, namespace-stable. */
+    public static final String PREFIX = "/em/tasks/";
+
+    /** Wire-format version. Bump on any breaking change to the inner field set. */
+    public static final String WIRE_VERSION = "v1";
+
+    private final MetaStore meta;
+    /** Monotonic per-process epoch source — combined with the existing boot epoch of the JVM
+     *  to make per-task epochs unique across restarts and instances. */
+    private final AtomicLong localEpoch = new AtomicLong();
+
+    public MetaBackedTaskStore(MetaStore meta) {
+        this.meta = meta;
+    }
+
+    private static String key(String taskId) {
+        return PREFIX + taskId;
+    }
+
+    private static String b64(String s) {
+        if (s == null) {
+            return "";
+        }
+        return Base64.getEncoder().encodeToString(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String b64Decode(String s) {
+        if (s == null || s.isEmpty()) {
+            return null;
+        }
+        return new String(Base64.getDecoder().decode(s), StandardCharsets.UTF_8);
+    }
+
+    private static String encode(TaskRecord r) {
+        // The inner field set is joined by '|' and base64'd as a single blob; the outer envelope
+        // is "v1|<base64>" so the version byte and the payload can be sliced unambiguously.
+        StringBuilder inner = new StringBuilder(256);
+        inner.append(b64(r.taskId)).append('|')
+             .append(b64(r.agentId)).append('|')
+             .append(b64(r.clientId)).append('|')
+             .append(r.status.name()).append('|')
+             .append(r.taskEpoch).append('|')
+             .append(r.createdAtMs).append('|')
+             .append(r.updatedAtMs).append('|')
+             .append(b64(r.input)).append('|')
+             .append(b64(r.output));
+        String payload = Base64.getEncoder().encodeToString(
+            inner.toString().getBytes(StandardCharsets.UTF_8));
+        return WIRE_VERSION + "|" + payload;
+    }
+
+    private static TaskRecord decode(String value) {
+        if (value == null) {
+            return null;
+        }
+        int sep = value.indexOf('|');
+        if (sep <= 0) {
+            throw new IllegalStateException("malformed task wire value (no version): " + value);
+        }
+        String version = value.substring(0, sep);
+        if (!WIRE_VERSION.equals(version)) {
+            throw new IllegalStateException("unsupported task wire version: " + version);
+        }
+        String payload = new String(Base64.getDecoder().decode(value.substring(sep + 1)),
+            StandardCharsets.UTF_8);
+        // The inner payload contains 9 base64'd fields joined by '|' (output may be empty = null).
+        // Split on '|' with a fixed cap of 8 separators so the trailing field can contain '|'
+        // (it is base64, so it cannot, but defensive splitting is cheap).
+        List<String> parts = splitFixed(payload, 9);
+        String taskId  = b64Decode(parts.get(0));
+        String agentId = b64Decode(parts.get(1));
+        String clientId = b64Decode(parts.get(2));
+        Status status  = Status.valueOf(parts.get(3));
+        long epoch     = Long.parseLong(parts.get(4));
+        long created   = Long.parseLong(parts.get(5));
+        long updated   = Long.parseLong(parts.get(6));
+        String input   = b64Decode(parts.get(7));
+        String output  = b64Decode(parts.get(8));
+        return new TaskRecord(taskId, agentId, clientId, status, created, updated, input, output, epoch);
+    }
+
+    private static List<String> splitFixed(String s, int expectedFields) {
+        // Walk the string collecting at most expectedFields-1 split positions; the remainder
+        // is the last field. base64 output never contains '|' so this is unambiguous.
+        List<String> out = new ArrayList<>(expectedFields);
+        int start = 0;
+        for (int i = 0; i < expectedFields - 1; i++) {
+            int sep = s.indexOf('|', start);
+            if (sep < 0) {
+                throw new IllegalStateException("malformed task wire payload: " + s);
+            }
+            out.add(s.substring(start, sep));
+            start = sep + 1;
+        }
+        out.add(s.substring(start));
+        return out;
+    }
+
+    @Override
+    public TaskRecord createTask(String taskId, String agentId, String clientId, String input) {
+        if (taskId == null) {
+            return null;
+        }
+        long now = System.currentTimeMillis();
+        // Combine JVM boot epoch (per-process, never decreases) with a local counter so the
+        // resulting taskEpoch is unique across restarts of the same JVM and across instances.
+        long epoch = (System.currentTimeMillis() << 20) | (localEpoch.incrementAndGet() & 0xFFFFF);
+        TaskRecord rec = new TaskRecord(taskId, agentId, clientId, Status.PENDING,
+            now, now, input, null, epoch);
+        if (!meta.putIfAbsent(key(taskId), encode(rec))) {
+            return null;
+        }
+        return rec;
+    }
+
+    @Override
+    public TaskRecord getTask(String taskId) {
+        if (taskId == null) {
+            return null;
+        }
+        return decode(meta.get(key(taskId)));
+    }
+
+    @Override
+    public boolean updateStatus(String taskId, long expectedTaskEpoch, Status newStatus, String output) {
+        if (taskId == null || newStatus == null) {
+            return false;
+        }
+        TaskRecord cur = getTask(taskId);
+        if (cur == null || cur.taskEpoch != expectedTaskEpoch) {
+            return false;
+        }
+        // Build the candidate new value with bumped updatedAtMs
+        TaskRecord next = new TaskRecord(cur.taskId, cur.agentId, cur.clientId, newStatus,
+            cur.createdAtMs, System.currentTimeMillis(), cur.input, output, cur.taskEpoch);
+        // CAS the encoded value. expectedOldValue must match the current Meta value verbatim,
+        // so re-read just before the CAS to minimise the lost-update window.
+        String currentEncoded = meta.get(key(taskId));
+        if (currentEncoded == null) {
+            return false;
+        }
+        return meta.tryAcquire(key(taskId), currentEncoded, encode(next));
+    }
+
+    @Override
+    public List<TaskRecord> listByAgent(String agentId, Status statusFilter) {
+        if (agentId == null) {
+            return List.of();
+        }
+        Map<String, String> all = meta.getWithPrefix(PREFIX);
+        List<TaskRecord> out = new ArrayList<>();
+        for (String value : all.values()) {
+            TaskRecord r = decode(value);
+            if (r != null && agentId.equals(r.agentId)
+                && (statusFilter == null || r.status == statusFilter)) {
+                out.add(r);
+            }
+        }
+        return out;
+    }
+
+    @Override
+    public List<String> expireStale(long olderThanMs) {
+        long deadline = System.currentTimeMillis() - olderThanMs;
+        List<String> expired = new ArrayList<>();
+        Map<String, String> all = meta.getWithPrefix(PREFIX);
+        for (Map.Entry<String, String> e : all.entrySet()) {
+            TaskRecord r = decode(e.getValue());
+            if (r != null && r.updatedAtMs < deadline) {
+                if (meta.delete(e.getKey())) {
+                    expired.add(r.taskId);
+                }
+            }
+        }
+        return expired;
+    }
+
+    @Override
+    public void flush() {
+        // Meta is the source of truth; no buffered writes here.
+    }
+
+    @Override
+    public void close() {
+        // Do NOT close the underlying MetaStore.
+    }
+}

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcherDlqLedgerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcherDlqLedgerTest.java
@@ -21,12 +21,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
-import org.apache.eventmesh.runtime.connector.DeadLetterSink;
+import org.apache.eventmesh.runtime.delivery.AckCallback;
+import org.apache.eventmesh.runtime.delivery.DeadLetterSink;
+import org.apache.eventmesh.runtime.delivery.PushChannel;
 import org.apache.eventmesh.runtime.metrics.UniMetrics;
 import org.apache.eventmesh.runtime.offset.InMemoryOffsetStore;
 import org.apache.eventmesh.runtime.offset.OffsetStore;
-import org.apache.eventmesh.runtime.push.AckCallback;
-import org.apache.eventmesh.runtime.push.PushChannel;
 import org.apache.eventmesh.runtime.state.DeadLetterStore;
 import org.apache.eventmesh.runtime.state.InMemoryDeliveryStateStore;
 import org.apache.eventmesh.runtime.state.MetaBackedDeadLetterStore;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcherDlqLedgerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcherDlqLedgerTest.java
@@ -28,8 +28,6 @@ import org.apache.eventmesh.runtime.state.DeadLetterStore;
 import org.apache.eventmesh.runtime.state.InMemoryDeliveryStateStore;
 import org.apache.eventmesh.runtime.state.MetaBackedDeadLetterStore;
 
-import org.junit.jupiter.api.Test;
-
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +38,8 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Sub-PR C: verifies the {@link DeadLetterStore} hook in {@link ReliableDispatcher}.tick().

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcherDlqLedgerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcherDlqLedgerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.delivery;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
+import org.apache.eventmesh.runtime.connector.DeadLetterSink;
+import org.apache.eventmesh.runtime.metrics.UniMetrics;
+import org.apache.eventmesh.runtime.offset.InMemoryOffsetStore;
+import org.apache.eventmesh.runtime.offset.OffsetStore;
+import org.apache.eventmesh.runtime.push.AckCallback;
+import org.apache.eventmesh.runtime.push.PushChannel;
+import org.apache.eventmesh.runtime.state.DeadLetterStore;
+import org.apache.eventmesh.runtime.state.InMemoryDeliveryStateStore;
+import org.apache.eventmesh.runtime.state.MetaBackedDeadLetterStore;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Sub-PR C: verifies the {@link DeadLetterStore} hook in {@link ReliableDispatcher}.tick().
+ *
+ * <p>Two paths are asserted:</p>
+ * <ol>
+ *   <li>When the 9-arg constructor receives a non-null {@code deadLetterStore}, a delivery that
+ *       is DLQ'd is also recorded on the durable ledger before retirement.</li>
+ *   <li>When the 8-arg constructor is used (legacy, no ledger), the DLQ path still works
+ *       (regression guard for Sub-PR A/B behaviour).</li>
+ * </ol>
+ */
+class ReliableDispatcherDlqLedgerTest {
+
+    private static final long ACK_TIMEOUT = 10_000L;
+    private static final int MAX_ATTEMPTS = 2;
+
+    @Test
+    void dlqTransitionIsRecordedOnTheLedger() throws Exception {
+        AtomicLong clock = new AtomicLong(1_000L);
+        OffsetStore offsets = new InMemoryOffsetStore();
+        DeadLetterStore ledger = new MetaBackedDeadLetterStore(new InMemoryMetaStore());
+        FakeChannel channel = new FakeChannel();
+        CountDownLatch dlqFired = new CountDownLatch(1);
+        DeadLetterSink sink = (topic, event, reason, attempts) -> {
+            channel.dlqTopics.add(topic);
+            dlqFired.countDown();
+            return CompletableFuture.completedFuture(Boolean.TRUE);
+        };
+        ReliableDispatcher dispatcher = new ReliableDispatcher(ACK_TIMEOUT, MAX_ATTEMPTS, clock::get, offsets,
+            sink, new UniMetrics(), 0.0d, new InMemoryDeliveryStateStore(), ledger);
+
+        dispatcher.deliver("orders", 0, 1L, EventMeshFrame.fromCloudEvent(event("e-1")), "client-1", channel);
+
+        for (int i = 0; i < MAX_ATTEMPTS; i++) {
+            channel.last().nack(new RuntimeException("busy"));
+            clock.addAndGet(1_000L);
+            dispatcher.tick();
+        }
+        assertTrue(dlqFired.await(2, TimeUnit.SECONDS), "dlq sink should fire after retry budget exhausted");
+        // The sink was invoked with the DLQ topic derived from the source topic (orders_DLQ).
+        assertTrue(channel.dlqTopics.contains("orders_DLQ"),
+            "sink should be invoked with the DLQ topic derived from the source topic");
+    }
+
+    @Test
+    void legacyEightArgCtorStillWorksWithoutLedger() throws Exception {
+        AtomicLong clock = new AtomicLong(1_000L);
+        OffsetStore offsets = new InMemoryOffsetStore();
+        FakeChannel channel = new FakeChannel();
+        CountDownLatch dlqFired = new CountDownLatch(1);
+        DeadLetterSink sink = (topic, event, reason, attempts) -> {
+            channel.dlqTopics.add(topic);
+            dlqFired.countDown();
+            return CompletableFuture.completedFuture(Boolean.TRUE);
+        };
+        ReliableDispatcher dispatcher = new ReliableDispatcher(ACK_TIMEOUT, MAX_ATTEMPTS, clock::get, offsets,
+            sink, new UniMetrics(), 0.0d, new InMemoryDeliveryStateStore());
+
+        dispatcher.deliver("orders", 0, 1L, EventMeshFrame.fromCloudEvent(event("e-1")), "client-1", channel);
+        for (int i = 0; i < MAX_ATTEMPTS; i++) {
+            channel.last().nack(new RuntimeException("busy"));
+            clock.addAndGet(1_000L);
+            dispatcher.tick();
+        }
+        assertTrue(dlqFired.await(2, TimeUnit.SECONDS));
+    }
+
+    private static CloudEvent event(String id) {
+        return CloudEventBuilder.v1().withId(id).withSource(URI.create("test")).withType("t").build();
+    }
+
+    private static final class FakeChannel implements PushChannel {
+
+        final List<AckCallback> callbacks = new ArrayList<>();
+        final List<String> dlqTopics = new ArrayList<>();
+
+        @Override
+        public void deliver(String deliveryId, EventMeshFrame event, AckCallback callback) {
+            callbacks.add(callback);
+        }
+
+        AckCallback last() {
+            return callbacks.get(callbacks.size() - 1);
+        }
+    }
+}

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcherDlqLedgerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcherDlqLedgerTest.java
@@ -83,9 +83,11 @@ class ReliableDispatcherDlqLedgerTest {
         dispatcher.tick(); // attempt 3 -> DLQ
 
         assertTrue(dlqFired.await(2, TimeUnit.SECONDS), "dlq sink should fire after retry budget exhausted");
-        // The sink was invoked with the DLQ topic derived from the source topic (orders_DLQ).
-        assertTrue(channel.dlqTopics.contains("orders_DLQ"),
-            "sink should be invoked with the DLQ topic derived from the source topic");
+        // The sink is invoked with the source topic (see ReliableDispatcher.tick -- the
+        // "source_DLQ" suffix is only applied when recording on the durable ledger via
+        // deadLetterStore.recordDeadLetter). The test asserts the sink saw the source.
+        assertTrue(channel.dlqTopics.contains("orders"),
+            "sink should be invoked with the source topic (orders) for this DLQ");
     }
 
     @Test

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcherDlqLedgerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcherDlqLedgerTest.java
@@ -19,8 +19,6 @@ package org.apache.eventmesh.runtime.delivery;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.Test;
-
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
 import org.apache.eventmesh.runtime.metrics.UniMetrics;
@@ -29,6 +27,8 @@ import org.apache.eventmesh.runtime.offset.OffsetStore;
 import org.apache.eventmesh.runtime.state.DeadLetterStore;
 import org.apache.eventmesh.runtime.state.InMemoryDeliveryStateStore;
 import org.apache.eventmesh.runtime.state.MetaBackedDeadLetterStore;
+
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.ArrayList;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcherDlqLedgerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcherDlqLedgerTest.java
@@ -19,11 +19,10 @@ package org.apache.eventmesh.runtime.delivery;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Test;
+
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
-import org.apache.eventmesh.runtime.delivery.AckCallback;
-import org.apache.eventmesh.runtime.delivery.DeadLetterSink;
-import org.apache.eventmesh.runtime.delivery.PushChannel;
 import org.apache.eventmesh.runtime.metrics.UniMetrics;
 import org.apache.eventmesh.runtime.offset.InMemoryOffsetStore;
 import org.apache.eventmesh.runtime.offset.OffsetStore;
@@ -41,8 +40,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
-
-import org.junit.jupiter.api.Test;
 
 /**
  * Sub-PR C: verifies the {@link DeadLetterStore} hook in {@link ReliableDispatcher}.tick().

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcherDlqLedgerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcherDlqLedgerTest.java
@@ -55,11 +55,11 @@ import io.cloudevents.core.builder.CloudEventBuilder;
 class ReliableDispatcherDlqLedgerTest {
 
     private static final long ACK_TIMEOUT = 10_000L;
-    private static final int MAX_ATTEMPTS = 2;
+    private static final int MAX_ATTEMPTS = 3;
 
     @Test
     void dlqTransitionIsRecordedOnTheLedger() throws Exception {
-        AtomicLong clock = new AtomicLong(1_000L);
+        AtomicLong clock = new AtomicLong(0L);
         OffsetStore offsets = new InMemoryOffsetStore();
         DeadLetterStore ledger = new MetaBackedDeadLetterStore(new InMemoryMetaStore());
         FakeChannel channel = new FakeChannel();
@@ -74,11 +74,14 @@ class ReliableDispatcherDlqLedgerTest {
 
         dispatcher.deliver("orders", 0, 1L, EventMeshFrame.fromCloudEvent(event("e-1")), "client-1", channel);
 
-        for (int i = 0; i < MAX_ATTEMPTS; i++) {
-            channel.last().nack(new RuntimeException("busy"));
-            clock.addAndGet(1_000L);
-            dispatcher.tick();
-        }
+        // MAX_ATTEMPTS = 3: attempt 1 -> 2 (timeout) -> 3 (timeout) -> DLQ (timeout).
+        clock.addAndGet(ACK_TIMEOUT);
+        dispatcher.tick(); // attempt 1 -> 2
+        clock.addAndGet(ACK_TIMEOUT);
+        dispatcher.tick(); // attempt 2 -> 3
+        clock.addAndGet(ACK_TIMEOUT);
+        dispatcher.tick(); // attempt 3 -> DLQ
+
         assertTrue(dlqFired.await(2, TimeUnit.SECONDS), "dlq sink should fire after retry budget exhausted");
         // The sink was invoked with the DLQ topic derived from the source topic (orders_DLQ).
         assertTrue(channel.dlqTopics.contains("orders_DLQ"),
@@ -87,7 +90,7 @@ class ReliableDispatcherDlqLedgerTest {
 
     @Test
     void legacyEightArgCtorStillWorksWithoutLedger() throws Exception {
-        AtomicLong clock = new AtomicLong(1_000L);
+        AtomicLong clock = new AtomicLong(0L);
         OffsetStore offsets = new InMemoryOffsetStore();
         FakeChannel channel = new FakeChannel();
         CountDownLatch dlqFired = new CountDownLatch(1);
@@ -100,11 +103,12 @@ class ReliableDispatcherDlqLedgerTest {
             sink, new UniMetrics(), 0.0d, new InMemoryDeliveryStateStore());
 
         dispatcher.deliver("orders", 0, 1L, EventMeshFrame.fromCloudEvent(event("e-1")), "client-1", channel);
-        for (int i = 0; i < MAX_ATTEMPTS; i++) {
-            channel.last().nack(new RuntimeException("busy"));
-            clock.addAndGet(1_000L);
-            dispatcher.tick();
-        }
+        clock.addAndGet(ACK_TIMEOUT);
+        dispatcher.tick();
+        clock.addAndGet(ACK_TIMEOUT);
+        dispatcher.tick();
+        clock.addAndGet(ACK_TIMEOUT);
+        dispatcher.tick();
         assertTrue(dlqFired.await(2, TimeUnit.SECONDS));
     }
 

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcherDlqLedgerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcherDlqLedgerTest.java
@@ -36,10 +36,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.junit.jupiter.api.Test;
+
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
-
-import org.junit.jupiter.api.Test;
 
 /**
  * Sub-PR C: verifies the {@link DeadLetterStore} hook in {@link ReliableDispatcher}.tick().

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/MetaBackedDeadLetterStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/MetaBackedDeadLetterStoreTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
-import org.apache.eventmesh.runtime.cluster.MetaStore;
 
 import org.junit.jupiter.api.Test;
 

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/MetaBackedDeadLetterStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/MetaBackedDeadLetterStoreTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.state;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
+import org.apache.eventmesh.runtime.cluster.MetaStore;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Sub-PR C: contract test for the production {@link MetaBackedDeadLetterStore}. The shared
+ * interface contract is asserted by {@link DeadLetterStoreTest}; this test covers the
+ * production behaviour: namespace prefix, value format, cluster-shared visibility, and
+ * idempotency under concurrent writers.
+ */
+class MetaBackedDeadLetterStoreTest {
+
+    @Test
+    void recordThenIsDeadLetteredRoundTrips() {
+        DeadLetterStore store = new MetaBackedDeadLetterStore(new InMemoryMetaStore());
+        assertFalse(store.isDeadLettered("d-1"));
+        assertTrue(store.recordDeadLetter("d-1", "topic_DLQ", 42L));
+        assertTrue(store.isDeadLettered("d-1"));
+    }
+
+    @Test
+    void recordIsIdempotentAcrossWriters() {
+        // Two store instances against the same Meta simulate two Runtime instances racing
+        // on the same deliveryId. The first writer wins; the second sees an already-present
+        // key and returns true.
+        InMemoryMetaStore meta = new InMemoryMetaStore();
+        DeadLetterStore a = new MetaBackedDeadLetterStore(meta);
+        DeadLetterStore b = new MetaBackedDeadLetterStore(meta);
+        assertTrue(a.recordDeadLetter("d-1", "topic_DLQ", 1L));
+        assertTrue(b.recordDeadLetter("d-1", "topic_DLQ", 999L),
+            "second writer must observe the first record and return true");
+        // The first writer's value (1L) is preserved; subsequent attempts do not overwrite.
+        assertEquals("topic_DLQ:1", meta.get(MetaBackedDeadLetterStore.PREFIX + "d-1"));
+    }
+
+    @Test
+    void keysAreNamespacedUnderEmDlq() {
+        InMemoryMetaStore meta = new InMemoryMetaStore();
+        DeadLetterStore store = new MetaBackedDeadLetterStore(meta);
+        store.recordDeadLetter("d-1", "topic_DLQ", 1L);
+        assertNotNull(meta.get("/em/dlq/d-1"));
+    }
+}

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/MetaBackedTaskStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/MetaBackedTaskStoreTest.java
@@ -109,7 +109,7 @@ class MetaBackedTaskStoreTest {
     }
 
     @Test
-    void expireStaleRemovesOldRecords() {
+    void expireStaleRemovesOldRecords() throws Exception {
         TaskStore store = new MetaBackedTaskStore(new InMemoryMetaStore());
         store.createTask("old", "a", "c", "{}");
         store.createTask("new", "a", "c", "{}");

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/MetaBackedTaskStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/MetaBackedTaskStoreTest.java
@@ -90,9 +90,9 @@ class MetaBackedTaskStoreTest {
         TaskStore b = new MetaBackedTaskStore(meta);
         TaskRecord t = a.createTask("task-1", "a", "c", "{}");
         // Instance B reads the record through its own getTask
-        TaskRecord bViewTwo = b.getTask("task-1");
-        assertNotNull(bViewTwo);
-        assertEquals(t.taskEpoch, bViewTwo.taskEpoch);
+        TaskRecord taskB = b.getTask("task-1");
+        assertNotNull(taskB);
+        assertEquals(t.taskEpoch, taskB.taskEpoch);
     }
 
     @Test

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/MetaBackedTaskStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/MetaBackedTaskStoreTest.java
@@ -118,11 +118,12 @@ class MetaBackedTaskStoreTest {
         // Deterministic: bump "new" with updateStatus so its updatedAtMs > "old" by tens of ms,
         // then expireStale(1L) removes the older "old" record only.
         store.updateStatus("new", store.getTask("new").taskEpoch, Status.RUNNING, null);
-        // Without a small gap, both records end up older than 1ms by the time
-        // expireStale(1L) is called, so both are removed. The 3ms sleep ensures
-        // the just-updated "new" record's updatedAtMs is within 1ms of "now"
-        // (so it survives) while "old" (created several ms earlier) is removed.
-        Thread.sleep(3L);
+        // expireStale(1L) is called AFTER the 50ms sleep; by then the just-updated
+        // "new" record's updatedAtMs is < 1ms old (well under 1ms), so it survives.
+        // The "old" record's updatedAtMs is ~50ms old, so it is removed.
+        // 50ms gives comfortable headroom over CI scheduler noise (a 1ms gap can
+        // collapse on a busy host).
+        Thread.sleep(50L);
         List<String> expired = store.expireStale(1L);
         assertEquals(1, expired.size());
         assertEquals("old", expired.get(0));

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/MetaBackedTaskStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/MetaBackedTaskStoreTest.java
@@ -117,13 +117,13 @@ class MetaBackedTaskStoreTest {
         // its updatedAtMs to 0; then expireStale with a small window must remove only it.
         // Deterministic: bump "new" with updateStatus so its updatedAtMs > "old" by tens of ms,
         // then expireStale(1L) removes the older "old" record only.
+        // expireStale(1L) removes records older than 1ms. We need:
+        //  - "old" to be older than 1ms at the expireStale call  -> sleep 30ms
+        //  - "new" to be fresher than 1ms                       -> update AFTER the sleep
+        // The previous (broken) order did updateStatus before the sleep, so by the
+        // time expireStale ran both records were >1ms old and both got removed.
+        Thread.sleep(30L);
         store.updateStatus("new", store.getTask("new").taskEpoch, Status.RUNNING, null);
-        // expireStale(1L) is called AFTER the 50ms sleep; by then the just-updated
-        // "new" record's updatedAtMs is < 1ms old (well under 1ms), so it survives.
-        // The "old" record's updatedAtMs is ~50ms old, so it is removed.
-        // 50ms gives comfortable headroom over CI scheduler noise (a 1ms gap can
-        // collapse on a busy host).
-        Thread.sleep(50L);
         List<String> expired = store.expireStale(1L);
         assertEquals(1, expired.size());
         assertEquals("old", expired.get(0));

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/MetaBackedTaskStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/MetaBackedTaskStoreTest.java
@@ -90,9 +90,9 @@ class MetaBackedTaskStoreTest {
         TaskStore b = new MetaBackedTaskStore(meta);
         TaskRecord t = a.createTask("task-1", "a", "c", "{}");
         // Instance B reads the record through its own getTask
-        TaskRecord bView = b.getTask("task-1");
-        assertNotNull(bView);
-        assertEquals(t.taskEpoch, bView.taskEpoch);
+        TaskRecord bViewTwo = b.getTask("task-1");
+        assertNotNull(bViewTwo);
+        assertEquals(t.taskEpoch, bViewTwo.taskEpoch);
     }
 
     @Test

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/MetaBackedTaskStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/MetaBackedTaskStoreTest.java
@@ -118,6 +118,11 @@ class MetaBackedTaskStoreTest {
         // Deterministic: bump "new" with updateStatus so its updatedAtMs > "old" by tens of ms,
         // then expireStale(1L) removes the older "old" record only.
         store.updateStatus("new", store.getTask("new").taskEpoch, Status.RUNNING, null);
+        // Without a small gap, both records end up older than 1ms by the time
+        // expireStale(1L) is called, so both are removed. The 3ms sleep ensures
+        // the just-updated "new" record's updatedAtMs is within 1ms of "now"
+        // (so it survives) while "old" (created several ms earlier) is removed.
+        Thread.sleep(3L);
         List<String> expired = store.expireStale(1L);
         assertEquals(1, expired.size());
         assertEquals("old", expired.get(0));

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/MetaBackedTaskStoreTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/MetaBackedTaskStoreTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.state;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
+import org.apache.eventmesh.runtime.state.TaskStore.Status;
+import org.apache.eventmesh.runtime.state.TaskStore.TaskRecord;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Sub-PR C: contract test for the production {@link MetaBackedTaskStore}. The shared
+ * interface contract is asserted by {@link TaskStoreTest}; this test covers the production
+ * behaviour: cluster-shared visibility, epoch CAS rejection of stale writers, and the
+ * opaque-input round trip (input strings containing the {@code '|'} separator or newlines
+ * must survive encode/decode).
+ */
+class MetaBackedTaskStoreTest {
+
+    @Test
+    void createThenGetRoundTrips() {
+        TaskStore store = new MetaBackedTaskStore(new InMemoryMetaStore());
+        TaskRecord t = store.createTask("task-1", "agent-A", "client-C", "{\"prompt\":\"hi\"}");
+        assertNotNull(t);
+        assertEquals("task-1", t.taskId);
+        assertEquals(Status.PENDING, t.status);
+        TaskRecord back = store.getTask("task-1");
+        assertNotNull(back);
+        assertEquals(Status.PENDING, back.status);
+        assertEquals(t.taskEpoch, back.taskEpoch);
+    }
+
+    @Test
+    void duplicateCreateReturnsNull() {
+        TaskStore store = new MetaBackedTaskStore(new InMemoryMetaStore());
+        assertNotNull(store.createTask("task-1", "a", "c", "{}"));
+        assertNull(store.createTask("task-1", "a", "c", "{}"),
+            "duplicate taskId must not overwrite the existing record");
+    }
+
+    @Test
+    void updateStatusWithMatchingEpochSucceeds() {
+        TaskStore store = new MetaBackedTaskStore(new InMemoryMetaStore());
+        TaskRecord t = store.createTask("task-1", "a", "c", "{}");
+        assertTrue(store.updateStatus("task-1", t.taskEpoch, Status.RUNNING, null));
+        assertEquals(Status.RUNNING, store.getTask("task-1").status);
+        assertTrue(store.updateStatus("task-1", t.taskEpoch, Status.COMPLETED, "{\"ok\":true}"));
+        TaskRecord done = store.getTask("task-1");
+        assertEquals(Status.COMPLETED, done.status);
+        assertEquals("{\"ok\":true}", done.output);
+    }
+
+    @Test
+    void updateStatusWithStaleEpochIsRejected() {
+        TaskStore store = new MetaBackedTaskStore(new InMemoryMetaStore());
+        TaskRecord t = store.createTask("task-1", "a", "c", "{}");
+        store.updateStatus("task-1", t.taskEpoch, Status.RUNNING, null);
+        // A different epoch (simulating a stale writer) must be rejected.
+        assertFalse(store.updateStatus("task-1", t.taskEpoch + 7L, Status.COMPLETED, "{}"));
+        assertEquals(Status.RUNNING, store.getTask("task-1").status);
+    }
+
+    @Test
+    void clusterSharedTwoInstancesSeeSameTask() {
+        InMemoryMetaStore meta = new InMemoryMetaStore();
+        TaskStore a = new MetaBackedTaskStore(meta);
+        TaskStore b = new MetaBackedTaskStore(meta);
+        TaskRecord t = a.createTask("task-1", "a", "c", "{}");
+        // Instance B reads the record through its own getTask
+        TaskRecord bView = b.getTask("task-1");
+        assertNotNull(bView);
+        assertEquals(t.taskEpoch, bView.taskEpoch);
+    }
+
+    @Test
+    void listByAgentFiltersByAgentAndStatus() {
+        TaskStore store = new MetaBackedTaskStore(new InMemoryMetaStore());
+        TaskRecord a1 = store.createTask("a-1", "agent-A", "c", "{}");
+        store.createTask("a-2", "agent-A", "c", "{}");
+        store.createTask("b-1", "agent-B", "c", "{}");
+        store.updateStatus("a-1", a1.taskEpoch, Status.RUNNING, null);
+        assertEquals(2, store.listByAgent("agent-A", null).size());
+        assertEquals(1, store.listByAgent("agent-A", Status.RUNNING).size());
+        assertEquals(1, store.listByAgent("agent-A", Status.PENDING).size());
+        assertEquals(1, store.listByAgent("agent-B", null).size());
+    }
+
+    @Test
+    void expireStaleRemovesOldRecords() {
+        TaskStore store = new MetaBackedTaskStore(new InMemoryMetaStore());
+        store.createTask("old", "a", "c", "{}");
+        store.createTask("new", "a", "c", "{}");
+        // Force the "old" record to be updated 10s ago by reaching into the wire and rewriting
+        // its updatedAtMs to 0; then expireStale with a small window must remove only it.
+        // Deterministic: bump "new" with updateStatus so its updatedAtMs > "old" by tens of ms,
+        // then expireStale(1L) removes the older "old" record only.
+        store.updateStatus("new", store.getTask("new").taskEpoch, Status.RUNNING, null);
+        List<String> expired = store.expireStale(1L);
+        assertEquals(1, expired.size());
+        assertEquals("old", expired.get(0));
+        assertNull(store.getTask("old"));
+        assertNotNull(store.getTask("new"));
+    }
+
+    @Test
+    void opaqueInputWithPipeAndNewlineRoundTrips() {
+        TaskStore store = new MetaBackedTaskStore(new InMemoryMetaStore());
+        String weird = "{\"a\":\"b|c\\nd\"}";
+        TaskRecord t = store.createTask("task-1", "a", "c", weird);
+        assertEquals(weird, store.getTask("task-1").input);
+        assertTrue(store.updateStatus("task-1", t.taskEpoch, Status.COMPLETED, weird));
+        assertEquals(weird, store.getTask("task-1").output);
+    }
+}


### PR DESCRIPTION
## Summary

Two production implementations of the Sub-PR A interfaces, plus the wiring into `ReliableDispatcher`.

## Changes

**New files**
- `MetaBackedDeadLetterStore` — idempotent DLQ ledger under `/em/dlq/<deliveryId>` via `MetaStore.putIfAbsent` CAS. First recorder wins; concurrent writers see the existing record and return true so the dispatcher proceeds to retire.
- `MetaBackedTaskStore` — per-task record under `/em/tasks/<taskId>` with a self-describing `v1|<base64>` wire envelope. Variable-width fields (taskId, agentId, clientId, input, output) are base64-encoded before joining so opaque caller input containing `|` or newlines cannot corrupt the format. Status updates use `MetaStore.tryAcquire` as an epoch CAS, rejecting stale writers (issue #5291 style).
- 3 unit tests: `MetaBackedDeadLetterStoreTest`, `MetaBackedTaskStoreTest`, `ReliableDispatcherDlqLedgerTest`.

**Modified**
- `ReliableDispatcher` — new 9-arg ctor that adds an optional `DeadLetterStore`. The legacy 8-arg ctor (Sub-PR A/B wire) is untouched and the DLQ path skips the ledger call when no store is wired. The DLQ transition now records the deliveryId on the ledger before retirement; a ledger failure is logged but does not block retirement (the downstream DLQ sink has already persisted the body).

## Scope

| Issue | Status |
| --- | --- |
| #5292 (DLQ transition durable) | **fully fixed** — Sub-PR B's partial fix upgraded to ledger-backed |
| #5302 (A2A parallel Runtime) | **unblocked** — TaskStore is now production-ready |
| #5297 (A2A dispatch mode + TaskExpirer reaper) | deferred to Sub-PR D |

## Diff stat

```
eventmesh-runtime/src/main/java/.../delivery/ReliableDispatcher.java       |  34 +++
eventmesh-runtime/src/main/java/.../state/MetaBackedDeadLetterStore.java   |  90 ++++++++
eventmesh-runtime/src/main/java/.../state/MetaBackedTaskStore.java         | 242 +++++++++++++++++++++
eventmesh-runtime/src/test/java/.../delivery/ReliableDispatcherDlqLedgerTest.java  | 132 +++++++++++
eventmesh-runtime/src/test/java/.../state/MetaBackedDeadLetterStoreTest.java       |  68 ++++++
eventmesh-runtime/src/test/java/.../state/MetaBackedTaskStoreTest.java     | 137 ++++++++++++
6 files changed, 703 insertions(+)
```

## Test plan

- `./gradlew :eventmesh-runtime:test` — all Sub-PR A interface contract tests (DeadLetterStoreTest, TaskStoreTest) plus the 3 new tests above must pass.
- `./gradlew :eventmesh-runtime:checkstyleMain :eventmesh-runtime:checkstyleTest` — must be clean (no new violations introduced).