### PR TITLE
[Fix] Gate RocketMQ 5 POP broker ACK on distribution completion (#5295)

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/UniIngressService.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/UniIngressService.java
@@ -357,11 +357,28 @@ public class UniIngressService {
                 long offset = nextOffset(topic);
                 // P2 fix: if the frame carries a POP check key (RocketMQ 5.x deferred ACK), build a
                 // callback that ACKs the broker on client ACK (restoring at-least-once).
+                // Issue #5295: use a broker-ACK barrier keyed by POP check key so the broker ACK
+                // fires only when ALL required deliveries have ACKed (BROADCAST / MULTICAST
+                // targets are not prematurely ACKed by the first delivery that finishes).
                 String popCk = f.attributes().get("empopck");
-                Runnable mqAck = (popCk != null) ? () -> storage.ackPulledMessage(topic, popCk) : null;
-                for (Subscription target : subscriptionManager.targetsFor(topic, f)) {
-                    dispatcher.deliver(topic, partition, offset, f, target.getClientId(),
-                        channelFor(target.getClientId()), mqAck);
+                List<Subscription> targets = subscriptionManager.targetsFor(topic, f);
+                if (popCk != null && !targets.isEmpty()) {
+                    java.util.concurrent.atomic.AtomicInteger pending =
+                        new java.util.concurrent.atomic.AtomicInteger(targets.size());
+                    Runnable mqAck = () -> {
+                        if (pending.decrementAndGet() == 0) {
+                            storage.ackPulledMessage(topic, popCk);
+                        }
+                    };
+                    for (Subscription target : targets) {
+                        dispatcher.deliver(topic, partition, offset, f, target.getClientId(),
+                            channelFor(target.getClientId()), mqAck);
+                    }
+                } else {
+                    for (Subscription target : targets) {
+                        dispatcher.deliver(topic, partition, offset, f, target.getClientId(),
+                            channelFor(target.getClientId()), null);
+                    }
                 }
             }
             UniTrace.end(dispatchSpan);


### PR DESCRIPTION
## What changes were proposed in this pull request

Fix #5295: Gate RocketMQ 5 POP broker ACK on distribution completion.

### Problem
Previously, a single `mqAck` callback was shared across all deliveries of a frame. In BROADCAST/MULTICAST mode, the first client ACK would immediately ACK the broker, even if other required targets had not yet received or acknowledged the message.

### Solution
Introduce a broker-ACK barrier using an `AtomicInteger` counter:
- All deliveries of the same frame share a single counter initialized to `targets.size()`
- Broker ACK fires only when all deliveries have ACKed (counter reaches 0)
- LOAD_BALANCE (1 target): 1 ACK → broker ACK
- BROADCAST (N targets): N ACKs → broker ACK
- MULTICAST (matched targets): all matched ACKs → broker ACK

### Changes
- `eventmesh-runtime/.../UniIngressService.java`: Replace the shared `mqAck` callback with a barrier that counts down remaining ACKs before firing the broker ACK

### Verification
- [ ] In BROADCAST mode, the first of multiple client ACKs does not ACK the POP message at the broker
- [ ] The final required ACK executes exactly one broker ACK
- [ ] Duplicate and out-of-order ACKs do not execute multiple broker ACKs (guarded by ReliableDispatcher.ack's idempotency)
- [ ] Runtime failure before completion causes broker redelivery after POP invisible time