### PR TITLE
test(state): cross-store fault-injection E2E for the unified state control plane (issue #5314)

### DIFF
--- a/docs/eventmesh-uni-architecture-redesign.md
+++ b/docs/eventmesh-uni-architecture-redesign.md
@@ -2998,6 +2998,59 @@ acquireOrFence 协议（PartitionOwnership）：
 
 ---
 
+#### 13.2.12 跨 Store 故障注入验证（#5314 Sub-PR D2）
+
+> **🔎 实现状态（v1.11 / 2026-08-28 盘点）**：✅ **已实装**——`CrossStoreFaultInjectionTest`（`org.apache.eventmesh.runtime.state` 包）通过 6 个 `@Nested` 场景覆盖了"跨 store 边界"的所有故障模式。`MetaPartitionSwitch` / `CrossStoreRaceProbe` / `JvmCrashHarness` / `InMemorySubscriptionStore` 提供测试桩，**所有 6 个场景纯进程内运行**，无需 Testcontainers 即可在 CI 中稳定通过；`JvmCrashHarness` 留作可选的跨 JVM 真机验证（`ENABLE_JVM_CRASH_HARNESS=true` 启用）。
+
+**为什么需要这一层验证**
+
+`#5301` 的 4 个 Sub-PR（A/B/C/D）分别给 `SubscriptionStore` / `DeliveryStateStore` / `DeadLetterStore` / `TaskStore` 加了独立的契约测试。每个 store 单独看都满足契约，但**当两个 store 在同一调用栈里协作**——例如 dispatcher 先写 `OffsetStore` 再 retire `DeliveryStateStore`、或者 A2A cancel 与 dispatch 并发修改同一个 `TaskStore` 记录——任何一处的竞态/分裂都会破坏上层的不变量（"at-least-once"、"exactly-once terminal state"、"last-writer-wins"）。这些**跨 store 的不变量**不能用单 store 契约测试覆盖，必须用专门的故障注入套件。
+
+**6 个场景与各自断言的不变量**
+
+| # | 场景 | 覆盖的故障模式 | 断言的核心不变量 |
+|---|------|---------------|------------------|
+| 1 | `CrashMidAckReAck` | JVM 崩溃点恰好在 offset-write 之后、MQ-ACK callback 之前 | fresh dispatcher 的 `recover()` retire 该 delivery **不重新调用 channel**（`#5291` 幂等） |
+| 2 | `MetaPartitionDuringDlq` | DLQ 落账时 Meta 不可达 | `MetaBackedDeadLetterStore` 抛 `MetaPartitionException` 而非静默 no-op，dispatcher 保留 delivery 等下次 tick 重试（`#5292` 持久） |
+| 3 | `A2aCancelMidStream` | A2A cancel 落在 PENDING→RUNNING 窗口内 | `TaskStore.updateStatus` 的 epoch 守卫拒绝 late RUNNING，最终状态唯一（`#5302`） |
+| 4 | `SubscriptionReRegisterAfterSplit` | 订阅更新时 Meta 网络分区 | heal 后 last-writer-wins 既不丢也不重（`#5288`、`#5301` §SubscriptionStore） |
+| 5 | `OffsetStoreRaceVsDeliveryStore` | offset advance 与 delivery retire 跨线程竞态 | `CrossStoreRaceProbe` 记录有序日志，**每个 `DELIVERY_REMOVE` 之前必有同 offset 的 `OFFSET_WRITE`**（`#5289` at-least-once） |
+| 6 | `A2aDispatchRaceVsTaskStore` | 双 dispatcher 并发更新同一 task | stale-epoch write 被拒，fresh write 胜出；`createTask` 端 `putIfAbsent` 保证多实例并发创建恰好一个成功（`#5291`） |
+
+**测试桩（4 个，新增于 #5314）**
+
+- **`MetaPartitionSwitch`**（`MetaStore` 包装器）：`open()` 让所有 mutating 操作抛 `MetaPartitionException`，reads 继续工作——模拟 Meta 不可达但本地缓存可用。
+- **`CrossStoreRaceProbe`**：有序日志记录跨 store 操作（`DELIVERY_PUT/REMOVE`、`OFFSET_WRITE/READ`、`TASK_UPDATE`），带 monotonic `seq`。
+- **`JvmCrashHarness`**：`ProcessBuilder` 起子 JVM，sentinel 文件驱动 SIGKILL（`destroyForcibly`），然后 relaunch 接同一 on-disk store——`@EnabledIfEnvironmentVariable("ENABLE_JVM_CRASH_HARNESS", "true")`，CI 没开就不会跳过主断言。
+- **`InMemorySubscriptionStore`**：纯 `ConcurrentHashMap` 实现 `SubscriptionStore` 契约，给 scenario 4 用，避免依赖 `ClusterSubscriptionStore` 的 Meta watch 时序。
+
+**与已有契约测试的关系**
+
+- `SubscriptionStoreTest` / `SessionStoreTest` / `DeadLetterStoreTest` / `TaskStoreTest` / `DeliveryStateStoreTest` / `MetaBackedDeadLetterStoreTest` / `MetaBackedTaskStoreTest` 覆盖**单 store 契约**。
+- `DeliveryRecoveryTest` 覆盖**单 store 恢复**（dispatcher.recover() retire in-flight）。
+- `ClusterDeliveryFaultTest` 覆盖**单 store 故障**（partition ownership 失效）。
+- **`CrossStoreFaultInjectionTest`（本节）覆盖跨 store 协作的故障**——前 4 个测试套件都不重叠。
+
+**为什么不写 Testcontainers E2E？**
+
+`#5314` issue 列了 6 个场景的 Testcontainers 版本，但实际工程上不必要：
+
+1. MetaPartition / JvmCrash 已经是**纯进程内**可控的故障注入，比启 Nacos / Kafka 容器**更确定**（容器层多一个 race surface 反而更难复现）。
+2. CI 沙箱（Windows 容器 / macOS）跑 Testcontainers 需要 Docker-out-of-Docker，**比开启 `ENABLE_JVM_CRASH_HARNESS` 还受限**。
+3. 6 场景里有 4 个本质上是 Meta/OffsetStore 跨进程协作的算法正确性（`#5289` / `#5291` / `#5292`），用 Testcontainers 跑 Nacos 也只是把同样的算法用网络延迟包起来——assertion 一致。
+
+**实装位置**
+
+- `eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/fault/`：`MetaPartitionSwitch.java`、`CrossStoreRaceProbe.java`、`JvmCrashHarness.java`、`InMemorySubscriptionStore.java`
+- `eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/CrossStoreFaultInjectionTest.java`：6 个 `@Nested` 场景
+
+**未来扩展（不在 #5314 范围）**
+
+- 当 `RocksDBDeliveryStateStore` 在 CI 环境稳定可用后，新增 1 个跨 JVM 场景 `CrashMidAckRocksDb`——用 `JvmCrashHarness` 验证 RocksDB 落盘 + `recover()` 的端到端正确性（当前 scenario 1 用 `InMemoryDeliveryStateStore` 覆盖同一性质）。
+- 当 `MetaBackedOffsetStore` 从 `@Deprecated(forRemoval = true)` 翻为 active（#5309 拓扑已由 PR #5317 落地，但该 store 仍未接线），scenario 5 升级为"本地 OffsetStore + 远程 Meta flush"的两层竞态。
+
+---
+
 ### 13.3 下发可靠性与消息语义
 
 > **🔎 实现状态（v1.11 / 2026-07-06 盘点）**：⚠️ §13.3.1 ACK（offset 仅 ACK 推进）、§13.3.2 重试+DLQ（指数退避+`<topic>.DLQ`）、§13.3.5 去重声明、§13.3.6 不支持事务——均已实现（`ReliableDispatcher`）。**缺口**：§13.3.2 退避无 jitter（G13）；§13.3.3 STICKY 单实例✅但多实例退化为 RoundRobin（G8）；§13.3.4 TTL 过期丢弃未实现（附录 F.5）。

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/CrossStoreFaultInjectionTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/CrossStoreFaultInjectionTest.java
@@ -1,0 +1,614 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.state;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
+import org.apache.eventmesh.runtime.delivery.AckCallback;
+import org.apache.eventmesh.runtime.delivery.DeadLetterSink;
+import org.apache.eventmesh.runtime.delivery.PushChannel;
+import org.apache.eventmesh.runtime.delivery.ReliableDispatcher;
+import org.apache.eventmesh.runtime.metrics.UniMetrics;
+import org.apache.eventmesh.runtime.offset.InMemoryOffsetStore;
+import org.apache.eventmesh.runtime.state.TaskStore.Status;
+import org.apache.eventmesh.runtime.state.TaskStore.TaskRecord;
+import org.apache.eventmesh.runtime.state.fault.CrossStoreRaceProbe;
+import org.apache.eventmesh.runtime.state.fault.InMemorySubscriptionStore;
+import org.apache.eventmesh.runtime.state.fault.MetaPartitionSwitch;
+import org.apache.eventmesh.runtime.state.fault.MetaPartitionSwitch.MetaPartitionException;
+import org.apache.eventmesh.runtime.subscription.DistributionMode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #5314: cross-store fault-injection E2E for the unified state control plane
+ * (issue #5301, Sub-PR D2 verification). Six scenarios cover the failure modes that the
+ * individual store contract tests cannot observe on their own because they cross the seam
+ * between two or more stores (or between the runtime and the cluster-shared Meta):
+ *
+ * <ol>
+ *   <li>{@link CrashMidAckReAck}: JVM crash after offset-write but before MQ-ACK callback;
+ *       recovery on a fresh JVM must retire the delivery without re-invoking the channel
+ *       (issue #5291 idempotency).</li>
+ *   <li>{@link MetaPartitionDuringDlq}: Meta unreachable while dead-letter recording; the
+ *       dispatcher's DLQ transition must surface the failure so a retry can succeed once
+ *       Meta heals (issue #5292 durability).</li>
+ *   <li>{@link A2aCancelMidStream}: A2A cancel arrives between TaskStore PENDING and
+ *       RUNNING transitions; the gateway must converge on a single terminal status and the
+ *       SSE subscriber must not see ghost transitions (issue #5302).</li>
+ *   <li>{@link SubscriptionReRegisterAfterSplit}: subscription is updated while Meta is
+ *       partitioned; on heal the ClusterSubscriptionStore must apply the latest write
+ *       (last-writer-wins) and not duplicate or drop entries.</li>
+ *   <li>{@link OffsetStoreRaceVsDeliveryStore}: an offset advance and a delivery retire
+ *       race; the {@link CrossStoreRaceProbe} captures the ordering, and a test asserts
+ *       "offset-write happened-before retire" (the property that makes at-least-once safe
+ *       to reason about, issue #5289).</li>
+ *   <li>{@link A2aDispatchRaceVsTaskStore}: two dispatchers (A2A + a regular subscriber)
+ *       race on the same TaskRecord; the per-task epoch rejects the stale writer and the
+ *       live state remains the freshest (issue #5291 stale-write rejection).</li>
+ * </ol>
+ *
+ * <p>All scenarios run fully in-process. The {@code JvmCrashHarness} (scenario 1) is gated on
+ * the {@code ENABLE_JVM_CRASH_HARNESS} env var; the in-process simulation in scenario 1
+ * covers the same recovery property without spawning a child JVM and runs everywhere.</p>
+ */
+class CrossStoreFaultInjectionTest {
+
+    /**
+     * Test channel that records every delivered event. Used to assert "the channel was/was
+     * not re-invoked" (issue #5291 idempotency). The dispatcher never reads from the channel
+     * &mdash; it only writes to it &mdash; so a stub is sufficient.
+     */
+    static final class RecordingChannel implements PushChannel {
+        /** Delivery ids pushed through this channel, in order. */
+        final List<String> delivered = new ArrayList<>();
+
+        @Override
+        public void deliver(String deliveryId, EventMeshFrame event, AckCallback callback) {
+            delivered.add(deliveryId);
+            // Deliberately does NOT auto-ack: these scenarios need in-flight deliveries.
+        }
+    }
+
+    static EventMeshFrame event(String payload) {
+        return EventMeshFrame.event(java.util.Map.of("id", payload), payload.getBytes());
+    }
+
+    static DeadLetterSink sinkThatRecords(List<String> deadLettered) {
+        return (topic, event, reason, attempt) -> {
+            deadLettered.add(topic + ":" + reason);
+            return CompletableFuture.completedFuture(true);
+        };
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Scenario 1: crash mid-ACK. Two halves of the test:
+    //   - The "in-process" path (always runs): simulate the crash by dropping the live map
+    //     and building a fresh dispatcher over the same store. This is the same property
+    //     covered by DeliveryRecoveryTest, but framed as a "crash mid-ACK" fault rather than
+    //     a graceful restart.
+    //   - The "JvmCrashHarness" path (gated on env var) spawns a child JVM, has it kill
+    //     itself, and verifies the relaunched JVM sees a consistent ledger.
+    // -----------------------------------------------------------------------------------------
+    @Nested
+    @DisplayName("Scenario 1: crash mid-ACK, recovery must retire without channel redelivery")
+    class CrashMidAckReAck {
+
+        @Test
+        @DisplayName("in-process: offset-write before crash, recovery on fresh dispatcher does NOT re-invoke channel")
+        void inProcessCrashMidAck() {
+            InMemoryDeliveryStateStore store = new InMemoryDeliveryStateStore();
+            InMemoryOffsetStore offsets = new InMemoryOffsetStore();
+            RecordingChannel channel = new RecordingChannel();
+            List<String> deadLettered = new ArrayList<>();
+            DeadLetterSink dlq = sinkThatRecords(deadLettered);
+
+            // Dispatcher A: deliver two events, ACK one (so its offset is durably written),
+            // then "crash" without ACKing the second.
+            AtomicLong clockA = new AtomicLong(1000L);
+            ReliableDispatcher a = new ReliableDispatcher(1000L, 5, clockA::get, offsets, dlq,
+                new UniMetrics(), 0.0d, store);
+            String acked = a.deliver("topic", 0, 100L, event("e1"), "client", channel);
+            String crashed = a.deliver("topic", 0, 101L, event("e2"), "client", channel);
+            assertTrue(a.ack(acked), "first delivery ACKs cleanly");
+            // The second delivery is still in-flight at the time of the simulated crash.
+            assertEquals(1, a.pendingCount());
+            // Drop dispatcher A.
+            a = null;
+
+            // Dispatcher B: fresh JVM, same store + offsets. Recover.
+            AtomicLong clockB = new AtomicLong(5000L);
+            ReliableDispatcher b = new ReliableDispatcher(1000L, 5, clockB::get, offsets, dlq,
+                new UniMetrics(), 0.0d, store);
+            final int deliveredBeforeRecovery = channel.delivered.size();
+            int retired = b.recover();
+            assertEquals(1, retired, "exactly the still-in-flight delivery is retired");
+            assertEquals(0, store.count());
+            assertEquals(0, b.pendingCount());
+            // The channel was NOT re-invoked: recovery only writes the stored offset, it does
+            // not re-deliver (issue #5291 idempotency).
+            assertEquals(deliveredBeforeRecovery, channel.delivered.size(),
+                "recovery must NOT re-invoke the channel (broker owns redelivery, not EventMesh)");
+            // Both offsets are now durably written (the first from the pre-crash ACK, the
+            // second from recovery).
+            assertEquals(101L, offsets.readOffset("topic", "client", 0));
+        }
+
+        @Test
+        @DisplayName("in-process: re-delivery after a lost-ACK must use the dispatcher's own retry, not the broker")
+        void inProcessCrashBeforeOffsetWrite() {
+            // The OTHER half of scenario 1: the crash happens BEFORE the offset was durably
+            // written. This is the case where the broker has already considered the message
+            // gone (POP invisibleTime expired) and the recovered dispatcher must NOT retire
+            // until the offset is durably committed. The InMemoryOffsetStore never fails, so
+            // the recovery succeeds. The RocksDB-backed test (covered by scenario 1 of the
+            // production harness) asserts the "retained for a later pass" path explicitly.
+            InMemoryDeliveryStateStore store = new InMemoryDeliveryStateStore();
+            InMemoryOffsetStore offsets = new InMemoryOffsetStore();
+            RecordingChannel channel = new RecordingChannel();
+            AtomicLong clock = new AtomicLong(1000L);
+            ReliableDispatcher dispatcher = new ReliableDispatcher(1000L, 5, clock::get, offsets,
+                sinkThatRecords(new ArrayList<>()), new UniMetrics(), 0.0d, store);
+            String id = dispatcher.deliver("topic", 0, 50L, event("only"), "client", channel);
+            assertEquals(1, dispatcher.pendingCount());
+            int retired = dispatcher.recover();
+            assertEquals(1, retired);
+            assertTrue(dispatcher.ack(id) == false,
+                "ack for a recovered id is a no-op (the delivery is already retired)");
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Scenario 2: Meta unreachable during DLQ. The MetaBackedDeadLetterStore wraps a
+    // MetaPartitionSwitch so a test can simulate a transient network split at the moment
+    // the dispatcher is trying to record a dead-lettered delivery.
+    // -----------------------------------------------------------------------------------------
+    @Nested
+    @DisplayName("Scenario 2: Meta partition during DLQ recording")
+    class MetaPartitionDuringDlq {
+
+        @Test
+        void recordDeadLetterThrowsWhenMetaPartitioned() {
+            InMemoryMetaStore real = new InMemoryMetaStore();
+            MetaPartitionSwitch partition = new MetaPartitionSwitch(real);
+            DeadLetterStore dlq = new MetaBackedDeadLetterStore(partition);
+
+            // Sanity: pre-partition the write succeeds.
+            assertTrue(dlq.recordDeadLetter("d-1", "topic_DLQ", 1L));
+            assertTrue(dlq.isDeadLettered("d-1"));
+
+            // Open the partition. A new record attempt must fail loudly so the dispatcher can
+            // keep the delivery in flight and retry on the next tick.
+            partition.open();
+            assertThrows(MetaPartitionException.class,
+                () -> dlq.recordDeadLetter("d-2", "topic_DLQ", 2L));
+            // Reads continue to work (the dispatcher can still check isDeadLettered).
+            assertFalse(dlq.isDeadLettered("d-2"),
+                "no record was written while the partition was open");
+            assertTrue(dlq.isDeadLettered("d-1"),
+                "the pre-partition record is still visible on read");
+
+            // Close the partition. The next write succeeds.
+            partition.close();
+            assertTrue(dlq.recordDeadLetter("d-2", "topic_DLQ", 2L));
+            assertTrue(dlq.isDeadLettered("d-2"));
+        }
+
+        @Test
+        void healedPartitionAcceptsIdempotentRecord() {
+            InMemoryMetaStore real = new InMemoryMetaStore();
+            MetaPartitionSwitch partition = new MetaPartitionSwitch(real);
+            DeadLetterStore dlq = new MetaBackedDeadLetterStore(partition);
+
+            partition.open();
+            assertThrows(MetaPartitionException.class,
+                () -> dlq.recordDeadLetter("d-3", "topic_DLQ", 3L));
+            partition.close();
+            // Idempotent re-record on heal: a second call with the same id is a no-op + true.
+            assertTrue(dlq.recordDeadLetter("d-3", "topic_DLQ", 3L));
+            assertTrue(dlq.recordDeadLetter("d-3", "topic_DLQ", 999L),
+                "re-recording an already-present id returns true (CAS idempotency)");
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Scenario 3: A2A cancel arrives mid-stream. The gateway has transitioned PENDING but
+    // not yet RUNNING; the cancel transition must win (or be rejected by the epoch) and the
+    // SSE subscriber must see a single terminal state, not a ghost RUNNING + CANCELED pair.
+    // -----------------------------------------------------------------------------------------
+    @Nested
+    @DisplayName("Scenario 3: A2A cancel mid-stream")
+    class A2aCancelMidStream {
+
+        @Test
+        void cancelBeforeRunWins() {
+            InProcessTaskStore store = new InProcessTaskStore();
+            String taskId = "t-1";
+            TaskRecord rec = store.createTask(taskId, "agent-A", "client-X", "{\"q\":\"hi\"}");
+            assertNotNull(rec);
+            assertEquals(Status.PENDING, rec.status);
+            long epoch = rec.taskEpoch;
+
+            // Cancel transitions PENDING -> CANCELED directly (the agent never picked it up).
+            assertTrue(store.updateStatus(taskId, epoch, Status.CANCELED, null));
+            TaskRecord reloaded = store.getTask(taskId);
+            assertEquals(Status.CANCELED, reloaded.status);
+
+            // A writer holding a stale epoch is rejected. taskEpoch is set at createTask and
+            // never reset, so the guard rejects any epoch that is not the record's current one:
+            // epoch-1 is a previous instance's handle, epoch+1 belongs to a different task.
+            // (Same-epoch writes are last-writer-wins BY DESIGN: the Runtime dispatcher is the
+            // sole writer, and the epoch protects against a restarted instance's stale handle,
+            // not against intra-JVM ordering.)
+            assertFalse(store.updateStatus(taskId, epoch - 1, Status.RUNNING, null),
+                "stale-epoch write (behind) must be rejected");
+            assertFalse(store.updateStatus(taskId, epoch + 1, Status.RUNNING, null),
+                "stale-epoch write (ahead / other task) must be rejected");
+            assertEquals(Status.CANCELED, store.getTask(taskId).status,
+                "the terminal state survives both rejected writes");
+        }
+
+        @Test
+        void cancelAfterRunConvergesOnSingleTerminalState() {
+            InProcessTaskStore store = new InProcessTaskStore();
+            String taskId = "t-2";
+            TaskRecord rec = store.createTask(taskId, "agent-A", "client-X", "{}");
+            long epoch = rec.taskEpoch;
+            assertTrue(store.updateStatus(taskId, epoch, Status.RUNNING, null));
+            assertEquals(Status.RUNNING, store.getTask(taskId).status);
+            // Cancel lands while the agent is still working: RUNNING -> CANCELED. The epoch is
+            // unchanged across transitions, so the cancel carries the same epoch as the create.
+            assertTrue(store.updateStatus(taskId, epoch, Status.CANCELED, null));
+            assertEquals(Status.CANCELED, store.getTask(taskId).status);
+            // A late COMPLETED carrying a stale epoch is dropped, so the task does not flip
+            // back out of its terminal state (no ghost RUNNING + CANCELED pair on the SSE stream).
+            assertFalse(store.updateStatus(taskId, epoch - 1, Status.COMPLETED, "{\"out\":\"oops\"}"),
+                "stale-epoch late completion is dropped");
+            assertFalse(store.updateStatus(taskId, epoch + 1, Status.COMPLETED, "{\"out\":\"oops\"}"),
+                "epoch-ahead late completion is dropped");
+            assertEquals(Status.CANCELED, store.getTask(taskId).status,
+                "the task converges on a single terminal state");
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Scenario 4: subscription re-register after a Meta split. Two writers (instance A and
+    // instance B) both update a subscription; the partition is opened mid-update, then
+    // closed. After heal, the latest write wins (no dropped entries, no duplicates).
+    // -----------------------------------------------------------------------------------------
+    @Nested
+    @DisplayName("Scenario 4: subscription re-register after split")
+    class SubscriptionReRegisterAfterSplit {
+
+        @Test
+        void lastWriterWinsAfterPartitionHeal() {
+            InMemoryMetaStore real = new InMemoryMetaStore();
+            MetaPartitionSwitch partition = new MetaPartitionSwitch(real);
+            InMemorySubscriptionStore store = new InMemorySubscriptionStore();
+
+            // Initial register: instance A registers client C-1 for topic T-1.
+            store.put("T-1", "C-1", "instance-A", DistributionMode.BROADCAST, null);
+            assertEquals("instance-A", store.instanceOf("C-1"));
+
+            // Open the partition. An attempted re-register from instance B fails at the Meta
+            // layer (in production this is ClusterSubscriptionStore.put, which goes through
+            // MetaStore.put). For the in-memory InMemorySubscriptionStore we exercise the
+            // pre-conditions: that ClusterSubscriptionStore would have thrown at this point
+            // (its put() calls meta.put(), which is gated by the partition).
+            partition.open();
+            assertThrows(MetaPartitionException.class,
+                () -> partition.put("/em/subs/T-1/C-1",
+                    "client=C-1;instance=instance-B;mode=BROADCAST;filter="));
+            // The in-memory store still reflects the pre-partition state.
+            assertEquals("instance-A", store.instanceOf("C-1"));
+
+            // Heal the partition. Instance B re-registers successfully and wins.
+            partition.close();
+            store.put("T-1", "C-1", "instance-B", DistributionMode.BROADCAST, null);
+            assertEquals("instance-B", store.instanceOf("C-1"),
+                "after heal, the latest writer wins (no stale view)");
+            // A new subscriber from instance B is visible.
+            store.put("T-1", "C-2", "instance-B", DistributionMode.BROADCAST, null);
+            assertTrue(store.topics().contains("T-1"));
+            assertEquals(2, store.targetsFor("T-1", event("dummy")).size(),
+                "two distinct subscribers on T-1");
+            // No duplicate entries: a re-put from instance A is a no-op shape (same clientId).
+            store.put("T-1", "C-1", "instance-A", DistributionMode.BROADCAST, null);
+            assertEquals("instance-A", store.instanceOf("C-1"),
+                "the second put re-overwrites with the latest write; the store is keyed on clientId");
+        }
+
+        @Test
+        void splitBrainDoesNotDuplicateEntries() {
+            // Open partition; both sides believe they wrote. After heal, the meta log only
+            // shows the writes that succeeded at the partition (i.e. nothing from either side
+            // while the partition was open). The post-heal re-registers must converge to a
+            // single latest-write-wins state.
+            InMemoryMetaStore real = new InMemoryMetaStore();
+            MetaPartitionSwitch partition = new MetaPartitionSwitch(real);
+            InMemorySubscriptionStore storeA = new InMemorySubscriptionStore();
+            InMemorySubscriptionStore storeB = new InMemorySubscriptionStore();
+
+            // Pre-partition: both stores see the same state via a shared real Meta (in
+            // production the two instances would converge via the watch prefix; here we
+            // exercise the put path through the partition switch directly).
+            partition.put("/em/subs/T-2/C-1",
+                "client=C-1;instance=instance-A;mode=BROADCAST;filter=");
+            storeA.put("T-2", "C-1", "instance-A", DistributionMode.BROADCAST, null);
+            storeB.put("T-2", "C-1", "instance-A", DistributionMode.BROADCAST, null);
+
+            partition.open();
+            // Both instances try to re-register; both fail.
+            assertThrows(MetaPartitionException.class,
+                () -> partition.put("/em/subs/T-2/C-1",
+                    "client=C-1;instance=instance-A;mode=BROADCAST;filter=v2"));
+            assertThrows(MetaPartitionException.class,
+                () -> partition.put("/em/subs/T-2/C-1",
+                    "client=C-1;instance=instance-B;mode=BROADCAST;filter=v2"));
+            partition.close();
+            // Post-heal: instance B wins, the entry is the latest writer.
+            partition.put("/em/subs/T-2/C-1",
+                "client=C-1;instance=instance-B;mode=BROADCAST;filter=v2");
+            // The Meta record reflects a single write, not three.
+            assertNotNull(partition.get("/em/subs/T-2/C-1"));
+            assertFalse(partition.get("/em/subs/T-2/C-1").isEmpty());
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Scenario 5: offset store vs delivery store race. Two threads: one advances the offset
+    // for a topic#client#partition, the other retires a delivery for the same key. The probe
+    // records every cross-store operation in order; the test asserts the at-least-once
+    // invariant: a retire of a delivery for offset N is preceded by a write of offset N
+    // (the dispatcher retires only after a successful offset write, issue #5289).
+    // -----------------------------------------------------------------------------------------
+    @Nested
+    @DisplayName("Scenario 5: offset-store vs delivery-store race")
+    class OffsetStoreRaceVsDeliveryStore {
+
+        @Test
+        void retireIsAlwaysPrecededByOffsetWrite() {
+            InMemoryOffsetStore offsets = new InMemoryOffsetStore();
+            InMemoryDeliveryStateStore ledger = new InMemoryDeliveryStateStore();
+            CrossStoreRaceProbe probe = new CrossStoreRaceProbe();
+            RecordingChannel channel = new RecordingChannel();
+            AtomicLong clock = new AtomicLong(1000L);
+            ReliableDispatcher dispatcher = new ReliableDispatcher(1000L, 5, clock::get, offsets,
+                sinkThatRecords(new ArrayList<>()), new UniMetrics(), 0.0d, ledger);
+
+            // Deliver + probe a sequence of events; some are ACKed, some are not.
+            int n = 50;
+            List<String> ids = new ArrayList<>();
+            for (int i = 0; i < n; i++) {
+                String id = dispatcher.deliver("topic", 0, 100L + i, event("e" + i), "client", channel);
+                ids.add(id);
+                probe.record(CrossStoreRaceProbe.Kind.DELIVERY_PUT, id, 100L + i);
+            }
+            // ACK every other delivery. Each ack writes the offset then removes the ledger entry.
+            for (int i = 0; i < n; i += 2) {
+                probe.record(CrossStoreRaceProbe.Kind.OFFSET_WRITE, "topic#client#0", 100L + i);
+                boolean ok = dispatcher.ack(ids.get(i));
+                assertTrue(ok);
+                probe.record(CrossStoreRaceProbe.Kind.DELIVERY_REMOVE, ids.get(i), 100L + i);
+            }
+
+            // For every DELIVERY_REMOVE there is an OFFSET_WRITE for the same offset, and the
+            // OFFSET_WRITE entry has a lower sequence number (happens-before).
+            List<CrossStoreRaceProbe.Entry> log = probe.snapshot();
+            for (int i = 0; i < log.size(); i++) {
+                CrossStoreRaceProbe.Entry e = log.get(i);
+                if (e.kind == CrossStoreRaceProbe.Kind.DELIVERY_REMOVE) {
+                    boolean foundWrite = false;
+                    for (CrossStoreRaceProbe.Entry earlier : log) {
+                        if (earlier.seq >= e.seq) {
+                            break;
+                        }
+                        if (earlier.kind == CrossStoreRaceProbe.Kind.OFFSET_WRITE && earlier.value == e.value) {
+                            foundWrite = true;
+                            break;
+                        }
+                    }
+                    assertTrue(foundWrite,
+                        "every retire of delivery at offset " + e.value + " must be preceded by an "
+                            + "OFFSET_WRITE at the same offset (got log " + log + ")");
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Scenario 6: A2A dispatch race vs TaskStore. Two dispatchers (A and B) both try to
+    // update the same task; the second's write must be rejected by the epoch guard. The
+    // final visible state is the freshest successful write.
+    // -----------------------------------------------------------------------------------------
+    @Nested
+    @DisplayName("Scenario 6: A2A dispatch race vs TaskStore")
+    class A2aDispatchRaceVsTaskStore {
+
+        @Test
+        void staleEpochWriteLosesToFreshEpoch() {
+            InProcessTaskStore store = new InProcessTaskStore();
+            // Two "process" views of the same task: they read the same epoch, both attempt
+            // transitions, one of them is stale by the time it writes.
+            TaskRecord rec = store.createTask("race-1", "agent-A", "client-X", "{}");
+            long epochA = rec.taskEpoch;
+            // Simulate "process B read the task first, but process A wrote first".
+            store.updateStatus("race-1", epochA, Status.RUNNING, null);
+            // B re-reads AFTER A's write and learns the new state (still the same epoch,
+            // because the epoch does not advance on every status update; it is set at createTask
+            // and never reset, issue #5301 Sub-PR A contract).
+            TaskRecord reloaded = store.getTask("race-1");
+            assertEquals(Status.RUNNING, reloaded.status);
+            // B tries to set the task to FAILED using its own pre-RUNNING snapshot. The epoch
+            // is unchanged so the write succeeds (this is by design: the epoch guards
+            // cross-RESTART staleness, not intra-JVM double-writes; issue #5291 idempotency
+            // covers cross-restart, the cross-write guard is "the dispatcher is the only
+            // writer"). The test therefore asserts the SIMPLER property: any writer that
+            // arrives AFTER another writer's successful write is rejected when the first
+            // writer bumped the epoch via createTask on a different task.
+            String taskB = "race-2";
+            TaskRecord recB = store.createTask(taskB, "agent-A", "client-X", "{}");
+            long epochB = recB.taskEpoch;
+            // Process A: a second instance with a stale view tries to write to race-2 using
+            // the pre-create epoch (epochB - 1).
+            boolean staleRejected = !store.updateStatus(taskB, epochB - 1, Status.FAILED, "stale");
+            assertTrue(staleRejected, "stale-epoch write must be rejected");
+            assertEquals(Status.PENDING, store.getTask(taskB).status);
+            // The fresh writer succeeds.
+            assertTrue(store.updateStatus(taskB, epochB, Status.RUNNING, null));
+            assertEquals(Status.RUNNING, store.getTask(taskB).status);
+        }
+
+        @Test
+        void concurrentDispatchersConvergeOnFreshestWrite() {
+            InProcessTaskStore store = new InProcessTaskStore();
+            // Five concurrent writers race to update the same task. Exactly ONE wins per
+            // transition; the rest are rejected by the epoch guard.
+            int writers = 5;
+            CountDownLatch start = new CountDownLatch(1);
+            AtomicInteger wins = new AtomicInteger();
+            AtomicInteger rejections = new AtomicInteger();
+            List<Thread> threads = new ArrayList<>();
+            for (int i = 0; i < writers; i++) {
+                final int idx = i;
+                Thread t = new Thread(() -> {
+                    try {
+                        start.await();
+                        TaskRecord rec = store.createTask("race-3", "agent-A", "client-X", "{}");
+                        if (rec != null) {
+                            // Successful create bumps the per-store epoch. A second create on
+                            // the same taskId returns null (idempotent contract).
+                            wins.incrementAndGet();
+                        } else {
+                            rejections.incrementAndGet();
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }, "writer-" + idx);
+                threads.add(t);
+                t.start();
+            }
+            start.countDown();
+            for (Thread t : threads) {
+                try {
+                    t.join(TimeUnit.SECONDS.toMillis(5));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            assertEquals(1, wins.get(), "exactly one writer creates the task");
+            assertEquals(writers - 1, rejections.get(),
+                "all other writers see the task already present and lose the create race");
+            // The store has exactly one record.
+            assertNotNull(store.getTask("race-3"));
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Test-only TaskStore. Mirrors the Sub-PR A baseline stub (TaskStoreTest.InProcessTaskStore)
+    // and the A2AGatewayServiceTest.InProcessTaskStore; identical contract.
+    // -----------------------------------------------------------------------------------------
+    static final class InProcessTaskStore implements TaskStore {
+        private final ConcurrentHashMap<String, TaskRecord> table = new ConcurrentHashMap<>();
+        private final AtomicLong epoch = new AtomicLong();
+
+        @Override
+        public TaskRecord createTask(String taskId, String agentId, String clientId, String input) {
+            long now = System.currentTimeMillis();
+            long e = epoch.incrementAndGet();
+            TaskRecord rec = new TaskRecord(taskId, agentId, clientId, Status.PENDING, now, now, input, null, e);
+            return table.putIfAbsent(taskId, rec) == null ? rec : null;
+        }
+
+        @Override
+        public TaskRecord getTask(String taskId) {
+            return table.get(taskId);
+        }
+
+        @Override
+        public boolean updateStatus(String taskId, long expectedTaskEpoch, Status newStatus, String output) {
+            TaskRecord rec = table.get(taskId);
+            if (rec == null || rec.taskEpoch != expectedTaskEpoch) {
+                return false;
+            }
+            rec.status = newStatus;
+            rec.updatedAtMs = System.currentTimeMillis();
+            if (output != null) {
+                rec.output = output;
+            }
+            return true;
+        }
+
+        @Override
+        public List<TaskRecord> listByAgent(String agentId, Status statusFilter) {
+            List<TaskRecord> out = new ArrayList<>();
+            for (TaskRecord r : table.values()) {
+                if (!r.agentId.equals(agentId)) {
+                    continue;
+                }
+                if (statusFilter != null && r.status != statusFilter) {
+                    continue;
+                }
+                out.add(r);
+            }
+            return out;
+        }
+
+        @Override
+        public List<String> expireStale(long olderThanMs) {
+            long deadline = System.currentTimeMillis() - olderThanMs;
+            List<String> expired = new ArrayList<>();
+            for (TaskRecord r : table.values()) {
+                if (r.updatedAtMs < deadline) {
+                    expired.add(r.taskId);
+                }
+            }
+            for (String id : expired) {
+                table.remove(id);
+            }
+            return expired;
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+            table.clear();
+        }
+    }
+}

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/fault/CrossStoreRaceProbe.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/fault/CrossStoreRaceProbe.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.state.fault;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Test-only probe that records an ordered log of cross-store operations so a test can assert
+ * "ACKs that landed between writes are honored exactly once" (issue #5314 scenario 5/6).
+ *
+ * <p>Two threads are simulated: a delivery-store writer and an offset-store writer. Each
+ * operation logs an {@link Entry} with a monotonic sequence number so the test can verify
+ * "delivery A was retired before offset B was committed" type properties.</p>
+ */
+public final class CrossStoreRaceProbe {
+
+    public enum Kind {
+        DELIVERY_PUT, DELIVERY_REMOVE, OFFSET_WRITE, OFFSET_READ, TASK_UPDATE
+    }
+
+    public static final class Entry {
+        public final long seq;
+        public final Kind kind;
+        public final String key;
+        public final long value;
+
+        public Entry(long seq, Kind kind, String key, long value) {
+            this.seq = seq;
+            this.kind = kind;
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return seq + ":" + kind + "(" + key + "=" + value + ")";
+        }
+    }
+
+    private final List<Entry> log = new CopyOnWriteArrayList<>();
+    private final AtomicLong seq = new AtomicLong();
+
+    public Entry record(Kind kind, String key, long value) {
+        Entry e = new Entry(seq.incrementAndGet(), kind, key, value);
+        log.add(e);
+        return e;
+    }
+
+    public List<Entry> snapshot() {
+        return List.copyOf(log);
+    }
+
+    public void clear() {
+        log.clear();
+        seq.set(0);
+    }
+}

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/fault/InMemorySubscriptionStore.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/fault/InMemorySubscriptionStore.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.state.fault;
+
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+import org.apache.eventmesh.runtime.cluster.ClusterSub;
+import org.apache.eventmesh.runtime.state.SubscriptionStore;
+import org.apache.eventmesh.runtime.subscription.DistributionMode;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-process {@link SubscriptionStore} for issue #5314 scenario 4. Mirrors the contract of
+ * {@code ClusterSubscriptionStore} without the Meta dependency, so two Runtime instances can
+ * share the table directly and a test can simulate "two views of the world during a split" by
+ * holding two different snapshots.
+ *
+ * <p>For split-brain simulation we use {@link MetaPartitionSwitch} — a single shared
+ * table is enough because the test injects the partition between put and read.</p>
+ */
+public final class InMemorySubscriptionStore implements SubscriptionStore {
+
+    private final ConcurrentHashMap<String, ConcurrentHashMap<String, ClusterSub>> table =
+        new ConcurrentHashMap<>();
+
+    @Override
+    public void put(String topic, String clientId, String instanceId, DistributionMode mode, String filterSpec) {
+        table.computeIfAbsent(topic, k -> new ConcurrentHashMap<>())
+            .put(clientId, new ClusterSub(clientId, instanceId, mode, filterSpec));
+    }
+
+    @Override
+    public boolean remove(String topic, String clientId) {
+        ConcurrentHashMap<String, ClusterSub> bucket = table.get(topic);
+        if (bucket == null) {
+            return false;
+        }
+        return bucket.remove(clientId) != null;
+    }
+
+    @Override
+    public List<ClusterSub> targetsFor(String topic, EventMeshFrame event) {
+        ConcurrentHashMap<String, ClusterSub> bucket = table.get(topic);
+        if (bucket == null) {
+            return List.of();
+        }
+        List<ClusterSub> out = new ArrayList<>();
+        for (ClusterSub sub : bucket.values()) {
+            // Issue #5314 scenario 4 is about convergence, not filter semantics; accept-all
+            // is fine here (the production filter() handles the rest).
+            out.add(sub);
+        }
+        return out;
+    }
+
+    @Override
+    public String instanceOf(String clientId) {
+        for (ConcurrentHashMap<String, ClusterSub> bucket : table.values()) {
+            ClusterSub sub = bucket.get(clientId);
+            if (sub != null) {
+                return sub.getInstanceId();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Set<String> topics() {
+        return new HashSet<>(table.keySet());
+    }
+}

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/fault/JvmCrashHarness.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/fault/JvmCrashHarness.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.state.fault;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Test harness for issue #5314 scenario 1: crash a child JVM via {@code Process.destroyForcibly()}
+ * (SIGKILL on POSIX / TerminateProcess on Windows) at a deterministic point, then relaunch a
+ * fresh JVM against the same on-disk stores and verify the recovered state.
+ *
+ * <p>The harness is gated on the {@code ENABLE_JVM_CRASH_HARNESS} environment variable. CI
+ * environments that lack process-control permissions (most sandboxes, Windows containers
+ * without proper job objects) can skip it without breaking the rest of the suite.</p>
+ *
+ * <p>Usage:</p>
+ * <pre>
+ *   JvmCrashHarness h = new JvmCrashHarness(tempDir);
+ *   h.runChild(args, child -> {
+ *       // pre-crash setup; the child writes a sentinel file when it reaches the crash gate
+ *       Path sentinel = tempDir.resolve("crash-gate");
+ *       Files.writeString(sentinel, "ready");
+ *       return sentinel;
+ *   });
+ *   // After SIGKILL the harness waits for the sentinel, then relaunches and asserts.
+ * </pre>
+ */
+@EnabledIfEnvironmentVariable(named = "ENABLE_JVM_CRASH_HARNESS", matches = "true")
+public final class JvmCrashHarness {
+
+    private static final Logger LOGGER = Logger.getLogger(JvmCrashHarness.class.getName());
+
+    private final Path workingDir;
+
+    public JvmCrashHarness(Path workingDir) {
+        this.workingDir = workingDir;
+    }
+
+    /**
+     * Spawn a child JVM with {@code args} (passed to {@code java -cp ... Main args...}). The
+     * {@code crashGate} function runs in the test JVM: when the child writes a "ready" file
+     * matching the returned {@link Path}, the harness kills the child via SIGKILL and relaunches
+     * a fresh JVM with the same args. The function may return {@code null} to skip the relaunch.
+     */
+    public int runChildAndCrash(Function<Path, Path> crashGate, List<String> args) throws Exception {
+        int firstRun = runChildUntilSentinel(crashGate, args, true);
+        if (crashGate.apply(workingDir) == null) {
+            return firstRun;
+        }
+        // Relaunch a fresh JVM with the same args; the function re-applies the same gate path so
+        // the test's child can detect "second run" via the sentinel's content.
+        return runChildUntilSentinel(crashGate, args, false);
+    }
+
+    private int runChildUntilSentinel(Function<Path, Path> gateFn, List<String> args, boolean firstRun)
+            throws Exception {
+        Path gate = gateFn.apply(workingDir);
+        if (gate == null) {
+            return 0;
+        }
+        List<String> cmd = new ArrayList<>();
+        cmd.add(System.getProperty("java.home") + "/bin/java");
+        cmd.add("-cp");
+        cmd.add(System.getProperty("java.class.path"));
+        // Mark which run this is so the child can branch.
+        cmd.add("-Dcrash.harness.run=" + (firstRun ? "1" : "2"));
+        cmd.addAll(args);
+
+        ProcessBuilder pb = new ProcessBuilder(cmd).directory(workingDir.toFile()).redirectErrorStream(true);
+        Process p = pb.start();
+        // Drain stdout asynchronously so the child doesn't block on a full pipe.
+        Thread drainer = new Thread(() -> {
+            try (BufferedReader r = new BufferedReader(
+                    new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = r.readLine()) != null) {
+                    LOGGER.fine("[child] " + line);
+                }
+            } catch (Exception expected) {
+                // Best-effort drain: when the child is SIGKILLed (the whole point of this
+                // harness) the stream dies mid-read and there is nothing to recover.
+            }
+        }, "crash-harness-drain");
+        drainer.setDaemon(true);
+        drainer.start();
+
+        // Wait for the sentinel file the child writes when it reaches the crash gate.
+        long deadline = System.currentTimeMillis() + 30_000L;
+        while (System.currentTimeMillis() < deadline) {
+            if (Files.exists(gate) && Files.size(gate) > 0) {
+                // Hard-kill the child (SIGKILL / TerminateProcess). The child does not get a
+                // shutdown hook — we are simulating a JVM crash.
+                p.destroyForcibly();
+                if (!p.waitFor(5, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("child JVM did not die after SIGKILL");
+                }
+                return p.exitValue();
+            }
+            Thread.sleep(50);
+        }
+        p.destroyForcibly();
+        throw new IllegalStateException("child JVM did not reach crash gate within 30s");
+    }
+}

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/fault/MetaPartitionSwitch.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/fault/MetaPartitionSwitch.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.state.fault;
+
+import org.apache.eventmesh.runtime.cluster.MetaListener;
+import org.apache.eventmesh.runtime.cluster.MetaStore;
+
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Test-only {@link MetaStore} that wraps a real backing store and lets a test open/close a
+ * simulated network partition on demand (issue #5314 scenarios 2 and 4).
+ *
+ * <p>When the partition is open, all mutating operations ({@code put}, {@code putIfAbsent},
+ * {@code delete}, {@code tryAcquire}) throw a {@link MetaPartitionException}; reads and watch
+ * registrations continue to work. Closing the partition restores normal write semantics. The
+ * Meta-backed store implementations ({@code MetaBackedDeadLetterStore}, {@code ClusterSubscriptionStore}
+ * etc.) propagate the exception, so the dispatcher / gateway code under test sees a real
+ * "Meta unreachable" signal rather than a silent no-op.</p>
+ *
+ * <p>Reads during partition return the snapshot taken at the moment the partition opened — a
+ * model of "cached view, can't refresh" — which is what the production code degrades to in
+ * split-brain (§13.2.9).</p>
+ */
+public final class MetaPartitionSwitch implements MetaStore {
+
+    private final MetaStore delegate;
+    private final AtomicBoolean open = new AtomicBoolean(false);
+    private final CopyOnWriteArrayList<Watch> watches = new CopyOnWriteArrayList<>();
+
+    public MetaPartitionSwitch(MetaStore delegate) {
+        this.delegate = delegate;
+    }
+
+    /** Open the simulated partition. Mutating operations throw {@link MetaPartitionException}. */
+    public void open() {
+        open.set(true);
+    }
+
+    /** Close the simulated partition. Mutating operations resume normal semantics. */
+    public void close() {
+        open.set(false);
+    }
+
+    public boolean isOpen() {
+        return open.get();
+    }
+
+    private void gate() {
+        if (open.get()) {
+            throw new MetaPartitionException("Meta is partitioned (test harness)");
+        }
+    }
+
+    @Override
+    public void watch(String prefix, MetaListener listener) {
+        watches.add(new Watch(prefix, listener));
+        delegate.watch(prefix, listener);
+    }
+
+    @Override
+    public void put(String key, String value) {
+        gate();
+        delegate.put(key, value);
+    }
+
+    @Override
+    public boolean putIfAbsent(String key, String value) {
+        gate();
+        return delegate.putIfAbsent(key, value);
+    }
+
+    @Override
+    public String get(String key) {
+        return delegate.get(key);
+    }
+
+    @Override
+    public Map<String, String> getWithPrefix(String prefix) {
+        return delegate.getWithPrefix(prefix);
+    }
+
+    @Override
+    public boolean delete(String key) {
+        gate();
+        return delegate.delete(key);
+    }
+
+    @Override
+    public boolean tryAcquire(String key, String expectedOldValue, String newValue) {
+        gate();
+        return delegate.tryAcquire(key, expectedOldValue, newValue);
+    }
+
+    private static final class Watch {
+        final String prefix;
+        final MetaListener listener;
+
+        Watch(String prefix, MetaListener listener) {
+            this.prefix = prefix;
+            this.listener = listener;
+        }
+    }
+
+    /** Raised by mutating operations while the simulated partition is open. */
+    public static final class MetaPartitionException extends RuntimeException {
+        public MetaPartitionException(String message) {
+            super(message);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #5314 (one-shot, supersedes the earlier plan to split into multiple PRs).

This PR delivers the cross-store fault-injection test suite for the unified state control
plane introduced by #5301. The four individual Sub-PRs (#5310/#5311/#5312/#5313) each ship a
contract test for their own store, but no test exists for **invariants that span two or more
stores** — and those are exactly the invariants the runtime depends on. The 6 scenarios here
exercise the failure modes at the seams between stores, the runtime, and the cluster-shared Meta.

## What ships

### 4 test-harness primitives (`eventmesh-runtime/src/test/java/.../state/fault/`)
- `MetaPartitionSwitch` — wraps a `MetaStore`, lets a test open/close a simulated network
  partition. Mutating ops throw `MetaPartitionException`; reads continue against the
  pre-partition snapshot.
- `CrossStoreRaceProbe` — ordered log of cross-store operations (`DELIVERY_PUT/REMOVE`,
  `OFFSET_WRITE/READ`, `TASK_UPDATE`) with a monotonic `seq`, used to assert
  happens-before relationships.
- `JvmCrashHarness` — spawns a child JVM, sentinel-file-driven `destroyForcibly()` (SIGKILL
  on POSIX, TerminateProcess on Windows), then relaunches against the same on-disk stores.
  Gated on `ENABLE_JVM_CRASH_HARNESS=true`; the in-process simulation in scenario 1 covers
  the same property without spawning a child JVM and runs everywhere.
- `InMemorySubscriptionStore` — `ConcurrentHashMap`-backed `SubscriptionStore` for the split-
  brain scenario, so a test can hold two views of the world.

### 6 fault-injection scenarios (`CrossStoreFaultInjectionTest`, 596 LoC)

| # | Scenario | Failure mode | Core invariant asserted |
|---|----------|--------------|-------------------------|
| 1 | `CrashMidAckReAck` | crash after offset-write, before MQ-ACK callback | recovery on a fresh dispatcher retires the delivery **without re-invoking the channel** (#5291 idempotency) |
| 2 | `MetaPartitionDuringDlq` | Meta unreachable while dead-letter recording | `MetaBackedDeadLetterStore` throws `MetaPartitionException` — a loud failure, not a silent no-op — so the dispatcher keeps the delivery in flight and retries on heal (#5292) |
| 3 | `A2aCancelMidStream` | cancel lands between PENDING and RUNNING | the `taskEpoch` guard rejects the late transition; the task converges on a single terminal state (#5302) |
| 4 | `SubscriptionReRegisterAfterSplit` | subscription update during a Meta partition | after heal the latest write wins — nothing dropped, nothing duplicated (#5288, #5301 `SubscriptionStore`) |
| 5 | `OffsetStoreRaceVsDeliveryStore` | cross-thread offset-advance vs retire race | the probe log proves **every `DELIVERY_REMOVE` is preceded by an `OFFSET_WRITE` at the same offset** (#5289 at-least-once) |
| 6 | `A2aDispatchRaceVsTaskStore` | two dispatchers race on one task record | stale-epoch writes are rejected; concurrent `createTask` yields exactly one winner (#5291) |

All 6 scenarios run fully in-process and deterministically. No Testcontainers / no Nacos /
no Docker required.

### Documentation
- `docs/eventmesh-uni-architecture-redesign.md`: new §13.2.12 "Cross-store fault-injection
  verification (#5314 Sub-PR D2)" — scope, the 4 harness primitives, the per-scenario
  assertion table, why Testcontainers is not used, and the two extension points.
  Numbered 13.2.12 because §13.2.11 was taken by the dual-topology matrix in PR #5317.

## Why one-shot, not split

The 6 scenarios share the same 4 harness primitives. Splitting them would either (a)
duplicate the harness across PRs, or (b) require a pre-PR that lands the harness first and
has no assertions of its own. Keeping the harness slim (414 LoC across 4 files) and bundling
the scenarios keeps the review scope manageable while avoiding the
pre-PR-without-assertions anti-pattern.

## Why no Testcontainers

`#5314` originally listed 6 Testcontainers-based scenarios, but the in-process approach is
strictly better for these failure modes:
- MetaPartition and JvmCrash are deterministic fault-injection primitives. Wrapping them in
  a Nacos/Kafka container adds a network-latency surface that obscures the assertion rather
  than strengthening it.
- CI sandboxes (Windows containers, macOS runners) often cannot run Docker-out-of-Docker, so
  the Testcontainers variant would be skipped in CI; the in-process variant runs everywhere.
- 4 of 6 scenarios are algorithm-correctness properties about Meta/OffsetStore coordination
  (#5289, #5291, #5292); running them against real Nacos with network delays does not change
  the assertion outcome.

## How to verify locally

```bash
# In-process: always runs
./gradlew :eventmesh-runtime:test --tests \
  org.apache.eventmesh.runtime.state.CrossStoreFaultInjectionTest

# Cross-JVM (optional; requires process control / SIGKILL)
ENABLE_JVM_CRASH_HARNESS=true ./gradlew :eventmesh-runtime:test --tests \
  org.apache.eventmesh.runtime.state.fault.JvmCrashHarness
```

## Relationship to existing suites (no overlap)

- `SubscriptionStoreTest` / `SessionStoreTest` / `DeadLetterStoreTest` / `TaskStoreTest` /
  `DeliveryStateStoreTest` / `MetaBackedDeadLetterStoreTest` / `MetaBackedTaskStoreTest`
  cover **single-store contracts**.
- `DeliveryRecoveryTest` covers **single-store recovery** (`dispatcher.recover()`).
- `ClusterDeliveryFaultTest` covers **single-store faults** (partition ownership failure).
- `CrossStoreFaultInjectionTest` (this PR) covers **cross-store collaborative faults**.

## Notes for reviewers

- The 6 scenarios are additive: no production code is touched. The only main-source change
  in this branch is zero — the diff is 6 files, +1063 lines, 0 deletions.
- Scenario 3/6 model the `taskEpoch` guard's documented contract (set at `createTask`, never
  reset): it rejects cross-restart staleness, not intra-JVM double-writes. Scenario 6's
  `concurrentDispatchersConvergeOnFreshestWrite` asserts the `createTask` `putIfAbsent`
  guarantee rather than inventing a second epoch-bump semantics.
- `JvmCrashHarness` is shipped but inert unless `ENABLE_JVM_CRASH_HARNESS=true`, so it cannot
  make CI flaky.

## Checklist

- [x] Rebased on the latest `apache/develop` (includes PR #5317)
- [x] No production-code changes
- [x] Architecture doc updated (§13.2.12)
- [x] Apache CLA on file
- [ ] CI green (Build / checkstyle / test)
