### PR TITLE
refactor(runtime): partition eventmesh-runtime via internal packages (#5297)

### DIFF
--- a/eventmesh-architecture-guard/build.gradle
+++ b/eventmesh-architecture-guard/build.gradle
@@ -28,6 +28,13 @@ dependencies {
     // "outside of common" package so that-clauses never match empty.
     testImplementation project(':eventmesh-common')
     testImplementation project(':eventmesh-spi')
+    // :eventmesh-runtime added for issue #5297 so the runtime.* ArchUnit
+    // rules (ruleRuntimeTcpInternalHidden, ruleRuntimeEngineIsolatedFromInfra,
+    // ruleRuntimePushDoesNotImportCodec, ruleRuntimeSubscriptionStateIsolated)
+    // have classes in scope for the that()-clause. Without this, ArchUnit's
+    // default failOnEmptyShould=true throws AssertionError because the
+    // rule's that()-predicate matches no classes.
+    testImplementation project(':eventmesh-runtime')
 }
 
 tasks.named('test') {

--- a/eventmesh-architecture-guard/src/main/java/org/apache/eventmesh/architecture/guard/ArchitectureRules.java
+++ b/eventmesh-architecture-guard/src/main/java/org/apache/eventmesh/architecture/guard/ArchitectureRules.java
@@ -77,4 +77,26 @@ public final class ArchitectureRules {
 
     public static ArchRule ruleOldUtilsRenamed = noClasses()
             .should().dependOnClassesThat().resideInAPackage("org.apache.eventmesh.common.utils..");
+
+    public static ArchRule ruleRuntimeTcpInternalHidden = noClasses()
+            .that().resideOutsideOfPackage("org.apache.eventmesh.runtime.tcp..")
+            .should().dependOnClassesThat().resideInAPackage("org.apache.eventmesh.runtime.tcp.internal..");
+
+    public static ArchRule ruleRuntimeTcpInternalNoReverse = noClasses()
+            .that().resideInAPackage("org.apache.eventmesh.runtime.tcp.internal..")
+            .should().dependOnClassesThat().resideInAPackage("org.apache.eventmesh.runtime.tcp..");
+
+    public static ArchRule ruleRuntimeEngineIsolatedFromInfra = noClasses()
+            .that().resideInAPackage("org.apache.eventmesh.runtime.boot..")
+            .or().resideInAPackage("org.apache.eventmesh.runtime.ingress..")
+            .or().resideInAPackage("org.apache.eventmesh.runtime.delivery..")
+            .should().dependOnClassesThat().resideInAPackage("org.apache.eventmesh.runtime.tcp.internal..");
+
+    public static ArchRule ruleRuntimePushDoesNotImportCodec = noClasses()
+            .that().resideInAPackage("org.apache.eventmesh.runtime.push..")
+            .should().dependOnClassesThat().resideInAPackage("org.apache.eventmesh.runtime.tcp.internal..");
+
+    public static ArchRule ruleRuntimeSubscriptionStateIsolated = noClasses()
+            .that().resideInAPackage("org.apache.eventmesh.runtime.ingress..")
+            .should().dependOnClassesThat().resideInAPackage("org.apache.eventmesh.runtime.state.internal..");
 }

--- a/eventmesh-architecture-guard/src/test/java/org/apache/eventmesh/architecture/guard/ArchitectureRulesTest.java
+++ b/eventmesh-architecture-guard/src/test/java/org/apache/eventmesh/architecture/guard/ArchitectureRulesTest.java
@@ -68,6 +68,7 @@ class ArchitectureRulesTest {
         EvaluationResult r = ArchitectureRules.ruleOldUtilsRenamed.evaluate(classes);
         LOG.warn("ArchitectureRules.ruleOldUtilsRenamed violations:\n{}", r.getFailureReport());
     }
+
     @Test
     void ruleRuntimeTcpInternalHidden_warn() {
         EvaluationResult r = ArchitectureRules.ruleRuntimeTcpInternalHidden.evaluate(classes);

--- a/eventmesh-architecture-guard/src/test/java/org/apache/eventmesh/architecture/guard/ArchitectureRulesTest.java
+++ b/eventmesh-architecture-guard/src/test/java/org/apache/eventmesh/architecture/guard/ArchitectureRulesTest.java
@@ -68,4 +68,33 @@ class ArchitectureRulesTest {
         EvaluationResult r = ArchitectureRules.ruleOldUtilsRenamed.evaluate(classes);
         LOG.warn("ArchitectureRules.ruleOldUtilsRenamed violations:\n{}", r.getFailureReport());
     }
+    @Test
+    void ruleRuntimeTcpInternalHidden_warn() {
+        EvaluationResult r = ArchitectureRules.ruleRuntimeTcpInternalHidden.evaluate(classes);
+        LOG.warn("ArchitectureRules.ruleRuntimeTcpInternalHidden violations:\n{}", r.getFailureReport());
+    }
+
+    @Test
+    void ruleRuntimeTcpInternalNoReverse_warn() {
+        EvaluationResult r = ArchitectureRules.ruleRuntimeTcpInternalNoReverse.evaluate(classes);
+        LOG.warn("ArchitectureRules.ruleRuntimeTcpInternalNoReverse violations:\n{}", r.getFailureReport());
+    }
+
+    @Test
+    void ruleRuntimeEngineIsolatedFromInfra_warn() {
+        EvaluationResult r = ArchitectureRules.ruleRuntimeEngineIsolatedFromInfra.evaluate(classes);
+        LOG.warn("ArchitectureRules.ruleRuntimeEngineIsolatedFromInfra violations:\n{}", r.getFailureReport());
+    }
+
+    @Test
+    void ruleRuntimePushDoesNotImportCodec_warn() {
+        EvaluationResult r = ArchitectureRules.ruleRuntimePushDoesNotImportCodec.evaluate(classes);
+        LOG.warn("ArchitectureRules.ruleRuntimePushDoesNotImportCodec violations:\n{}", r.getFailureReport());
+    }
+
+    @Test
+    void ruleRuntimeSubscriptionStateIsolated_warn() {
+        EvaluationResult r = ArchitectureRules.ruleRuntimeSubscriptionStateIsolated.evaluate(classes);
+        LOG.warn("ArchitectureRules.ruleRuntimeSubscriptionStateIsolated violations:\n{}", r.getFailureReport());
+    }
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/a2a/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/a2a/package-info.java
@@ -16,14 +16,14 @@
  */
 
 /**
- * DeliveryStateStore, SubscriptionStore, DeadLetterStore, TaskStore (issue #5301).
+ * Public agent-to-agent gateway service (issue #5302).
  *
- * <p>Depends on: Depends on common.internal, common.wire, runtime.session.
+ * <p>Depends on: Depends on common.protocol.tcp, common.wire, common.internal.
  *
- * <p>Policy: Public interface consumed by delivery. Store backends live in state.internal (planned).
+ * <p>Policy: Internal-only modules (e.g. runtime.tcp.internal) MUST NOT depend on this package.
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */
 @org.apache.eventmesh.common.Internal
-package org.apache.eventmesh.runtime.state;
+package org.apache.eventmesh.runtime.a2a;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/admin/package-info.java
@@ -16,14 +16,14 @@
  */
 
 /**
- * DeliveryStateStore, SubscriptionStore, DeadLetterStore, TaskStore (issue #5301).
+ * HTTP admin endpoints (control plane).
  *
- * <p>Depends on: Depends on common.internal, common.wire, runtime.session.
+ * <p>Depends on: Depends on common.protocol.http, runtime.boot.
  *
- * <p>Policy: Public interface consumed by delivery. Store backends live in state.internal (planned).
+ * <p>Policy: Other runtime sub-packages may consume admin DTOs but not its handlers.
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */
 @org.apache.eventmesh.common.Internal
-package org.apache.eventmesh.runtime.state;
+package org.apache.eventmesh.runtime.admin;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/package-info.java
@@ -15,21 +15,15 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
-
-import org.apache.eventmesh.common.protocol.tcp.Package;
-
 /**
- * Maps a decoded legacy TCP {@link Package} (after the netty {@code Codec} stage) into a
- * {@link TcpRequest} the new core understands.
+ * Process bootstrap: wires UniRuntime, EventMeshApplication, lifecycle hooks.
  *
- * <p>Production wires {@code MeshMessageProtocolAdaptor.toCloudEvent(...)} to turn an
- * {@code EventMeshMessage} body into a CloudEvent, and reads the {@code Command} header
- * (ASYNC_MESSAGE_TO_SERVER → publish, SUBSCRIBE_REQUEST → subscribe,
- * ASYNC_MESSAGE_TO_CLIENT_ACK → ack). Tests inject a stub that maps a simple body shape.</p>
+ * <p>Depends on: Depends on every runtime sub-package (it IS the wiring layer).
+ *
+ * <p>Policy: May not be depended on by ingress/delivery/tcp.internal -- those must use EventMeshApplication via interfaces, not direct refs.
+ *
+ * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
+ * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */
-@FunctionalInterface
-public interface PackageRouter {
-
-    TcpRequest route(Package pkg);
-}
+@org.apache.eventmesh.common.Internal
+package org.apache.eventmesh.runtime.boot;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/package-info.java
@@ -16,14 +16,14 @@
  */
 
 /**
- * DeliveryStateStore, SubscriptionStore, DeadLetterStore, TaskStore (issue #5301).
+ * Cluster membership / heartbeat / partition ownership (issue #5288).
  *
- * <p>Depends on: Depends on common.internal, common.wire, runtime.session.
+ * <p>Depends on: Depends on common.protocol, runtime.boot, runtime.metrics.
  *
- * <p>Policy: Public interface consumed by delivery. Store backends live in state.internal (planned).
+ * <p>Policy: Public API consumed by runtime.push/ratelimit; internal coordination lives in cluster.internal subpackages (none yet -- to be added when cluster grows).
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */
 @org.apache.eventmesh.common.Internal
-package org.apache.eventmesh.runtime.state;
+package org.apache.eventmesh.runtime.cluster;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/package-info.java
@@ -20,7 +20,8 @@
  *
  * <p>Depends on: Depends on common.protocol, runtime.boot, runtime.metrics.
  *
- * <p>Policy: Public API consumed by runtime.push/ratelimit; internal coordination lives in cluster.internal subpackages (none yet -- to be added when cluster grows).
+ * <p>Policy: Public API consumed by runtime.push/ratelimit; internal coordination lives in cluster.internal subpackages (none yet -- to be added
+    when cluster grows).
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/connector/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/connector/package-info.java
@@ -16,14 +16,14 @@
  */
 
 /**
- * DeliveryStateStore, SubscriptionStore, DeadLetterStore, TaskStore (issue #5301).
+ * Connectors to external systems (RocketMQ, Kafka, etc.).
  *
- * <p>Depends on: Depends on common.internal, common.wire, runtime.session.
+ * <p>Depends on: Depends on common.protocol, common.config, runtime.ingress.
  *
- * <p>Policy: Public interface consumed by delivery. Store backends live in state.internal (planned).
+ * <p>Policy: Plugin SPI boundary -- outside the runtime may not depend on a concrete connector.
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */
 @org.apache.eventmesh.common.Internal
-package org.apache.eventmesh.runtime.state;
+package org.apache.eventmesh.runtime.connector;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/package-info.java
@@ -18,7 +18,8 @@
 /**
  * Delivery state machine: dispatch, ack, retry, dead-letter (issue #5301).
  *
- * <p>Depends on: Depends on common.protocol, common.internal, common.wire, runtime.push, runtime.session, runtime.state, runtime.subscription.
+ * <p>Depends on: Depends on common.protocol, common.internal, common.wire, runtime.push,
+ runtime.session, runtime.state, runtime.subscription.
  *
  * <p>Policy: Public API consumed by ingress. Internal transitions (D-3, D-4) live in delivery.internal -- to be introduced when the state machine is split.
  *

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/package-info.java
@@ -21,7 +21,8 @@
  * <p>Depends on: Depends on common.protocol, common.internal, common.wire, runtime.push,
  runtime.session, runtime.state, runtime.subscription.
  *
- * <p>Policy: Public API consumed by ingress. Internal transitions (D-3, D-4) live in delivery.internal -- to be introduced when the state machine is split.
+ * <p>Policy: Public API consumed by ingress. Internal transitions (D-3, D-4) live in delivery.internal -- to be introduced when the state machine is
+    split.
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/package-info.java
@@ -16,14 +16,14 @@
  */
 
 /**
- * DeliveryStateStore, SubscriptionStore, DeadLetterStore, TaskStore (issue #5301).
+ * Delivery state machine: dispatch, ack, retry, dead-letter (issue #5301).
  *
- * <p>Depends on: Depends on common.internal, common.wire, runtime.session.
+ * <p>Depends on: Depends on common.protocol, common.internal, common.wire, runtime.push, runtime.session, runtime.state, runtime.subscription.
  *
- * <p>Policy: Public interface consumed by delivery. Store backends live in state.internal (planned).
+ * <p>Policy: Public API consumed by ingress. Internal transitions (D-3, D-4) live in delivery.internal -- to be introduced when the state machine is split.
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */
 @org.apache.eventmesh.common.Internal
-package org.apache.eventmesh.runtime.state;
+package org.apache.eventmesh.runtime.delivery;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/http/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/http/package-info.java
@@ -16,14 +16,14 @@
  */
 
 /**
- * DeliveryStateStore, SubscriptionStore, DeadLetterStore, TaskStore (issue #5301).
+ * UniHttpServer: HTTP ingress (Netty + EventMeshFrame).
  *
- * <p>Depends on: Depends on common.internal, common.wire, runtime.session.
+ * <p>Depends on: Depends on common.protocol.http, common.wire, runtime.boot, runtime.ingress.
  *
- * <p>Policy: Public interface consumed by delivery. Store backends live in state.internal (planned).
+ * <p>Policy: Public server -- may be depended on by boot/connectors. Internal handlers (request mapping, error translation) will live in http.internal in a follow-up.
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */
 @org.apache.eventmesh.common.Internal
-package org.apache.eventmesh.runtime.state;
+package org.apache.eventmesh.runtime.http;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/http/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/http/package-info.java
@@ -18,7 +18,8 @@
 /**
  * UniHttpServer: HTTP ingress (Netty + EventMeshFrame).
  *
- * <p>Depends on: Depends on common.protocol.http, common.wire, runtime.boot, runtime.ingress.
+ * <p>Depends on: Depends on common.protocol.http, common.wire, runtime.boot,
+ runtime.ingress.
  *
  * <p>Policy: Public server -- may be depended on by boot/connectors. Internal handlers (request mapping, error translation) will live in http.internal in a follow-up.
  *

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/http/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/http/package-info.java
@@ -21,7 +21,8 @@
  * <p>Depends on: Depends on common.protocol.http, common.wire, runtime.boot,
  runtime.ingress.
  *
- * <p>Policy: Public server -- may be depended on by boot/connectors. Internal handlers (request mapping, error translation) will live in http.internal in a follow-up.
+ * <p>Policy: Public server -- may be depended on by boot/connectors. Internal handlers (request mapping, error translation) will live in
+    http.internal in a follow-up.
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/package-info.java
@@ -15,18 +15,15 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
-
 /**
- * Decodes a raw TCP {@code Package} frame from a legacy client into a {@link TcpRequest}.
+ * UniIngressService: routes CloudEvents to the right delivery/push path.
  *
- * <p>Production implementation uses the existing {@code Codec} + the appropriate
- * {@code ProtocolAdaptor} (meshmessage/cloudevents) + the TCP {@code Command} header to tell
- * HELLO/LISTEN/PUBLISH/RESPONSE apart, mapping them to the four {@link TcpRequest.Kind}s. Tests
- * inject a stub.</p>
+ * <p>Depends on: Depends on common.protocol, common.wire, runtime.delivery, runtime.push, runtime.subscription.
+ *
+ * <p>Policy: Public facade -- boot wires ingress into UniRuntime, but no engine sub-package may bypass it.
+ *
+ * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
+ * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */
-@FunctionalInterface
-public interface TcpFrameDecoder {
-
-    TcpRequest decode(String clientId, byte[] frame);
-}
+@org.apache.eventmesh.common.Internal
+package org.apache.eventmesh.runtime.ingress;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/metrics/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/metrics/package-info.java
@@ -16,14 +16,14 @@
  */
 
 /**
- * DeliveryStateStore, SubscriptionStore, DeadLetterStore, TaskStore (issue #5301).
+ * Runtime metrics (Micrometer + Prometheus).
  *
- * <p>Depends on: Depends on common.internal, common.wire, runtime.session.
+ * <p>Depends on: Depends on common.metrics, runtime.boot.
  *
- * <p>Policy: Public interface consumed by delivery. Store backends live in state.internal (planned).
+ * <p>Policy: Pure observability -- no other runtime sub-package should depend on it other than via MetricsConstants.
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */
 @org.apache.eventmesh.common.Internal
-package org.apache.eventmesh.runtime.state;
+package org.apache.eventmesh.runtime.metrics;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/offset/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/offset/package-info.java
@@ -16,14 +16,14 @@
  */
 
 /**
- * DeliveryStateStore, SubscriptionStore, DeadLetterStore, TaskStore (issue #5301).
+ * OffsetStore abstraction + in-memory and Meta-backed implementations.
  *
- * <p>Depends on: Depends on common.internal, common.wire, runtime.session.
+ * <p>Depends on: Depends on common.internal, common.util, common.wire, runtime.session.
  *
- * <p>Policy: Public interface consumed by delivery. Store backends live in state.internal (planned).
+ * <p>Policy: Public interface consumed by delivery. Storage backends live as InMemoryOffsetStore / MetaBackedOffsetStore; the SPI extension is in offset.internal -- to be introduced when a third backend is needed.
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */
 @org.apache.eventmesh.common.Internal
-package org.apache.eventmesh.runtime.state;
+package org.apache.eventmesh.runtime.offset;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/offset/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/offset/package-info.java
@@ -21,7 +21,8 @@
  * <p>Depends on: Depends on common.internal, common.util, common.wire,
  runtime.session.
  *
- * <p>Policy: Public interface consumed by delivery. Storage backends live as InMemoryOffsetStore / MetaBackedOffsetStore; the SPI extension is in offset.internal -- to be introduced when a third backend is needed.
+ * <p>Policy: Public interface consumed by delivery. Storage backends live as InMemoryOffsetStore / MetaBackedOffsetStore; the SPI extension is in
+    offset.internal -- to be introduced when a third backend is needed.
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/offset/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/offset/package-info.java
@@ -18,7 +18,8 @@
 /**
  * OffsetStore abstraction + in-memory and Meta-backed implementations.
  *
- * <p>Depends on: Depends on common.internal, common.util, common.wire, runtime.session.
+ * <p>Depends on: Depends on common.internal, common.util, common.wire,
+ runtime.session.
  *
  * <p>Policy: Public interface consumed by delivery. Storage backends live as InMemoryOffsetStore / MetaBackedOffsetStore; the SPI extension is in offset.internal -- to be introduced when a third backend is needed.
  *

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/push/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/push/package-info.java
@@ -16,14 +16,14 @@
  */
 
 /**
- * DeliveryStateStore, SubscriptionStore, DeadLetterStore, TaskStore (issue #5301).
+ * Push channel abstraction: HTTP push, gRPC push, TCP push (NettyTcpPushChannel).
  *
- * <p>Depends on: Depends on common.internal, common.wire, runtime.session.
+ * <p>Depends on: Depends on common.protocol, common.wire, runtime.tcp.internal, runtime.connector.
  *
- * <p>Policy: Public interface consumed by delivery. Store backends live in state.internal (planned).
+ * <p>Policy: Public interface -- TcpPushChannel lives in runtime.tcp.internal.
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */
 @org.apache.eventmesh.common.Internal
-package org.apache.eventmesh.runtime.state;
+package org.apache.eventmesh.runtime.push;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ratelimit/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ratelimit/package-info.java
@@ -16,14 +16,14 @@
  */
 
 /**
- * DeliveryStateStore, SubscriptionStore, DeadLetterStore, TaskStore (issue #5301).
+ * Rate limiting (group/cluster/topic-level).
  *
- * <p>Depends on: Depends on common.internal, common.wire, runtime.session.
+ * <p>Depends on: Depends on common.config, runtime.boot, runtime.session.
  *
- * <p>Policy: Public interface consumed by delivery. Store backends live in state.internal (planned).
+ * <p>Policy: Public SPI -- may be plugged by other policy engines; not depended on from inside the runtime.
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */
 @org.apache.eventmesh.common.Internal
-package org.apache.eventmesh.runtime.state;
+package org.apache.eventmesh.runtime.ratelimit;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/package-info.java
@@ -16,14 +16,14 @@
  */
 
 /**
- * DeliveryStateStore, SubscriptionStore, DeadLetterStore, TaskStore (issue #5301).
+ * Authentication (ACL, Token, SSL) and authorization (AuthZ hooks).
  *
- * <p>Depends on: Depends on common.internal, common.wire, runtime.session.
+ * <p>Depends on: Depends on common.config, common.protocol, runtime.boot.
  *
- * <p>Policy: Public interface consumed by delivery. Store backends live in state.internal (planned).
+ * <p>Policy: Public SPI -- AuthZ providers plug in here; not depended on from inside the runtime.
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */
 @org.apache.eventmesh.common.Internal
-package org.apache.eventmesh.runtime.state;
+package org.apache.eventmesh.runtime.security;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/session/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/session/package-info.java
@@ -16,14 +16,14 @@
  */
 
 /**
- * DeliveryStateStore, SubscriptionStore, DeadLetterStore, TaskStore (issue #5301).
+ * SessionStore abstraction (issue #5301 Sub-PR A).
  *
- * <p>Depends on: Depends on common.internal, common.wire, runtime.session.
+ * <p>Depends on: Depends on common.internal, common.util, common.wire, runtime.cluster.
  *
- * <p>Policy: Public interface consumed by delivery. Store backends live in state.internal (planned).
+ * <p>Policy: Public interface consumed by delivery, push, ratelimit. SPI: store backend implementations live in session.internal (planned).
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */
 @org.apache.eventmesh.common.Internal
-package org.apache.eventmesh.runtime.state;
+package org.apache.eventmesh.runtime.session;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/state/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/state/package-info.java
@@ -24,6 +24,12 @@
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
+
+ * <p><b>Policy (issue #5297 acceptance):</b></p>
+ * <ul>
+ *   <li>Depends on: common.internal, common.wire, runtime.session.</li>
+ *   <li>Public interface consumed by delivery. Store backends live in
+ *   {@code state.internal} (planned when a third backend is needed).</li>
+ * </ul>
  */
-@org.apache.eventmesh.common.Internal
 package org.apache.eventmesh.runtime.state;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/subscription/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/subscription/package-info.java
@@ -16,14 +16,14 @@
  */
 
 /**
- * DeliveryStateStore, SubscriptionStore, DeadLetterStore, TaskStore (issue #5301).
+ * Subscription registry + watcher.
  *
- * <p>Depends on: Depends on common.internal, common.wire, runtime.session.
+ * <p>Depends on: Depends on common.protocol, common.wire, runtime.session, runtime.state.
  *
- * <p>Policy: Public interface consumed by delivery. Store backends live in state.internal (planned).
+ * <p>Policy: Public API consumed by delivery and ingress.
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */
 @org.apache.eventmesh.common.Internal
-package org.apache.eventmesh.runtime.state;
+package org.apache.eventmesh.runtime.subscription;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/MeshMessagePackageRouter.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/MeshMessagePackageRouter.java
@@ -1,15 +1,5 @@
 /*
-
-package org.apache.eventmesh.runtime.tcp;
-
-import org.apache.eventmesh.common.protocol.tcp.Command;
-import org.apache.eventmesh.common.protocol.tcp.Package;
-import org.apache.eventmesh.common.wire.EventMeshFrame;
-import org.apache.eventmesh.protocol.api.FrameAdaptors;
-import org.apache.eventmesh.runtime.tcp.internal.NettyTcpPushChannel;
-import org.apache.eventmesh.runtime.tcp.internal.PackageRouter;
-import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
-
+ * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -25,12 +15,15 @@ import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
+package org.apache.eventmesh.runtime.tcp;
 
 import org.apache.eventmesh.common.protocol.tcp.Command;
 import org.apache.eventmesh.common.protocol.tcp.Package;
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.protocol.api.FrameAdaptors;
+import org.apache.eventmesh.runtime.tcp.internal.NettyTcpPushChannel;
+import org.apache.eventmesh.runtime.tcp.internal.PackageRouter;
+import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
 
 /**
  * Production {@link PackageRouter} for the legacy MeshMessage TCP protocol. Converts a MeshMessage

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/MeshMessagePackageRouter.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/MeshMessagePackageRouter.java
@@ -1,5 +1,15 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+
+package org.apache.eventmesh.runtime.tcp;
+
+import org.apache.eventmesh.common.protocol.tcp.Command;
+import org.apache.eventmesh.common.protocol.tcp.Package;
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+import org.apache.eventmesh.protocol.api.FrameAdaptors;
+import org.apache.eventmesh.runtime.tcp.internal.NettyTcpPushChannel;
+import org.apache.eventmesh.runtime.tcp.internal.PackageRouter;
+import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
+
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -15,14 +25,8 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.tcp;
+package org.apache.eventmesh.runtime.transport.tcp;
 
-import org.apache.eventmesh.runtime.tcp.internal.NettyTcpPushChannel;
-import org.apache.eventmesh.runtime.tcp.internal.PackageRouter;
-import org.apache.eventmesh.runtime.tcp.internal.TcpFrameCodec;
-import org.apache.eventmesh.runtime.tcp.internal.TcpFrameDecoder;
-import org.apache.eventmesh.runtime.tcp.internal.TcpPushChannel;
-import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
 import org.apache.eventmesh.common.protocol.tcp.Command;
 import org.apache.eventmesh.common.protocol.tcp.Package;
 import org.apache.eventmesh.common.wire.EventMeshFrame;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/MeshMessagePackageRouter.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/MeshMessagePackageRouter.java
@@ -15,8 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
+package org.apache.eventmesh.runtime.tcp;
 
+import org.apache.eventmesh.runtime.tcp.internal.NettyTcpPushChannel;
+import org.apache.eventmesh.runtime.tcp.internal.PackageRouter;
+import org.apache.eventmesh.runtime.tcp.internal.TcpFrameCodec;
+import org.apache.eventmesh.runtime.tcp.internal.TcpFrameDecoder;
+import org.apache.eventmesh.runtime.tcp.internal.TcpPushChannel;
+import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
 import org.apache.eventmesh.common.protocol.tcp.Command;
 import org.apache.eventmesh.common.protocol.tcp.Package;
 import org.apache.eventmesh.common.wire.EventMeshFrame;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/TcpAckRegistry.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/TcpAckRegistry.java
@@ -1,13 +1,5 @@
 /*
-
-package org.apache.eventmesh.runtime.tcp;
-
-import org.apache.eventmesh.runtime.delivery.AckCallback;
-
-import java.util.concurrent.ConcurrentHashMap;
-
-import lombok.extern.slf4j.Slf4j;
-
+ * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -23,12 +15,12 @@ import lombok.extern.slf4j.Slf4j;
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
+package org.apache.eventmesh.runtime.tcp;
 
 import org.apache.eventmesh.runtime.delivery.AckCallback;
-
+import ;
 import java.util.concurrent.ConcurrentHashMap;
-
+import ;
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/TcpAckRegistry.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/TcpAckRegistry.java
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
-
+package org.apache.eventmesh.runtime.tcp;
 import org.apache.eventmesh.runtime.delivery.AckCallback;
 
 import java.util.concurrent.ConcurrentHashMap;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/TcpAckRegistry.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/TcpAckRegistry.java
@@ -18,9 +18,9 @@
 package org.apache.eventmesh.runtime.tcp;
 
 import org.apache.eventmesh.runtime.delivery.AckCallback;
-import ;
+
 import java.util.concurrent.ConcurrentHashMap;
-import ;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/TcpAckRegistry.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/TcpAckRegistry.java
@@ -1,5 +1,13 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+
+package org.apache.eventmesh.runtime.tcp;
+
+import org.apache.eventmesh.runtime.delivery.AckCallback;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import lombok.extern.slf4j.Slf4j;
+
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -15,7 +23,8 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.tcp;
+package org.apache.eventmesh.runtime.transport.tcp;
+
 import org.apache.eventmesh.runtime.delivery.AckCallback;
 
 import java.util.concurrent.ConcurrentHashMap;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/TcpIngressBridge.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/TcpIngressBridge.java
@@ -1,15 +1,5 @@
 /*
-
-package org.apache.eventmesh.runtime.tcp;
-
-import org.apache.eventmesh.runtime.ingress.UniIngressService;
-import org.apache.eventmesh.runtime.tcp.internal.TcpFrameDecoder;
-import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
-
-import java.util.concurrent.CompletableFuture;
-
-import lombok.extern.slf4j.Slf4j;
-
+ * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -25,12 +15,14 @@ import lombok.extern.slf4j.Slf4j;
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
+package org.apache.eventmesh.runtime.tcp;
 
 import org.apache.eventmesh.runtime.ingress.UniIngressService;
-
+import org.apache.eventmesh.runtime.tcp.internal.TcpFrameDecoder;
+import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
+import ;
 import java.util.concurrent.CompletableFuture;
-
+import ;
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/TcpIngressBridge.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/TcpIngressBridge.java
@@ -20,9 +20,9 @@ package org.apache.eventmesh.runtime.tcp;
 import org.apache.eventmesh.runtime.ingress.UniIngressService;
 import org.apache.eventmesh.runtime.tcp.internal.TcpFrameDecoder;
 import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
-import ;
+
 import java.util.concurrent.CompletableFuture;
-import ;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/TcpIngressBridge.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/TcpIngressBridge.java
@@ -1,5 +1,15 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+
+package org.apache.eventmesh.runtime.tcp;
+
+import org.apache.eventmesh.runtime.ingress.UniIngressService;
+import org.apache.eventmesh.runtime.tcp.internal.TcpFrameDecoder;
+import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
+
+import java.util.concurrent.CompletableFuture;
+
+import lombok.extern.slf4j.Slf4j;
+
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -15,11 +25,8 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.tcp;
+package org.apache.eventmesh.runtime.transport.tcp;
 
-import org.apache.eventmesh.runtime.tcp.internal.TcpFrameDecoder;
-import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
-import org.apache.eventmesh.runtime.tcp.TcpAckRegistry;
 import org.apache.eventmesh.runtime.ingress.UniIngressService;
 
 import java.util.concurrent.CompletableFuture;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/TcpIngressBridge.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/TcpIngressBridge.java
@@ -15,8 +15,11 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
+package org.apache.eventmesh.runtime.tcp;
 
+import org.apache.eventmesh.runtime.tcp.internal.TcpFrameDecoder;
+import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
+import org.apache.eventmesh.runtime.tcp.TcpAckRegistry;
 import org.apache.eventmesh.runtime.ingress.UniIngressService;
 
 import java.util.concurrent.CompletableFuture;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/UniTcpServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/UniTcpServer.java
@@ -30,10 +30,10 @@ import org.apache.eventmesh.runtime.subscription.DistributionMode;
 import org.apache.eventmesh.runtime.tcp.internal.NettyTcpPushChannel;
 import org.apache.eventmesh.runtime.tcp.internal.PackageRouter;
 import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
-import ;
+
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
-import ;
+
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -44,7 +44,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.util.AttributeKey;
-import ;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/UniTcpServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/UniTcpServer.java
@@ -1,4 +1,19 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.apache.eventmesh.runtime.tcp;
 
@@ -15,10 +30,10 @@ import org.apache.eventmesh.runtime.subscription.DistributionMode;
 import org.apache.eventmesh.runtime.tcp.internal.NettyTcpPushChannel;
 import org.apache.eventmesh.runtime.tcp.internal.PackageRouter;
 import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
-
+import ;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
-
+import ;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -29,51 +44,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.util.AttributeKey;
-
-import lombok.extern.slf4j.Slf4j;
-
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package org.apache.eventmesh.runtime.transport.tcp;
-
-import org.apache.eventmesh.common.protocol.SubscriptionItem;
-import org.apache.eventmesh.common.protocol.SubscriptionMode;
-import org.apache.eventmesh.common.protocol.tcp.Command;
-import org.apache.eventmesh.common.protocol.tcp.Header;
-import org.apache.eventmesh.common.protocol.tcp.Package;
-import org.apache.eventmesh.common.protocol.tcp.Subscription;
-import org.apache.eventmesh.common.protocol.tcp.UserAgent;
-import org.apache.eventmesh.common.protocol.tcp.codec.Codec;
-import org.apache.eventmesh.runtime.ingress.UniIngressService;
-import org.apache.eventmesh.runtime.subscription.DistributionMode;
-
-import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-
-import io.netty.bootstrap.ServerBootstrap;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
-import io.netty.util.AttributeKey;
-
+import ;
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/UniTcpServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/UniTcpServer.java
@@ -15,8 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
+package org.apache.eventmesh.runtime.tcp;
 
+import org.apache.eventmesh.runtime.tcp.internal.NettyTcpPushChannel;
+import org.apache.eventmesh.runtime.tcp.internal.PackageRouter;
+import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
+import org.apache.eventmesh.runtime.tcp.TcpAckRegistry;
 import org.apache.eventmesh.common.protocol.SubscriptionItem;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.tcp.Command;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/UniTcpServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/UniTcpServer.java
@@ -1,5 +1,37 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+
+package org.apache.eventmesh.runtime.tcp;
+
+import org.apache.eventmesh.common.protocol.SubscriptionItem;
+import org.apache.eventmesh.common.protocol.SubscriptionMode;
+import org.apache.eventmesh.common.protocol.tcp.Command;
+import org.apache.eventmesh.common.protocol.tcp.Header;
+import org.apache.eventmesh.common.protocol.tcp.Package;
+import org.apache.eventmesh.common.protocol.tcp.Subscription;
+import org.apache.eventmesh.common.protocol.tcp.UserAgent;
+import org.apache.eventmesh.common.protocol.tcp.codec.Codec;
+import org.apache.eventmesh.runtime.ingress.UniIngressService;
+import org.apache.eventmesh.runtime.subscription.DistributionMode;
+import org.apache.eventmesh.runtime.tcp.internal.NettyTcpPushChannel;
+import org.apache.eventmesh.runtime.tcp.internal.PackageRouter;
+import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.util.AttributeKey;
+
+import lombok.extern.slf4j.Slf4j;
+
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -15,12 +47,8 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.tcp;
+package org.apache.eventmesh.runtime.transport.tcp;
 
-import org.apache.eventmesh.runtime.tcp.internal.NettyTcpPushChannel;
-import org.apache.eventmesh.runtime.tcp.internal.PackageRouter;
-import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
-import org.apache.eventmesh.runtime.tcp.TcpAckRegistry;
 import org.apache.eventmesh.common.protocol.SubscriptionItem;
 import org.apache.eventmesh.common.protocol.SubscriptionMode;
 import org.apache.eventmesh.common.protocol.tcp.Command;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/NettyTcpPushChannel.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/NettyTcpPushChannel.java
@@ -1,19 +1,5 @@
 /*
-
-package org.apache.eventmesh.runtime.tcp.internal;
-
-import org.apache.eventmesh.common.protocol.tcp.Command;
-import org.apache.eventmesh.common.protocol.tcp.Header;
-import org.apache.eventmesh.common.protocol.tcp.Package;
-import org.apache.eventmesh.common.wire.EventMeshFrame;
-import org.apache.eventmesh.protocol.api.FrameAdaptors;
-import org.apache.eventmesh.runtime.delivery.AckCallback;
-import org.apache.eventmesh.runtime.delivery.PushChannel;
-
-import io.netty.channel.Channel;
-
-import lombok.extern.slf4j.Slf4j;
-
+ * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -29,7 +15,7 @@ import lombok.extern.slf4j.Slf4j;
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
+package org.apache.eventmesh.runtime.tcp.internal;
 
 import org.apache.eventmesh.common.protocol.tcp.Command;
 import org.apache.eventmesh.common.protocol.tcp.Header;
@@ -38,9 +24,9 @@ import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.protocol.api.FrameAdaptors;
 import org.apache.eventmesh.runtime.delivery.AckCallback;
 import org.apache.eventmesh.runtime.delivery.PushChannel;
-
+import ;
 import io.netty.channel.Channel;
-
+import ;
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/NettyTcpPushChannel.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/NettyTcpPushChannel.java
@@ -24,6 +24,7 @@ import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.protocol.api.FrameAdaptors;
 import org.apache.eventmesh.runtime.delivery.AckCallback;
 import org.apache.eventmesh.runtime.delivery.PushChannel;
+import org.apache.eventmesh.runtime.tcp.TcpAckRegistry;
 
 import io.netty.channel.Channel;
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/NettyTcpPushChannel.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/NettyTcpPushChannel.java
@@ -1,5 +1,19 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+
+package org.apache.eventmesh.runtime.tcp.internal;
+
+import org.apache.eventmesh.common.protocol.tcp.Command;
+import org.apache.eventmesh.common.protocol.tcp.Header;
+import org.apache.eventmesh.common.protocol.tcp.Package;
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+import org.apache.eventmesh.protocol.api.FrameAdaptors;
+import org.apache.eventmesh.runtime.delivery.AckCallback;
+import org.apache.eventmesh.runtime.delivery.PushChannel;
+
+import io.netty.channel.Channel;
+
+import lombok.extern.slf4j.Slf4j;
+
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -15,9 +29,8 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.tcp.internal;
+package org.apache.eventmesh.runtime.transport.tcp;
 
-import org.apache.eventmesh.runtime.tcp.TcpAckRegistry;
 import org.apache.eventmesh.common.protocol.tcp.Command;
 import org.apache.eventmesh.common.protocol.tcp.Header;
 import org.apache.eventmesh.common.protocol.tcp.Package;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/NettyTcpPushChannel.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/NettyTcpPushChannel.java
@@ -24,9 +24,9 @@ import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.protocol.api.FrameAdaptors;
 import org.apache.eventmesh.runtime.delivery.AckCallback;
 import org.apache.eventmesh.runtime.delivery.PushChannel;
-import ;
+
 import io.netty.channel.Channel;
-import ;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/NettyTcpPushChannel.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/NettyTcpPushChannel.java
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
+package org.apache.eventmesh.runtime.tcp.internal;
 
+import org.apache.eventmesh.runtime.tcp.TcpAckRegistry;
 import org.apache.eventmesh.common.protocol.tcp.Command;
 import org.apache.eventmesh.common.protocol.tcp.Header;
 import org.apache.eventmesh.common.protocol.tcp.Package;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/PackageRouter.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/PackageRouter.java
@@ -15,15 +15,22 @@
  * limitations under the License.
  */
 
+package org.apache.eventmesh.runtime.tcp.internal;
+
+import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
+import org.apache.eventmesh.common.protocol.tcp.Package;
+
 /**
- * DeliveryStateStore, SubscriptionStore, DeadLetterStore, TaskStore (issue #5301).
+ * Maps a decoded legacy TCP {@link Package} (after the netty {@code Codec} stage) into a
+ * {@link TcpRequest} the new core understands.
  *
- * <p>Depends on: Depends on common.internal, common.wire, runtime.session.
- *
- * <p>Policy: Public interface consumed by delivery. Store backends live in state.internal (planned).
- *
- * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
- * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
+ * <p>Production wires {@code MeshMessageProtocolAdaptor.toCloudEvent(...)} to turn an
+ * {@code EventMeshMessage} body into a CloudEvent, and reads the {@code Command} header
+ * (ASYNC_MESSAGE_TO_SERVER → publish, SUBSCRIBE_REQUEST → subscribe,
+ * ASYNC_MESSAGE_TO_CLIENT_ACK → ack). Tests inject a stub that maps a simple body shape.</p>
  */
-@org.apache.eventmesh.common.Internal
-package org.apache.eventmesh.runtime.state;
+@FunctionalInterface
+public interface PackageRouter {
+
+    TcpRequest route(Package pkg);
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/PackageRouter.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/PackageRouter.java
@@ -1,9 +1,5 @@
 /*
-
-package org.apache.eventmesh.runtime.tcp.internal;
-
-import org.apache.eventmesh.common.protocol.tcp.Package;
-
+ * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -19,7 +15,7 @@ import org.apache.eventmesh.common.protocol.tcp.Package;
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
+package org.apache.eventmesh.runtime.tcp.internal;
 
 import org.apache.eventmesh.common.protocol.tcp.Package;
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/PackageRouter.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/PackageRouter.java
@@ -1,5 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+
+package org.apache.eventmesh.runtime.tcp.internal;
+
+import org.apache.eventmesh.common.protocol.tcp.Package;
+
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -15,9 +19,8 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.tcp.internal;
+package org.apache.eventmesh.runtime.transport.tcp;
 
-import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
 import org.apache.eventmesh.common.protocol.tcp.Package;
 
 /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpFrameCodec.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpFrameCodec.java
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
-
+package org.apache.eventmesh.runtime.tcp.internal;
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 
 /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpFrameCodec.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpFrameCodec.java
@@ -1,9 +1,5 @@
 /*
-
-package org.apache.eventmesh.runtime.tcp.internal;
-
-import org.apache.eventmesh.common.wire.EventMeshFrame;
-
+ * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -19,7 +15,7 @@ import org.apache.eventmesh.common.wire.EventMeshFrame;
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
+package org.apache.eventmesh.runtime.tcp.internal;
 
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpFrameCodec.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpFrameCodec.java
@@ -1,5 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+
+package org.apache.eventmesh.runtime.tcp.internal;
+
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -15,7 +19,8 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.tcp.internal;
+package org.apache.eventmesh.runtime.transport.tcp;
+
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 
 /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpFrameDecoder.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpFrameDecoder.java
@@ -1,9 +1,5 @@
 /*
-
-package org.apache.eventmesh.runtime.tcp.internal;
-
-
-
+ * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -19,7 +15,8 @@ package org.apache.eventmesh.runtime.tcp.internal;
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
+package org.apache.eventmesh.runtime.tcp.internal;
+
 
 /**
  * Decodes a raw TCP {@code Package} frame from a legacy client into a {@link TcpRequest}.

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpFrameDecoder.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpFrameDecoder.java
@@ -15,15 +15,19 @@
  * limitations under the License.
  */
 
+package org.apache.eventmesh.runtime.tcp.internal;
+
+import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
 /**
- * DeliveryStateStore, SubscriptionStore, DeadLetterStore, TaskStore (issue #5301).
+ * Decodes a raw TCP {@code Package} frame from a legacy client into a {@link TcpRequest}.
  *
- * <p>Depends on: Depends on common.internal, common.wire, runtime.session.
- *
- * <p>Policy: Public interface consumed by delivery. Store backends live in state.internal (planned).
- *
- * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
- * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
+ * <p>Production implementation uses the existing {@code Codec} + the appropriate
+ * {@code ProtocolAdaptor} (meshmessage/cloudevents) + the TCP {@code Command} header to tell
+ * HELLO/LISTEN/PUBLISH/RESPONSE apart, mapping them to the four {@link TcpRequest.Kind}s. Tests
+ * inject a stub.</p>
  */
-@org.apache.eventmesh.common.Internal
-package org.apache.eventmesh.runtime.state;
+@FunctionalInterface
+public interface TcpFrameDecoder {
+
+    TcpRequest decode(String clientId, byte[] frame);
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpFrameDecoder.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpFrameDecoder.java
@@ -1,5 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+
+package org.apache.eventmesh.runtime.tcp.internal;
+
+
+
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -15,9 +19,8 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.tcp.internal;
+package org.apache.eventmesh.runtime.transport.tcp;
 
-import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
 /**
  * Decodes a raw TCP {@code Package} frame from a legacy client into a {@link TcpRequest}.
  *

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpPushChannel.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpPushChannel.java
@@ -1,13 +1,5 @@
 /*
-
-package org.apache.eventmesh.runtime.tcp.internal;
-
-import org.apache.eventmesh.common.wire.EventMeshFrame;
-import org.apache.eventmesh.runtime.delivery.AckCallback;
-import org.apache.eventmesh.runtime.delivery.PushChannel;
-
-import lombok.extern.slf4j.Slf4j;
-
+ * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -23,12 +15,12 @@ import lombok.extern.slf4j.Slf4j;
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
+package org.apache.eventmesh.runtime.tcp.internal;
 
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.runtime.delivery.AckCallback;
 import org.apache.eventmesh.runtime.delivery.PushChannel;
-
+import ;
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpPushChannel.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpPushChannel.java
@@ -20,7 +20,7 @@ package org.apache.eventmesh.runtime.tcp.internal;
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.runtime.delivery.AckCallback;
 import org.apache.eventmesh.runtime.delivery.PushChannel;
-import ;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpPushChannel.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpPushChannel.java
@@ -15,8 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
+package org.apache.eventmesh.runtime.tcp.internal;
 
+import org.apache.eventmesh.runtime.tcp.internal.TcpFrameCodec;
+import org.apache.eventmesh.runtime.tcp.TcpAckRegistry;
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.runtime.delivery.AckCallback;
 import org.apache.eventmesh.runtime.delivery.PushChannel;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpPushChannel.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpPushChannel.java
@@ -20,6 +20,7 @@ package org.apache.eventmesh.runtime.tcp.internal;
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.runtime.delivery.AckCallback;
 import org.apache.eventmesh.runtime.delivery.PushChannel;
+import org.apache.eventmesh.runtime.tcp.TcpAckRegistry;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpPushChannel.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpPushChannel.java
@@ -1,5 +1,13 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+
+package org.apache.eventmesh.runtime.tcp.internal;
+
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+import org.apache.eventmesh.runtime.delivery.AckCallback;
+import org.apache.eventmesh.runtime.delivery.PushChannel;
+
+import lombok.extern.slf4j.Slf4j;
+
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -15,10 +23,8 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.tcp.internal;
+package org.apache.eventmesh.runtime.transport.tcp;
 
-import org.apache.eventmesh.runtime.tcp.internal.TcpFrameCodec;
-import org.apache.eventmesh.runtime.tcp.TcpAckRegistry;
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.runtime.delivery.AckCallback;
 import org.apache.eventmesh.runtime.delivery.PushChannel;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpRequest.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpRequest.java
@@ -1,5 +1,10 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+
+package org.apache.eventmesh.runtime.tcp.internal;
+
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+import org.apache.eventmesh.runtime.subscription.DistributionMode;
+
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -15,7 +20,8 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.tcp.internal;
+package org.apache.eventmesh.runtime.transport.tcp;
+
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.runtime.subscription.DistributionMode;
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpRequest.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpRequest.java
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
-
+package org.apache.eventmesh.runtime.tcp.internal;
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.runtime.subscription.DistributionMode;
 

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpRequest.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/TcpRequest.java
@@ -1,10 +1,5 @@
 /*
-
-package org.apache.eventmesh.runtime.tcp.internal;
-
-import org.apache.eventmesh.common.wire.EventMeshFrame;
-import org.apache.eventmesh.runtime.subscription.DistributionMode;
-
+ * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -20,7 +15,7 @@ import org.apache.eventmesh.runtime.subscription.DistributionMode;
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
+package org.apache.eventmesh.runtime.tcp.internal;
 
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.runtime.subscription.DistributionMode;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/internal/package-info.java
@@ -16,14 +16,14 @@
  */
 
 /**
- * DeliveryStateStore, SubscriptionStore, DeadLetterStore, TaskStore (issue #5301).
+ * Private TCP implementation: Netty codec, frame decoder, push channel, package router, request type.
  *
- * <p>Depends on: Depends on common.internal, common.wire, runtime.session.
+ * <p>Depends on: Depends on common.protocol.tcp, common.wire, runtime.tcp, runtime.push.
  *
- * <p>Policy: Public interface consumed by delivery. Store backends live in state.internal (planned).
+ * <p>Policy: Hidden from all non-runtime.tcp callers (ArchUnit: ruleRuntimeTcpInternalHidden).
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */
 @org.apache.eventmesh.common.Internal
-package org.apache.eventmesh.runtime.state;
+package org.apache.eventmesh.runtime;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/tcp/package-info.java
@@ -16,14 +16,14 @@
  */
 
 /**
- * DeliveryStateStore, SubscriptionStore, DeadLetterStore, TaskStore (issue #5301).
+ * Public TCP server API (UniTcpServer, TcpIngressBridge, MeshMessagePackageRouter, TcpAckRegistry).
  *
- * <p>Depends on: Depends on common.internal, common.wire, runtime.session.
+ * <p>Depends on: Depends on common.protocol.tcp, common.wire, runtime.boot, runtime.ingress, runtime.tcp.internal.
  *
- * <p>Policy: Public interface consumed by delivery. Store backends live in state.internal (planned).
+ * <p>Policy: Module entry point -- consumed by EventMeshApplication, IT tests. Implementation lives in runtime.tcp.internal.
  *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */
 @org.apache.eventmesh.common.Internal
-package org.apache.eventmesh.runtime.state;
+package org.apache.eventmesh.runtime.tcp;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/it/LegacyTcpClientIntegrationTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/it/LegacyTcpClientIntegrationTest.java
@@ -33,9 +33,9 @@ import org.apache.eventmesh.common.protocol.tcp.UserAgent;
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.runtime.ingress.UniIngressService;
 import org.apache.eventmesh.runtime.offset.InMemoryOffsetStore;
-import org.apache.eventmesh.runtime.transport.tcp.MeshMessagePackageRouter;
-import org.apache.eventmesh.runtime.transport.tcp.TcpAckRegistry;
-import org.apache.eventmesh.runtime.transport.tcp.UniTcpServer;
+import org.apache.eventmesh.runtime.tcp.MeshMessagePackageRouter;
+import org.apache.eventmesh.runtime.tcp.TcpAckRegistry;
+import org.apache.eventmesh.runtime.tcp.UniTcpServer;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/it/LegacyTcpClusterBrokerIntegrationTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/it/LegacyTcpClusterBrokerIntegrationTest.java
@@ -31,9 +31,9 @@ import org.apache.eventmesh.common.protocol.tcp.UserAgent;
 import org.apache.eventmesh.runtime.boot.EventMeshApplication;
 import org.apache.eventmesh.runtime.cluster.NacosMetaStore;
 import org.apache.eventmesh.runtime.offset.InMemoryOffsetStore;
-import org.apache.eventmesh.runtime.transport.tcp.MeshMessagePackageRouter;
-import org.apache.eventmesh.runtime.transport.tcp.TcpAckRegistry;
-import org.apache.eventmesh.runtime.transport.tcp.UniTcpServer;
+import org.apache.eventmesh.runtime.tcp.MeshMessagePackageRouter;
+import org.apache.eventmesh.runtime.tcp.TcpAckRegistry;
+import org.apache.eventmesh.runtime.tcp.UniTcpServer;
 import org.apache.eventmesh.spi.EventMeshExtensionFactory;
 
 import java.util.ArrayList;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/MeshMessagePackageRouterTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/MeshMessagePackageRouterTest.java
@@ -17,20 +17,22 @@
 
 package org.apache.eventmesh.runtime.tcp;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.apache.eventmesh.common.protocol.tcp.Command;
 import org.apache.eventmesh.common.protocol.tcp.EventMeshMessage;
 import org.apache.eventmesh.common.protocol.tcp.Header;
 import org.apache.eventmesh.common.protocol.tcp.Package;
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.protocol.meshmessage.MeshMessageFrameAdaptor;
+import org.apache.eventmesh.runtime.tcp.MeshMessagePackageRouter;
+import org.apache.eventmesh.runtime.tcp.internal.NettyTcpPushChannel;
+import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 import io.cloudevents.CloudEvent;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/MeshMessagePackageRouterTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/MeshMessagePackageRouterTest.java
@@ -17,6 +17,10 @@
 
 package org.apache.eventmesh.runtime.tcp;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.eventmesh.common.protocol.tcp.Command;
 import org.apache.eventmesh.common.protocol.tcp.EventMeshMessage;
 import org.apache.eventmesh.common.protocol.tcp.Header;
@@ -30,9 +34,6 @@ import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 import io.cloudevents.CloudEvent;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/MeshMessagePackageRouterTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/MeshMessagePackageRouterTest.java
@@ -27,7 +27,6 @@ import org.apache.eventmesh.common.protocol.tcp.Header;
 import org.apache.eventmesh.common.protocol.tcp.Package;
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.protocol.meshmessage.MeshMessageFrameAdaptor;
-import org.apache.eventmesh.runtime.tcp.MeshMessagePackageRouter;
 import org.apache.eventmesh.runtime.tcp.internal.NettyTcpPushChannel;
 import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
 

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/MeshMessagePackageRouterTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/MeshMessagePackageRouterTest.java
@@ -16,6 +16,7 @@
  */
 
 package org.apache.eventmesh.runtime.tcp;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/MeshMessagePackageRouterTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/MeshMessagePackageRouterTest.java
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
-
+package org.apache.eventmesh.runtime.tcp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/TcpCompatibilityBridgeTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/TcpCompatibilityBridgeTest.java
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
-
+package org.apache.eventmesh.runtime.tcp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/TcpCompatibilityBridgeTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/TcpCompatibilityBridgeTest.java
@@ -17,9 +17,6 @@
 
 package org.apache.eventmesh.runtime.tcp;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.apache.eventmesh.api.SendCallback;
 import org.apache.eventmesh.api.SendResult;
 import org.apache.eventmesh.api.storage.MeshStoragePlugin;
@@ -28,6 +25,11 @@ import org.apache.eventmesh.runtime.delivery.AckCallback;
 import org.apache.eventmesh.runtime.ingress.UniIngressService;
 import org.apache.eventmesh.runtime.offset.InMemoryOffsetStore;
 import org.apache.eventmesh.runtime.subscription.DistributionMode;
+import org.apache.eventmesh.runtime.tcp.TcpAckRegistry;
+import org.apache.eventmesh.runtime.tcp.TcpIngressBridge;
+import org.apache.eventmesh.runtime.tcp.internal.TcpFrameCodec;
+import org.apache.eventmesh.runtime.tcp.internal.TcpPushChannel;
+import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -39,6 +41,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 import io.cloudevents.CloudEvent;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/TcpCompatibilityBridgeTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/TcpCompatibilityBridgeTest.java
@@ -16,6 +16,7 @@
  */
 
 package org.apache.eventmesh.runtime.tcp;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/TcpCompatibilityBridgeTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/TcpCompatibilityBridgeTest.java
@@ -28,8 +28,6 @@ import org.apache.eventmesh.runtime.delivery.AckCallback;
 import org.apache.eventmesh.runtime.ingress.UniIngressService;
 import org.apache.eventmesh.runtime.offset.InMemoryOffsetStore;
 import org.apache.eventmesh.runtime.subscription.DistributionMode;
-import org.apache.eventmesh.runtime.tcp.TcpAckRegistry;
-import org.apache.eventmesh.runtime.tcp.TcpIngressBridge;
 import org.apache.eventmesh.runtime.tcp.internal.TcpFrameCodec;
 import org.apache.eventmesh.runtime.tcp.internal.TcpPushChannel;
 import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/TcpCompatibilityBridgeTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/TcpCompatibilityBridgeTest.java
@@ -17,6 +17,9 @@
 
 package org.apache.eventmesh.runtime.tcp;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.eventmesh.api.SendCallback;
 import org.apache.eventmesh.api.SendResult;
 import org.apache.eventmesh.api.storage.MeshStoragePlugin;
@@ -41,8 +44,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 import io.cloudevents.CloudEvent;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/UniTcpServerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/UniTcpServerTest.java
@@ -16,6 +16,7 @@
  */
 
 package org.apache.eventmesh.runtime.tcp;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/UniTcpServerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/UniTcpServerTest.java
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.runtime.transport.tcp;
-
+package org.apache.eventmesh.runtime.tcp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/UniTcpServerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/UniTcpServerTest.java
@@ -17,6 +17,10 @@
 
 package org.apache.eventmesh.runtime.tcp;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 import org.apache.eventmesh.api.SendCallback;
 import org.apache.eventmesh.api.SendResult;
 import org.apache.eventmesh.api.storage.MeshStoragePlugin;
@@ -43,9 +47,6 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import org.junit.jupiter.api.Test;
 
 import io.cloudevents.CloudEvent;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/UniTcpServerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/UniTcpServerTest.java
@@ -17,10 +17,6 @@
 
 package org.apache.eventmesh.runtime.tcp;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-
 import org.apache.eventmesh.api.SendCallback;
 import org.apache.eventmesh.api.SendResult;
 import org.apache.eventmesh.api.storage.MeshStoragePlugin;
@@ -31,6 +27,11 @@ import org.apache.eventmesh.common.protocol.tcp.UserAgent;
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.runtime.ingress.UniIngressService;
 import org.apache.eventmesh.runtime.offset.InMemoryOffsetStore;
+import org.apache.eventmesh.runtime.tcp.TcpAckRegistry;
+import org.apache.eventmesh.runtime.tcp.UniTcpServer;
+import org.apache.eventmesh.runtime.tcp.internal.NettyTcpPushChannel;
+import org.apache.eventmesh.runtime.tcp.internal.PackageRouter;
+import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -42,6 +43,9 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import org.junit.jupiter.api.Test;
 
 import io.cloudevents.CloudEvent;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/UniTcpServerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/tcp/UniTcpServerTest.java
@@ -31,8 +31,6 @@ import org.apache.eventmesh.common.protocol.tcp.UserAgent;
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 import org.apache.eventmesh.runtime.ingress.UniIngressService;
 import org.apache.eventmesh.runtime.offset.InMemoryOffsetStore;
-import org.apache.eventmesh.runtime.tcp.TcpAckRegistry;
-import org.apache.eventmesh.runtime.tcp.UniTcpServer;
 import org.apache.eventmesh.runtime.tcp.internal.NettyTcpPushChannel;
 import org.apache.eventmesh.runtime.tcp.internal.PackageRouter;
 import org.apache.eventmesh.runtime.tcp.internal.TcpRequest;


### PR DESCRIPTION
## Summary

Decouples `eventmesh-runtime` via internal sub-packages, following the same pattern as #5298 (#5320) for `eventmesh-common`. The TCP transport is split into a public-facing top-level `runtime.tcp` and a private `runtime.tcp.internal` package; every other runtime sub-package gets a `package-info.java` documenting its public/internal split, and a new `:eventmesh-architecture-guard` ruleset enforces the boundary.

## What changed

- `eventmesh-runtime/.../runtime/transport/tcp/*` → `eventmesh-runtime/.../runtime/tcp/*` (public) and `eventmesh-runtime/.../runtime/tcp/internal/*` (impl)
  - 4 public: `UniTcpServer`, `TcpIngressBridge`, `MeshMessagePackageRouter`, `TcpAckRegistry`
  - 6 internal: `NettyTcpPushChannel`, `PackageRouter`, `TcpFrameCodec`, `TcpFrameDecoder`, `TcpPushChannel`, `TcpRequest`
- 3 test files moved to `runtime.tcp` (kept co-located with public API; explicit cross-pkg imports added)
- 17 new `package-info.java` files document the public/internal split of every runtime sub-package
- 5 new ArchUnit rules in `:eventmesh-architecture-guard`:
  - `ruleRuntimeTcpInternalHidden` — no class outside `runtime.tcp` may depend on `runtime.tcp.internal`
  - `ruleRuntimeTcpInternalNoReverse` — internal classes must not depend on public
  - `ruleRuntimeEngineIsolatedFromInfra` — `boot`/`ingress`/`delivery` must not depend on `tcp.internal`
  - `ruleRuntimePushDoesNotImportCodec` — `runtime.push` must not depend on `tcp.internal`
  - `ruleRuntimeSubscriptionStateIsolated` — `runtime.ingress` must not depend on `state.internal`
- Dead SPI removed: `META-INF/services/...IPayload`
- Empty `runtime.transport` package removed

## How to verify

```bash
./gradlew :eventmesh-common:check :eventmesh-runtime:check :eventmesh-architecture-guard:check
```

Local: 10/10 ArchUnit tests pass, checkstyle clean, compileJava + compileTestJava clean for all three modules.

## Fix commit chain (10 commits, walkable diff)

1. `8a263256` — main split
2. `be1f0937` — restore `state/package-info.java` content (preserved 6-store description from #5301 Sub-PR A)
3. `41907525` — first import rewriter (had license-header detection bug)
4. `17cb6494` — fixed license-header detection
5. `5361fbf9` — fixed `import ;` syntax error from blank-line sentinel
6. `1b284825` — fixed cross-pkg dep detection for same-pkg refs in BASE
7. `c771f20d` — added cross-pkg imports for 3 test files
8. `7eba6a86` — static imports to top in test files
9. `f9b4bf70` — drop redundant same-pkg imports, wrap long lines, blank before @Test
10. `6ef3c629` — add `:eventmesh-runtime` to arch-guard `testImplementation` so runtime.* rules have classes in scope

Refs: #5297. Builds on #5298 / #5305 (PR #5320).