### PR TITLE
feat(arch-guard): enforce architecture rules in FAIL mode + dedicated CI workflow (#5305)

### DIFF
--- a/.github/workflows/architecture-guard.yml
+++ b/.github/workflows/architecture-guard.yml
@@ -1,0 +1,70 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: 'Architecture Guard'
+
+# Runs the ArchUnit rules as their own check so a violation shows up as
+# "Architecture Guard" on the PR instead of hiding inside the 30-minute
+# Build job. Only the modules that feed the analysis trigger it.
+on:
+  push:
+    branches: [ '**' ]
+    paths:
+      - 'eventmesh-architecture-guard/**'
+      - 'eventmesh-common/**'
+      - 'eventmesh-runtime/**'
+      - 'eventmesh-spi/**'
+      - 'eventmesh-protocol-plugin/**'
+      - 'eventmesh-storage-plugin/**'
+      - '.github/workflows/architecture-guard.yml'
+  pull_request:
+    branches: [ '**' ]
+    paths:
+      - 'eventmesh-architecture-guard/**'
+      - 'eventmesh-common/**'
+      - 'eventmesh-runtime/**'
+      - 'eventmesh-spi/**'
+      - 'eventmesh-protocol-plugin/**'
+      - 'eventmesh-storage-plugin/**'
+      - '.github/workflows/architecture-guard.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  arch-guard:
+    name: Architecture Guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e #v6.1.0
+
+      - name: Run architecture rules
+        run: ./gradlew :eventmesh-architecture-guard:architectureCheck --no-daemon
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,15 @@ jobs:
           java-version: ${{ matrix.java }}
 
       # https://docs.gradle.org/current/userguide/performance.html
+      # :eventmesh-architecture-guard:test is excluded here because the
+      # dedicated Architecture Guard workflow already runs those rules
+      # (via architectureCheck) on every relevant change; running them
+      # twice just lengthens the matrix build.
       - name: Build
         run: >
           ./gradlew clean build dist jacocoTestReport --parallel --daemon --scan
           -x spotlessJava -x generateGrammarSource -x generateDistLicense -x checkDeniedLicense
+          -x :eventmesh-architecture-guard:test
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 

--- a/eventmesh-architecture-guard/README.md
+++ b/eventmesh-architecture-guard/README.md
@@ -1,31 +1,54 @@
 # :eventmesh-architecture-guard
 
-Minimum-viable architecture guard for issue #5305. Ships with the #5298
-PR (sub-package split of eventmesh-common).
+Architecture guard for issue #5305. Enforces the package boundaries
+introduced by #5298 (`eventmesh-common` sub-packages) and #5297
+(`eventmesh-runtime` sub-packages).
 
 ## What it does
 
-Five ArchUnit rules that enforce the new org.apache.eventmesh.common
-sub-package boundaries declared in #5298:
+Nine ArchUnit rules, asserted in FAIL mode: any violation breaks the
+build.
 
-| Rule                       | Forbids                                                                                  |
-|----------------------------|------------------------------------------------------------------------------------------|
-| ruleInternalHidden         | org.apache.eventmesh.common.internal.. reached from outside org.apache.eventmesh.common.. |
-| ruleHttpProtocolHidden     | org.apache.eventmesh.common.protocol.http.. from modules other than meshmessage / sdks    |
-| ruleGrpcProtocolHidden     | org.apache.eventmesh.common.protocol.grpc.. from modules other than meshmessage / sdks    |
-| ruleTcpProtocolHidden      | org.apache.eventmesh.common.protocol.tcp.. from modules other than meshmessage / sdks / runtime |
-| ruleOldUtilsRenamed        | org.apache.eventmesh.common.utils.. (renamed to .util.. in #5298)                         |
+`eventmesh-common` boundaries (from #5298):
 
-## Severity: WARN in 1.13.0, FAIL in 1.14.0
+| Rule                   | Forbids                                                                                   |
+|------------------------|-------------------------------------------------------------------------------------------|
+| ruleInternalHidden     | org.apache.eventmesh.common.internal.. reached from outside org.apache.eventmesh.common..  |
+| ruleHttpProtocolHidden | org.apache.eventmesh.common.protocol.http.. from modules other than meshmessage / sdks      |
+| ruleGrpcProtocolHidden | org.apache.eventmesh.common.protocol.grpc.. from modules other than meshmessage / sdks      |
+| ruleTcpProtocolHidden  | org.apache.eventmesh.common.protocol.tcp.. from modules other than meshmessage / sdks / runtime |
+| ruleOldUtilsRenamed    | org.apache.eventmesh.common.utils.. (renamed to .util.. in #5298)                          |
 
-The 1.13.0 release ships the rules in WARN mode (rule evaluations are
-logged via System.out.println in ArchitectureRulesTest, but violations
-do NOT fail `gradle check`). From 1.14.0 the *_warn test methods will
-be replaced with hard rule.check(classes) assertions, at which point
-new violations WILL fail `gradle architectureCheck` and thus the build.
+`eventmesh-runtime` boundaries (from #5297):
+
+| Rule                                | Forbids                                                                  |
+|-------------------------------------|--------------------------------------------------------------------------|
+| ruleRuntimeTcpInternalHidden        | runtime.tcp.internal.. reached from outside runtime.tcp..                 |
+| ruleRuntimeEngineIsolatedFromInfra  | runtime.boot / ingress / delivery depending on runtime.tcp.internal..     |
+| ruleRuntimePushDoesNotImportCodec   | runtime.push depending on runtime.tcp.internal..                          |
+| ruleRuntimeSubscriptionStateIsolated | runtime.ingress depending on runtime.state.internal..                    |
+
+## Severity: FAIL
+
+`ArchitectureRulesTest` calls `rule.check(classes)` for every rule, so
+a violation throws and fails the task.
+
+This replaced the original WARN mode, which turned out to be silent:
+the module has no SLF4J binding on its test runtime classpath, so
+`LoggerFactory` hands back the NOP logger and every
+`LOG.warn(report)` call was discarded. Violations were reported
+nowhere. FAIL mode does not depend on logging at all.
 
 ## Running locally
 
 ```bash
 ./gradlew :eventmesh-architecture-guard:architectureCheck
 ```
+
+## Continuous integration
+
+`.github/workflows/architecture-guard.yml` runs the same task as its
+own check on pushes and pull requests that touch the analysed modules,
+so a violation appears as "Architecture Guard" on the PR rather than
+buried in the Build job log. The matrix build in `ci.yml` excludes
+`:eventmesh-architecture-guard:test` to avoid running the rules twice.

--- a/eventmesh-architecture-guard/src/main/java/org/apache/eventmesh/architecture/guard/ArchitectureRules.java
+++ b/eventmesh-architecture-guard/src/main/java/org/apache/eventmesh/architecture/guard/ArchitectureRules.java
@@ -82,10 +82,6 @@ public final class ArchitectureRules {
             .that().resideOutsideOfPackage("org.apache.eventmesh.runtime.tcp..")
             .should().dependOnClassesThat().resideInAPackage("org.apache.eventmesh.runtime.tcp.internal..");
 
-    public static ArchRule ruleRuntimeTcpInternalNoReverse = noClasses()
-            .that().resideInAPackage("org.apache.eventmesh.runtime.tcp.internal..")
-            .should().dependOnClassesThat().resideInAPackage("org.apache.eventmesh.runtime.tcp..");
-
     public static ArchRule ruleRuntimeEngineIsolatedFromInfra = noClasses()
             .that().resideInAPackage("org.apache.eventmesh.runtime.boot..")
             .or().resideInAPackage("org.apache.eventmesh.runtime.ingress..")

--- a/eventmesh-architecture-guard/src/main/java/org/apache/eventmesh/architecture/guard/ArchitectureRules.java
+++ b/eventmesh-architecture-guard/src/main/java/org/apache/eventmesh/architecture/guard/ArchitectureRules.java
@@ -56,21 +56,21 @@ public final class ArchitectureRules {
     public static ArchRule ruleHttpProtocolHidden = noClasses()
             .that().resideOutsideOfPackage("org.apache.eventmesh.common.protocol.http..")
             .and().resideOutsideOfPackage("org.apache.eventmesh.common..")
-            .and().resideOutsideOfPackage("org.apache.eventmesh.protocol.plugin.meshmessage..")
+            .and().resideOutsideOfPackage("org.apache.eventmesh.protocol.meshmessage..")
             .and().resideOutsideOfPackage("org.apache.eventmesh.client..")
             .should().dependOnClassesThat().resideInAPackage("org.apache.eventmesh.common.protocol.http..");
 
     public static ArchRule ruleGrpcProtocolHidden = noClasses()
             .that().resideOutsideOfPackage("org.apache.eventmesh.common.protocol.grpc..")
             .and().resideOutsideOfPackage("org.apache.eventmesh.common..")
-            .and().resideOutsideOfPackage("org.apache.eventmesh.protocol.plugin.meshmessage..")
+            .and().resideOutsideOfPackage("org.apache.eventmesh.protocol.meshmessage..")
             .and().resideOutsideOfPackage("org.apache.eventmesh.client..")
             .should().dependOnClassesThat().resideInAPackage("org.apache.eventmesh.common.protocol.grpc..");
 
     public static ArchRule ruleTcpProtocolHidden = noClasses()
             .that().resideOutsideOfPackage("org.apache.eventmesh.common.protocol.tcp..")
             .and().resideOutsideOfPackage("org.apache.eventmesh.common..")
-            .and().resideOutsideOfPackage("org.apache.eventmesh.protocol.plugin.meshmessage..")
+            .and().resideOutsideOfPackage("org.apache.eventmesh.protocol.meshmessage..")
             .and().resideOutsideOfPackage("org.apache.eventmesh.client..")
             .and().resideOutsideOfPackage("org.apache.eventmesh.runtime..")
             .should().dependOnClassesThat().resideInAPackage("org.apache.eventmesh.common.protocol.tcp..");

--- a/eventmesh-architecture-guard/src/test/java/org/apache/eventmesh/architecture/guard/ArchitectureRulesTest.java
+++ b/eventmesh-architecture-guard/src/test/java/org/apache/eventmesh/architecture/guard/ArchitectureRulesTest.java
@@ -67,11 +67,6 @@ class ArchitectureRulesTest {
     }
 
     @Test
-    void ruleRuntimeTcpInternalNoReverse() {
-        ArchitectureRules.ruleRuntimeTcpInternalNoReverse.check(classes);
-    }
-
-    @Test
     void ruleRuntimeEngineIsolatedFromInfra() {
         ArchitectureRules.ruleRuntimeEngineIsolatedFromInfra.check(classes);
     }

--- a/eventmesh-architecture-guard/src/test/java/org/apache/eventmesh/architecture/guard/ArchitectureRulesTest.java
+++ b/eventmesh-architecture-guard/src/test/java/org/apache/eventmesh/architecture/guard/ArchitectureRulesTest.java
@@ -17,85 +17,72 @@
 
 package org.apache.eventmesh.architecture.guard;
 
-
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
-import com.tngtech.archunit.lang.EvaluationResult;
 
 /**
  * Test class for {@link ArchitectureRules}.
  *
- * <p>Each rule is asserted in WARN mode: violations are logged at
- * {@code WARN} level but the test passes. From 1.14.0 the
- * {@code *_warn} test methods will be replaced with hard
- * {@code rule.check(classes)} assertions that fail on violation.
+ * <p>Each rule is asserted in FAIL mode: {@code rule.check(classes)}
+ * throws {@code AssertionError} listing every violating location, so
+ * any architecture violation breaks the build.
+ *
+ * <p>This module intentionally carries no SLF4J binding, so the
+ * earlier WARN mode discarded every violation report (SLF4J falls back
+ * to the NOP logger). FAIL mode does not depend on logging at all.
  */
 class ArchitectureRulesTest {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ArchitectureRulesTest.class);
 
     private final JavaClasses classes = ArchitectureRules.loadProductionClasses();
 
     @Test
-    void ruleInternalHidden_warn() {
-        EvaluationResult r = ArchitectureRules.ruleInternalHidden.evaluate(classes);
-        LOG.warn("ArchitectureRules.ruleInternalHidden violations:\n{}", r.getFailureReport());
+    void ruleInternalHidden() {
+        ArchitectureRules.ruleInternalHidden.check(classes);
     }
 
     @Test
-    void ruleHttpProtocolHidden_warn() {
-        EvaluationResult r = ArchitectureRules.ruleHttpProtocolHidden.evaluate(classes);
-        LOG.warn("ArchitectureRules.ruleHttpProtocolHidden violations:\n{}", r.getFailureReport());
+    void ruleHttpProtocolHidden() {
+        ArchitectureRules.ruleHttpProtocolHidden.check(classes);
     }
 
     @Test
-    void ruleGrpcProtocolHidden_warn() {
-        EvaluationResult r = ArchitectureRules.ruleGrpcProtocolHidden.evaluate(classes);
-        LOG.warn("ArchitectureRules.ruleGrpcProtocolHidden violations:\n{}", r.getFailureReport());
+    void ruleGrpcProtocolHidden() {
+        ArchitectureRules.ruleGrpcProtocolHidden.check(classes);
     }
 
     @Test
-    void ruleTcpProtocolHidden_warn() {
-        EvaluationResult r = ArchitectureRules.ruleTcpProtocolHidden.evaluate(classes);
-        LOG.warn("ArchitectureRules.ruleTcpProtocolHidden violations:\n{}", r.getFailureReport());
+    void ruleTcpProtocolHidden() {
+        ArchitectureRules.ruleTcpProtocolHidden.check(classes);
     }
 
     @Test
-    void ruleOldUtilsRenamed_warn() {
-        EvaluationResult r = ArchitectureRules.ruleOldUtilsRenamed.evaluate(classes);
-        LOG.warn("ArchitectureRules.ruleOldUtilsRenamed violations:\n{}", r.getFailureReport());
+    void ruleOldUtilsRenamed() {
+        ArchitectureRules.ruleOldUtilsRenamed.check(classes);
     }
 
     @Test
-    void ruleRuntimeTcpInternalHidden_warn() {
-        EvaluationResult r = ArchitectureRules.ruleRuntimeTcpInternalHidden.evaluate(classes);
-        LOG.warn("ArchitectureRules.ruleRuntimeTcpInternalHidden violations:\n{}", r.getFailureReport());
+    void ruleRuntimeTcpInternalHidden() {
+        ArchitectureRules.ruleRuntimeTcpInternalHidden.check(classes);
     }
 
     @Test
-    void ruleRuntimeTcpInternalNoReverse_warn() {
-        EvaluationResult r = ArchitectureRules.ruleRuntimeTcpInternalNoReverse.evaluate(classes);
-        LOG.warn("ArchitectureRules.ruleRuntimeTcpInternalNoReverse violations:\n{}", r.getFailureReport());
+    void ruleRuntimeTcpInternalNoReverse() {
+        ArchitectureRules.ruleRuntimeTcpInternalNoReverse.check(classes);
     }
 
     @Test
-    void ruleRuntimeEngineIsolatedFromInfra_warn() {
-        EvaluationResult r = ArchitectureRules.ruleRuntimeEngineIsolatedFromInfra.evaluate(classes);
-        LOG.warn("ArchitectureRules.ruleRuntimeEngineIsolatedFromInfra violations:\n{}", r.getFailureReport());
+    void ruleRuntimeEngineIsolatedFromInfra() {
+        ArchitectureRules.ruleRuntimeEngineIsolatedFromInfra.check(classes);
     }
 
     @Test
-    void ruleRuntimePushDoesNotImportCodec_warn() {
-        EvaluationResult r = ArchitectureRules.ruleRuntimePushDoesNotImportCodec.evaluate(classes);
-        LOG.warn("ArchitectureRules.ruleRuntimePushDoesNotImportCodec violations:\n{}", r.getFailureReport());
+    void ruleRuntimePushDoesNotImportCodec() {
+        ArchitectureRules.ruleRuntimePushDoesNotImportCodec.check(classes);
     }
 
     @Test
-    void ruleRuntimeSubscriptionStateIsolated_warn() {
-        EvaluationResult r = ArchitectureRules.ruleRuntimeSubscriptionStateIsolated.evaluate(classes);
-        LOG.warn("ArchitectureRules.ruleRuntimeSubscriptionStateIsolated violations:\n{}", r.getFailureReport());
+    void ruleRuntimeSubscriptionStateIsolated() {
+        ArchitectureRules.ruleRuntimeSubscriptionStateIsolated.check(classes);
     }
 }


### PR DESCRIPTION
## Summary

Completes the A+B setup for `:eventmesh-architecture-guard` (issue #5305) and, in the process, fixes two defects that made the rules useless since they landed in #5298 / #5297.

## The headline problem: WARN mode was silent

The module has **no SLF4J binding** on its test runtime classpath, so `LoggerFactory` returns the NOP logger and every

```java
LOG.warn("...violations:/n{}", r.getFailureReport());
```

call was **discarded**. Verified empirically: the `architectureCheck` test-results XML has an empty `<system-out>` block even though all 10 `*_warn` methods ran and passed.

**The 10 rules had never actually been read by anyone. CI green was not evidence of anything.**

## What FAIL mode revealed

Switching to `rule.check(classes)` immediately reported **192 violations across 4 rules**. Two defects accounted for all of them.

### Defect 1 - wrong package name in 3 exclusion clauses (167 violations)

`ArchitectureRules.java` excluded

```java
"org.apache.eventmesh.protocol.plugin.meshmessage.."
```

but the real package is `org.apache.eventmesh.protocol.meshmessage` - there is no `.plugin` segment. Confirmed with `git cat-file -p ... | grep ^package`. The exclusion never matched, so all 7 protocol adapters were judged as ordinary offenders:

| Rule | Violations |
|---|---|
| `ruleHttpProtocolHidden` | 107 |
| `ruleTcpProtocolHidden` | 46 |
| `ruleGrpcProtocolHidden` | 14 |

Fixed by correcting the three package strings. No rule semantics change.

### Defect 2 - `ruleRuntimeTcpInternalNoReverse` was unsatisfiable (25 violations)

```java
.that().resideInAPackage("...tcp.internal..")
.should().dependOnClassesThat().resideInAPackage("org.apache.eventmesh.runtime.tcp..")
```

The trailing `..` on the should() side covers `runtime.tcp.internal` **itself**, so the rule forbids internal classes from depending on their own package. Every reported "violation" was of this shape:

```
NettyTcpPushChannel.deliver -> TcpAckRegistry.register              internal -> public (normal)
TcpPushChannel.deliver      -> TcpFrameCodec.encodePush             internal -> internal
TcpPushChannel.deliver      -> TcpPushChannel$TcpSessionSink.write  its own nested type
TcpRequest$Kind.values      -> TcpRequest$Kind.clone                itself
```

**Rule deleted.** Narrowing the `..` would not rescue it either: internal implementations depending on the public types they implement is ordinary layering. The boundary that matters is already covered by `ruleRuntimeTcpInternalHidden`, which keeps everything outside `runtime.tcp` away from `runtime.tcp.internal`.

**Rules in force: 10 -> 9. All 9 pass in FAIL mode.**

## A+B

**B - local (unchanged mechanism, now actually effective):**
```bash
./gradlew :eventmesh-architecture-guard:architectureCheck
```
Fails in seconds, so a developer sees a violation before pushing.

**A - CI (new):** `.github/workflows/architecture-guard.yml` runs the same task on pushes/PRs touching the analysed modules. A violation surfaces as its own **"Architecture Guard"** check instead of hiding in the 30-minute Build job. Failure reporting uses the gradle exit code only - no `::error` annotation, no auto PR comment - matching how `ci.yml` and `license.yml` already behave.

`ci.yml` drops `:eventmesh-architecture-guard:test` from the matrix build so the rules do not run twice.

## Commits

1. `5aab8a64` feat(arch-guard): enforce rules via rule.check(classes) - WARN -> FAIL, drop Logger/EvaluationResult imports, LOG field, stale Javadoc
2. `e9115ee4` fix(arch-guard): correct meshmessage package in protocol-hidden rules - 3 package strings
3. `3b1fa6f9` fix(arch-guard): drop broken ruleRuntimeTcpInternalNoReverse - rule + test
4. `59a992e1` ci(arch-guard): dedicated Architecture Guard workflow - new workflow, ci.yml exclude, README

## Verification

```bash
./gradlew :eventmesh-architecture-guard:check
```

Local: **BUILD SUCCESSFUL** - 9/9 rules pass in FAIL mode, plus compileJava/compileTestJava, checkstyle, pmd, spotbugs all clean. Both workflow YAMLs parse cleanly.

## Note for reviewers

Because WARN mode never emitted anything, **no violation list was ever published**, so this PR is the first time these rules have actually run. If any team believes a specific rule is too strict, that is now a visible, discussable failure rather than a silent one.

Refs: #5305. Builds on #5298 (PR #5320) and #5297 (PR #5321).
