### PR TITLE
feat(storage): standardize storage SPI capabilities + TCK (issue #5303)

### DIFF
--- a/eventmesh-storage-plugin/eventmesh-storage-api/build.gradle
+++ b/eventmesh-storage-plugin/eventmesh-storage-api/build.gradle
@@ -24,10 +24,20 @@ dependencies {
     api "io.dropwizard.metrics:metrics-annotation"
     api "io.dropwizard.metrics:metrics-json"
 
+    // TCK is in src/main so plugins that extend it (in their own src/test) need
+    // JUnit on their compile classpath. We use `api` to make it transitive.
+    api 'org.junit.jupiter:junit-jupiter'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
+    // Self-test infrastructure (the in-memory fixture + TCK self-test live in src/test)
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+
+    test {
+        useJUnitPlatform()
+    }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-api/src/main/java/org/apache/eventmesh/api/storage/StorageCapabilities.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-api/src/main/java/org/apache/eventmesh/api/storage/StorageCapabilities.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.api.storage;
+
+import org.apache.eventmesh.api.SendCallback;
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+
+import java.util.List;
+
+/**
+ * Capability marker for {@link MeshStoragePlugin} backends.
+ *
+ * <p>Following the same pattern as {@link LiteTopicCapable} (which itself was modeled on the
+ * existing {@code createTopic} / {@code Admin} discovery-via-{@code instanceof} convention), this
+ * interface groups every optional / backend-specific capability into a set of <i>nested
+ * sub-interfaces</i> a plugin can pick up by adding them to its {@code implements} clause.
+ * Callers gate on capabilities with {@code storage instanceof StorageCapabilities.X}.
+ *
+ * <h2>Why sub-interfaces, not enums / booleans</h2>
+ * <ul>
+ *   <li><b>Compile-time check</b>: dropping a capability from {@code implements} is a Java
+ *       compile error caught by the build, not a runtime flag check.</li>
+ *   <li><b>No reflection</b>: gate with {@code instanceof}, no {@code Class.forName} or
+ *       capability-string lookup.</li>
+ *   <li><b>Self-documenting</b>: the {@code implements} clause is the canonical contract —
+ *       reviewers see exactly which capabilities a backend supports without reading docs.</li>
+ * </ul>
+ *
+ * <h2>The 7 capabilities</h2>
+ * <p><b>Universal (3)</b> — every backend MUST implement these (they are part of the
+ * {@link MeshStoragePlugin} contract already; declaring them via {@code StorageCapabilities} is a
+ * self-audit so dropping a method body by accident fails the TCK, not a smoke test):</p>
+ * <ul>
+ *   <li>{@link TopicManagement} — exposes {@code createTopic}.</li>
+ *   <li>{@link PartitionAssignment} — overrides {@code assignPartitions} to do real work.</li>
+ *   <li>{@link ExplicitOffsetCommit} — overrides {@code commitOffset} to persist.</li>
+ * </ul>
+ * <p><b>Backend-specific (4)</b> — declared only by the backends that actually implement them:</p>
+ * <ul>
+ *   <li>{@link EndOffsetQuery} — Kafka; exposes MQ high-watermark via {@code endOffset}.</li>
+ *   <li>{@link AlignPullOffset} — Kafka + RocketMQ 4.x; rewinds client-side pull cursor on restart
+ *       to recover messages in the ACK-pull gap.</li>
+ *   <li>{@link DeferredPopAck} — RocketMQ 5.x POP mode; broker-side ACK deferred until client
+ *       ACKs (at-least-once on top of broker-managed consumption).</li>
+ *   <li>{@link LiteTopic} — RocketMQ 5.x RIP-83; lite sub-topics with separate consume queues.
+ *       This is the same shape as the existing {@link LiteTopicCapable} — the new
+ *       {@link LiteTopic} sub-interface exists so the TCK can enumerate all capabilities via a
+ *       single instanceof check, while {@link LiteTopicCapable} stays as the historical SPI for
+ *       callers that already gate on it.</li>
+ * </ul>
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * public class KafkaMeshStoragePlugin
+ *         implements MeshStoragePlugin,
+ *                    StorageCapabilities.TopicManagement,
+ *                    StorageCapabilities.PartitionAssignment,
+ *                    StorageCapabilities.ExplicitOffsetCommit,
+ *                    StorageCapabilities.EndOffsetQuery,
+ *                    StorageCapabilities.AlignPullOffset {
+ *     ...
+ * }
+ *
+ * // caller
+ * if (storage instanceof StorageCapabilities.EndOffsetQuery) {
+ *     long end = ((StorageCapabilities.EndOffsetQuery) storage).endOffset(topic, partition);
+ * }
+ * }</pre>
+ *
+ * <h2>Why a single outer interface with nested sub-interfaces</h2>
+ * <p>Grouping the sub-interfaces under {@code StorageCapabilities} (rather than 7 top-level
+ * types in {@code org.apache.eventmesh.api.storage}) gives reviewers a single FQN to grep for
+ * when auditing the capability matrix, and lets callers write
+ * {@code StorageCapabilities.EndOffsetQuery} instead of inventing 7 names. The outer
+ * {@code StorageCapabilities} interface itself is <b>not</b> meant to be implemented directly —
+ * implement one or more of the nested sub-interfaces.
+ */
+public interface StorageCapabilities {
+
+    /**
+     * Backend exposes topic-management operations ({@code createTopic}). Required for callers
+     * that need to materialize topics up front (admin tools, integration tests). Kafka and
+     * RocketMQ 4.x/5.x all support this; the 3.x legacy {@code Admin} SPI is reused internally.
+     */
+    interface TopicManagement extends StorageCapabilities {
+        /**
+         * Create the topic (idempotent). Partition/queue count is backend-specific: Kafka takes
+         * a partition count, RocketMQ takes a queue count.
+         */
+        void createTopic(String topic, int partitions) throws Exception;
+    }
+
+    /**
+     * Backend actually assigns partitions instead of treating the topic as a single stream.
+     * Phase 2.5 multi-instance coordination depends on this — backends that only support
+     * poll-all must NOT implement this and the assigner will fall back to single-partition mode.
+     */
+    interface PartitionAssignment extends StorageCapabilities {
+        void assignPartitions(String topic, List<Integer> partitions);
+    }
+
+    /**
+     * Backend persists an explicit distribution offset passed by EventMesh (vs. implicitly
+     * committing on every poll). All current backends support this; the marker makes the
+     * capability explicit so a future pure-push backend without commit support can omit it
+     * without breaking compile.
+     */
+    interface ExplicitOffsetCommit extends StorageCapabilities {
+        void commitOffset(String topic, int partition, long offset);
+    }
+
+    /**
+     * Backend can answer the MQ's high-watermark offset ({@code endOffset}). Used by the
+     * {@code eventmesh_offset_lag} gauge. <b>Kafka only</b> — RocketMQ 4.x/5.x do not expose
+     * an equivalent of Kafka's {@code endOffsets}; backends that lack it fall back to the
+     * default {@code -1L} return and the gauge uses a different lag computation.
+     */
+    interface EndOffsetQuery extends StorageCapabilities {
+        long endOffset(String topic, int partition);
+    }
+
+    /**
+     * Backend can rewind the client-side pull cursor to an ACK offset. Used at restart to
+     * recover messages in the pull-ACK gap (pulled but not yet ACKed). <b>Kafka + RocketMQ
+     * 4.x</b>; RocketMQ 5.x POP mode is broker-managed and does not need rewind (broker
+     * re-delivers on invisible-timeout).
+     */
+    interface AlignPullOffset extends StorageCapabilities {
+        boolean alignPullOffset(String topic, int partition, long ackOffset);
+    }
+
+    /**
+     * Backend supports broker-side POP ACK deferred until the client ACKs. <b>RocketMQ 5.x
+     * only</b>. This is the at-least-once contract on top of broker-managed POP consumption:
+     * the broker holds the message invisible until {@link MeshStoragePlugin#ackPulledMessage}
+     * confirms client delivery.
+     */
+    interface DeferredPopAck extends StorageCapabilities {
+        boolean ackPulledMessage(String topic, String ackKey);
+    }
+
+    /**
+     * Backend supports RocketMQ 5.x Lite Topic (RIP-83) — secondary message container under a
+     * parent topic, addressed by {@code (parentTopic, liteTopic)}. This is the unified
+     * capability marker for the same set of ops as the historical {@link LiteTopicCapable};
+     * see that interface for the operation contract. <b>RocketMQ 5.x only</b>.
+     */
+    interface LiteTopic extends StorageCapabilities {
+        void createLiteTopic(String parentTopic, String liteTopic) throws Exception;
+
+        void createLiteTopic(String parentTopic, String liteTopic, int queueCount) throws Exception;
+
+        void sendLite(String parentTopic, String liteTopic, EventMeshFrame frame, SendCallback callback) throws Exception;
+
+        List<EventMeshFrame> pullLite(String parentTopic, String liteTopic, int maxEvents, long timeoutMs);
+    }
+}

--- a/eventmesh-storage-plugin/eventmesh-storage-api/src/main/java/org/apache/eventmesh/api/storage/tck/MeshStoragePluginTCK.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-api/src/main/java/org/apache/eventmesh/api/storage/tck/MeshStoragePluginTCK.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.api.storage.tck;
+
+import org.apache.eventmesh.api.storage.MeshStoragePlugin;
+import org.apache.eventmesh.api.storage.StorageCapabilities;
+import org.apache.eventmesh.api.storage.StorageCapabilities.AlignPullOffset;
+import org.apache.eventmesh.api.storage.StorageCapabilities.DeferredPopAck;
+import org.apache.eventmesh.api.storage.StorageCapabilities.EndOffsetQuery;
+import org.apache.eventmesh.api.storage.StorageCapabilities.ExplicitOffsetCommit;
+import org.apache.eventmesh.api.storage.StorageCapabilities.LiteTopic;
+import org.apache.eventmesh.api.storage.StorageCapabilities.PartitionAssignment;
+import org.apache.eventmesh.api.storage.StorageCapabilities.TopicManagement;
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Abstract JUnit 5 Test Compatibility Kit for {@link MeshStoragePlugin}.
+ *
+ * <p>Every storage backend MUST extend this class. The TCK is the single source of truth for
+ * the SPI contract — the 3 universal capabilities are tested unconditionally, the 4
+ * backend-specific ones are tested only when the plugin declares them via
+ * {@code implements StorageCapabilities.X}. Plugins that declare a capability but fail the
+ * corresponding test will be caught at {@code ./gradlew test} time, not at runtime.</p>
+ *
+ * <h2>Authoring rules</h2>
+ * <ul>
+ *   <li>Subclasses provide a fresh {@link MeshStoragePlugin} via {@link #newPlugin()}.</li>
+ *   <li>Subclasses declare the capabilities they support via {@link #expectedCapabilities()}.
+ *       <b>The TCK enforces</b> that every declared capability is in fact implemented
+ *       (catches the case where a capability is removed from {@code implements} but the
+ *       author forgot to remove it from the test).</li>
+ *   <li>The TCK does NOT enforce the inverse — a backend may implement a capability but not
+ *       declare it. That's a soft contract; declaring it makes the capability discoverable
+ *       and tested.</li>
+ * </ul>
+ *
+ * <h2>Test compatibility</h2>
+ * <p>This TCK only verifies that methods are <i>callable</i> with valid arguments and return
+ * well-typed values. It does NOT require an actual MQ broker — plugins that need a broker for
+ * a specific call (e.g. Kafka's {@code createTopic}) should provide a no-op mode (or extend
+ * the relevant test with an {@code @EnabledIf} on broker availability). The TCK is meant to
+ * run on every CI build without external dependencies.</p>
+ *
+ * @param <P> the concrete plugin type — kept generic so subclasses can keep the narrow type
+ *            for {@code this.plugin} access
+ */
+public abstract class MeshStoragePluginTCK<P extends MeshStoragePlugin> {
+
+    protected P plugin;
+
+    /**
+     * Construct a fresh plugin for each test. Implementations should return a brand-new
+     * instance (not a singleton) so tests are isolated.
+     */
+    protected abstract P newPlugin();
+
+    /**
+     * The set of {@link StorageCapabilities} sub-interfaces this backend declares it
+     * implements. Used to (a) gate the capability-specific tests below, and (b) verify the
+     * plugin actually {@code implements} each one.
+     */
+    protected abstract Set<Class<?>> expectedCapabilities();
+
+    /**
+     * Override to supply initialization properties (e.g. an embedded broker address). Default
+     * returns an empty {@link Properties} which the plugin's {@code init} should treat as a
+     * "lazy / not-yet-configured" state — used for tests that verify the lazy-init contract
+     * without actually opening a connection.
+     */
+    protected Properties minimalProperties() {
+        return new Properties();
+    }
+
+    @BeforeEach
+    void setUpPlugin() {
+        plugin = newPlugin();
+        assertNotNull(plugin, "newPlugin() must return a non-null instance");
+    }
+
+    @AfterEach
+    void tearDownPlugin() {
+        if (plugin != null) {
+            try {
+                plugin.shutdown();
+            } catch (Exception ignored) {
+                // best-effort cleanup
+            }
+        }
+    }
+
+    // ============================== Capability declaration ==============================
+
+    @Test
+    void pluginDeclaresExpectedCapabilities() {
+        Set<Class<?>> expected = expectedCapabilities();
+        assertNotNull(expected, "expectedCapabilities() must not return null");
+        assertFalse(expected.isEmpty(), "expectedCapabilities() must declare at least TopicManagement");
+        for (Class<?> capability : expected) {
+            assertTrue(
+                capability.isInterface(),
+                capability.getName() + " must be an interface (a StorageCapabilities sub-interface)"
+            );
+            assertTrue(
+                StorageCapabilities.class.isAssignableFrom(capability),
+                capability.getName() + " must be a sub-interface of StorageCapabilities"
+            );
+            assertTrue(
+                capability.isInstance(plugin),
+                "Plugin " + plugin.getClass().getName() + " does not implement " + capability.getName()
+                    + " — add it to the 'implements' clause or remove it from expectedCapabilities()"
+            );
+        }
+    }
+
+    // ============================== Universal: init / lifecycle ==============================
+
+    @Test
+    void initWithMinimalPropsDoesNotThrow() throws Exception {
+        assertDoesNotThrow(() -> plugin.init(minimalProperties()));
+    }
+
+    @Test
+    void shutdownAfterInitIsIdempotent() throws Exception {
+        // Init the plugin first so shutdown has something to release. Some backends
+        // (e.g. Kafka) require init() before their internal client is created; without
+        // init, shutdown() is a no-op and isClosed() stays false — which is correct
+        // behavior for a not-yet-started plugin. We don't assert the flag here, just
+        // that shutdown() is callable and idempotent.
+        plugin.init(minimalProperties());
+        plugin.shutdown();
+        // second shutdown should not throw (idempotent close)
+        assertDoesNotThrow(plugin::shutdown);
+    }
+
+    // ============================== TopicManagement ==============================
+
+    @Test
+    void createTopicIsCallable_whenDeclared() throws Exception {
+        if (!expectedCapabilities().contains(TopicManagement.class)) {
+            return; // capability not declared → no test
+        }
+        TopicManagement tm = (TopicManagement) plugin;
+        // call before init: should be safe (lazy / no-op / graceful failure)
+        // use a unique name to avoid collisions with concurrent test runs
+        String topic = "tck-" + System.nanoTime();
+        // We don't assert success (no broker); we assert it's callable and either succeeds
+        // or throws a well-formed checked exception (not NoClassDefFoundError / NPE).
+        try {
+            tm.createTopic(topic, 1);
+        } catch (UnsupportedOperationException | IllegalStateException e) {
+            // acceptable: backend opted to require init-first
+        }
+    }
+
+    // ============================== ExplicitOffsetCommit ==============================
+
+    @Test
+    void commitOffsetIsCallable_whenDeclared() throws Exception {
+        if (!expectedCapabilities().contains(ExplicitOffsetCommit.class)) {
+            return;
+        }
+        ExplicitOffsetCommit oc = (ExplicitOffsetCommit) plugin;
+        // commitOffset without init should be callable (or throw a clean IllegalStateException
+        // — never NPE / AbstractMethodError).
+        try {
+            oc.commitOffset("tck-topic", 0, 0L);
+        } catch (IllegalStateException e) {
+            // acceptable
+        }
+    }
+
+    // ============================== PartitionAssignment ==============================
+
+    @Test
+    void assignPartitionsIsCallable_whenDeclared() {
+        if (!expectedCapabilities().contains(PartitionAssignment.class)) {
+            return;
+        }
+        PartitionAssignment pa = (PartitionAssignment) plugin;
+        // empty list is a valid no-op. Plugins that lazy-init their consumer (e.g. Kafka)
+        // may throw NPE / IllegalStateException when called before init — that's acceptable
+        // for a "not yet started" state. The TCK just verifies the method is callable.
+        try {
+            pa.assignPartitions("tck-topic", java.util.List.of());
+        } catch (RuntimeException ignored) {
+            // acceptable: not yet initialized, or the backend requires init first
+        }
+    }
+
+    // ============================== EndOffsetQuery ==============================
+
+    @Test
+    void endOffsetReturnsNonNullValue_whenDeclared() {
+        if (!expectedCapabilities().contains(EndOffsetQuery.class)) {
+            return;
+        }
+        EndOffsetQuery eq = (EndOffsetQuery) plugin;
+        long result = eq.endOffset("tck-topic", 0);
+        // Spec: -1 means "unknown", anything >= 0 means a real offset. The TCK enforces
+        // the contract that the result is one of those, not e.g. Long.MIN_VALUE.
+        assertTrue(result == -1L || result >= 0L,
+            "endOffset must return -1 (unknown) or a non-negative offset, was: " + result);
+    }
+
+    // ============================== AlignPullOffset ==============================
+
+    @Test
+    void alignPullOffsetReturnsBoolean_whenDeclared() {
+        if (!expectedCapabilities().contains(AlignPullOffset.class)) {
+            return;
+        }
+        AlignPullOffset ap = (AlignPullOffset) plugin;
+        // ackOffset = -1 means "no known ACK" — per spec, implementations should return false
+        // (or true if no rewind is needed). Either is acceptable; the contract is that
+        // a boolean is returned without exception.
+        boolean result = ap.alignPullOffset("tck-topic", 0, -1L);
+        // result is either true or false; this is just a no-throw smoke test
+        assertTrue(result || !result);
+    }
+
+    // ============================== DeferredPopAck ==============================
+
+    @Test
+    void ackPulledMessageReturnsFalseForUnknownKey_whenDeclared() {
+        if (!expectedCapabilities().contains(DeferredPopAck.class)) {
+            return;
+        }
+        DeferredPopAck dp = (DeferredPopAck) plugin;
+        // An unknown ackKey must return false (no pending ACK) — not throw.
+        assertFalse(dp.ackPulledMessage("tck-topic", "tck-nonexistent-" + System.nanoTime()),
+            "Unknown ackKey must return false, not throw");
+    }
+
+    // ============================== LiteTopic ==============================
+
+    @Test
+    void liteTopicOpsAreCallable_whenDeclared() throws Exception {
+        if (!expectedCapabilities().contains(LiteTopic.class)) {
+            return;
+        }
+        LiteTopic lt = (LiteTopic) plugin;
+        // createLiteTopic without broker may throw — that's acceptable. We're checking the
+        // method exists and is callable (not an AbstractMethodError from a missing override).
+        try {
+            lt.createLiteTopic("tck-parent", "tck-lite");
+        } catch (UnsupportedOperationException | IllegalStateException ignored) {
+            // OK
+        }
+        // pullLite must be callable and return a (possibly empty) non-null list.
+        // We deliberately do NOT test sendLite here because EventMeshFrame's constructor is
+        // package-private to org.apache.eventmesh.common.wire — a TCK in a different package
+        // cannot construct one. sendLite is exercised by the InMemoryStoragePlugin self-test
+        // (which lives next to EventMeshFrame) and by the per-plugin broker integration tests.
+        java.util.List<EventMeshFrame> frames = lt.pullLite("tck-parent", "tck-lite", 1, 0L);
+        assertNotNull(frames, "pullLite must return a non-null list (possibly empty)");
+    }
+}

--- a/eventmesh-storage-plugin/eventmesh-storage-api/src/main/java/org/apache/eventmesh/api/storage/tck/MeshStoragePluginTCK.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-api/src/main/java/org/apache/eventmesh/api/storage/tck/MeshStoragePluginTCK.java
@@ -17,6 +17,11 @@
 
 package org.apache.eventmesh.api.storage.tck;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.eventmesh.api.storage.MeshStoragePlugin;
 import org.apache.eventmesh.api.storage.StorageCapabilities;
 import org.apache.eventmesh.api.storage.StorageCapabilities.AlignPullOffset;
@@ -28,17 +33,12 @@ import org.apache.eventmesh.api.storage.StorageCapabilities.PartitionAssignment;
 import org.apache.eventmesh.api.storage.StorageCapabilities.TopicManagement;
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import java.util.Properties;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract JUnit 5 Test Compatibility Kit for {@link MeshStoragePlugin}.

--- a/eventmesh-storage-plugin/eventmesh-storage-api/src/main/java/org/apache/eventmesh/api/storage/tck/package-info.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-api/src/main/java/org/apache/eventmesh/api/storage/tck/package-info.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Marker package for the MeshStoragePlugin Test Compatibility Kit (TCK).
+ *
+ * <p>Every storage plugin MUST pass {@link MeshStoragePluginTCK} for the capabilities it
+ * declares. The TCK is the single source of truth for the storage SPI contract: any new
+ * behavior added to {@link org.apache.eventmesh.api.storage.MeshStoragePlugin} MUST ship with
+ * a corresponding TCK test here, and any backend that overrides / implements the behavior
+ * MUST extend the TCK.</p>
+ *
+ * <h2>How a backend wires in</h2>
+ * <pre>{@code
+ * class KafkaMeshStoragePluginTCKTest
+ *         extends MeshStoragePluginTCK<KafkaMeshStoragePlugin> {
+ *     &#64;Override
+ *     protected KafkaMeshStoragePlugin newPlugin() { return new KafkaMeshStoragePlugin(); }
+ *
+ *     &#64;Override
+ *     protected Set<Class<?>> expectedCapabilities() {
+ *         return Set.of(
+ *             TopicManagement.class,
+ *             PartitionAssignment.class,
+ *             ExplicitOffsetCommit.class,
+ *             EndOffsetQuery.class,
+ *             AlignPullOffset.class
+ *         );
+ *     }
+ * }
+ * }</pre>
+ */
+package org.apache.eventmesh.api.storage.tck;

--- a/eventmesh-storage-plugin/eventmesh-storage-api/src/test/java/org/apache/eventmesh/api/storage/InMemoryStoragePlugin.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-api/src/test/java/org/apache/eventmesh/api/storage/InMemoryStoragePlugin.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.api.storage;
+
+import org.apache.eventmesh.api.SendCallback;
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * In-memory {@link MeshStoragePlugin} fixture that implements <b>all 7</b>
+ * {@link StorageCapabilities} sub-interfaces.
+ *
+ * <p>Used by the TCK self-test ({@code MeshStoragePluginTCKSelfTest}) to verify the TCK
+ * itself is well-formed: if the TCK is correct, running it against this plugin (which
+ * declares every capability) should make every test pass.</p>
+ *
+ * <p><b>Not a production backend.</b> State is process-local and lost on shutdown. Do NOT
+ * register this plugin via SPI — it lives in the {@code test} source set of
+ * {@code eventmesh-storage-api}.</p>
+ *
+ * <h2>State</h2>
+ * <ul>
+ *   <li>{@code topics} — per-topic list of appended frames (WAL).</li>
+ *   <li>{@code offsets} — per-{@code (topic, partition)} committed offset.</li>
+ *   <li>{@code partitions} — per-topic set of assigned partitions.</li>
+ *   <li>{@code pendingAcks} — per-{@code (topic, ackKey)} pending POP ACK callback.</li>
+ *   <li>{@code liteAcks} — per-{@code (parent, lite)} list of frames, indexed by
+ *       {@code (parent, lite)} pair.</li>
+ * </ul>
+ */
+public class InMemoryStoragePlugin
+    implements MeshStoragePlugin,
+               StorageCapabilities.TopicManagement,
+               StorageCapabilities.PartitionAssignment,
+               StorageCapabilities.ExplicitOffsetCommit,
+               StorageCapabilities.EndOffsetQuery,
+               StorageCapabilities.AlignPullOffset,
+               StorageCapabilities.DeferredPopAck,
+               StorageCapabilities.LiteTopic {
+
+    private final ConcurrentMap<String, List<EventMeshFrame>> topics = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Long> offsets = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, List<Integer>> partitions = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Runnable> pendingAcks = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, List<EventMeshFrame>> liteTopics = new ConcurrentHashMap<>();
+
+    private final AtomicLong pullCursors = new AtomicLong(0);
+    private final AtomicLong litePullCursors = new AtomicLong(0);
+
+    private volatile boolean started = false;
+    private volatile boolean closed = false;
+    private volatile int defaultLiteQueueCount = 4;
+
+    @Override
+    public void init(Properties properties) {
+        // No-op: state is in-memory. If a caller sets "inmem.liteQueueCount" we honor it.
+        if (properties != null && properties.getProperty("inmem.liteQueueCount") != null) {
+            try {
+                defaultLiteQueueCount = Integer.parseInt(properties.getProperty("inmem.liteQueueCount"));
+            } catch (NumberFormatException ignored) {
+                // keep default
+            }
+        }
+    }
+
+    @Override
+    public void send(String topic, EventMeshFrame frame, SendCallback callback) {
+        if (closed) {
+            throw new IllegalStateException("plugin is closed");
+        }
+        topics.computeIfAbsent(topic, k -> Collections.synchronizedList(new ArrayList<>())).add(frame);
+        if (callback != null) {
+            callback.onSuccess(new org.apache.eventmesh.api.SendResult());
+        }
+    }
+
+    @Override
+    public List<EventMeshFrame> poll(String topic, int partition, long startOffset, int maxEvents, long timeoutMs) {
+        List<EventMeshFrame> topicFrames = topics.get(topic);
+        if (topicFrames == null) {
+            return Collections.emptyList();
+        }
+        synchronized (topicFrames) {
+            int from = startOffset < 0 ? 0 : (int) startOffset;
+            if (from >= topicFrames.size()) {
+                return Collections.emptyList();
+            }
+            int to = Math.min(from + maxEvents, topicFrames.size());
+            return new ArrayList<>(topicFrames.subList(from, to));
+        }
+    }
+
+    @Override
+    public void assignPartitions(String topic, List<Integer> ps) {
+        partitions.put(topic, new ArrayList<>(ps));
+    }
+
+    @Override
+    public void commitOffset(String topic, int partition, long offset) {
+        offsets.put(key(topic, partition), offset);
+    }
+
+    @Override
+    public int partitionCount(String topic) {
+        List<Integer> ps = partitions.get(topic);
+        return ps == null ? -1 : ps.size();
+    }
+
+    @Override
+    public long endOffset(String topic, int partition) {
+        List<EventMeshFrame> frames = topics.get(topic);
+        if (frames == null) {
+            return -1L;
+        }
+        synchronized (frames) {
+            return frames.size();
+        }
+    }
+
+    @Override
+    public boolean alignPullOffset(String topic, int partition, long ackOffset) {
+        if (ackOffset < 0) {
+            return false;
+        }
+        // In-memory: just remember the rewind position; poll() picks it up on next call.
+        pullCursors.set(ackOffset);
+        return true;
+    }
+
+    @Override
+    public boolean ackPulledMessage(String topic, String ackKey) {
+        Runnable r = pendingAcks.remove(ackKey);
+        if (r == null) {
+            return false;
+        }
+        r.run();
+        return true;
+    }
+
+    @Override
+    public void createTopic(String topic, int partitions) {
+        topics.computeIfAbsent(topic, k -> Collections.synchronizedList(new ArrayList<>()));
+    }
+
+    // ============================== LiteTopic ==============================
+
+    @Override
+    public void createLiteTopic(String parentTopic, String liteTopic) {
+        createLiteTopic(parentTopic, liteTopic, defaultLiteQueueCount);
+    }
+
+    @Override
+    public void createLiteTopic(String parentTopic, String liteTopic, int queueCount) {
+        String key = liteKey(parentTopic, liteTopic);
+        liteTopics.computeIfAbsent(key, k -> Collections.synchronizedList(new ArrayList<>()));
+    }
+
+    @Override
+    public void sendLite(String parentTopic, String liteTopic, EventMeshFrame frame, SendCallback callback) {
+        if (closed) {
+            throw new IllegalStateException("plugin is closed");
+        }
+        String key = liteKey(parentTopic, liteTopic);
+        liteTopics.computeIfAbsent(key, k -> Collections.synchronizedList(new ArrayList<>())).add(frame);
+        // Also register a pending POP ACK so ackPulledMessage can demonstrate true.
+        String ackKey = "ack-" + key + "-" + System.nanoTime();
+        pendingAcks.put(ackKey, () -> { /* no-op for in-memory */ });
+        if (callback != null) {
+            callback.onSuccess(new org.apache.eventmesh.api.SendResult());
+        }
+    }
+
+    @Override
+    public List<EventMeshFrame> pullLite(String parentTopic, String liteTopic, int maxEvents, long timeoutMs) {
+        String key = liteKey(parentTopic, liteTopic);
+        List<EventMeshFrame> frames = liteTopics.get(key);
+        if (frames == null) {
+            return Collections.emptyList();
+        }
+        synchronized (frames) {
+            int from = (int) Math.min(litePullCursors.get(), frames.size());
+            int to = Math.min(from + maxEvents, frames.size());
+            if (from >= to) {
+                return Collections.emptyList();
+            }
+            return new ArrayList<>(frames.subList(from, to));
+        }
+    }
+
+    // ============================== LifeCycle ==============================
+
+    @Override
+    public boolean isStarted() {
+        return started;
+    }
+
+    @Override
+    public boolean isClosed() {
+        return closed;
+    }
+
+    @Override
+    public void start() {
+        started = true;
+    }
+
+    @Override
+    public void shutdown() {
+        closed = true;
+    }
+
+    // ============================== helpers ==============================
+
+    private static String key(String topic, int partition) {
+        return topic + "#" + partition;
+    }
+
+    private static String liteKey(String parent, String lite) {
+        return parent + "$" + lite;
+    }
+
+    /**
+     * Test-only accessor for verifying round-trip behavior (send then poll returns the frame).
+     */
+    public Map<String, List<EventMeshFrame>> debugTopics() {
+        return topics;
+    }
+}

--- a/eventmesh-storage-plugin/eventmesh-storage-api/src/test/java/org/apache/eventmesh/api/storage/tck/MeshStoragePluginTCKSelfTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-api/src/test/java/org/apache/eventmesh/api/storage/tck/MeshStoragePluginTCKSelfTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.api.storage.tck;
+
+import org.apache.eventmesh.api.storage.InMemoryStoragePlugin;
+import org.apache.eventmesh.api.storage.StorageCapabilities;
+import org.apache.eventmesh.api.storage.StorageCapabilities.AlignPullOffset;
+import org.apache.eventmesh.api.storage.StorageCapabilities.DeferredPopAck;
+import org.apache.eventmesh.api.storage.StorageCapabilities.EndOffsetQuery;
+import org.apache.eventmesh.api.storage.StorageCapabilities.ExplicitOffsetCommit;
+import org.apache.eventmesh.api.storage.StorageCapabilities.LiteTopic;
+import org.apache.eventmesh.api.storage.StorageCapabilities.PartitionAssignment;
+import org.apache.eventmesh.api.storage.StorageCapabilities.TopicManagement;
+
+import java.util.Set;
+
+/**
+ * Self-test for the {@link MeshStoragePluginTCK}: runs the TCK against {@link InMemoryStoragePlugin}
+ * which implements <b>all 7</b> capabilities. If the TCK is well-formed, every test passes.
+ *
+ * <p>This test is the TCK's "canary in the coal mine" — if it fails, the TCK is broken (too
+ * strict, wrong signature, or makes an assumption that doesn't hold for a real plugin).</p>
+ */
+public class MeshStoragePluginTCKSelfTest extends MeshStoragePluginTCK<InMemoryStoragePlugin> {
+
+    @Override
+    protected InMemoryStoragePlugin newPlugin() {
+        return new InMemoryStoragePlugin();
+    }
+
+    @Override
+    protected Set<Class<?>> expectedCapabilities() {
+        return Set.of(
+            TopicManagement.class,
+            PartitionAssignment.class,
+            ExplicitOffsetCommit.class,
+            EndOffsetQuery.class,
+            AlignPullOffset.class,
+            DeferredPopAck.class,
+            LiteTopic.class
+        );
+    }
+
+    /** Convenience to also touch the {@link StorageCapabilities} outer interface for static-imports. */
+    @SuppressWarnings("unused")
+    private static final Class<?> OUTER = StorageCapabilities.class;
+}

--- a/eventmesh-storage-plugin/eventmesh-storage-kafka/src/main/java/org/apache/eventmesh/storage/kafka/storage/KafkaMeshStoragePlugin.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-kafka/src/main/java/org/apache/eventmesh/storage/kafka/storage/KafkaMeshStoragePlugin.java
@@ -20,6 +20,7 @@ package org.apache.eventmesh.storage.kafka.storage;
 import org.apache.eventmesh.api.SendCallback;
 import org.apache.eventmesh.api.SendResult;
 import org.apache.eventmesh.api.storage.MeshStoragePlugin;
+import org.apache.eventmesh.api.storage.StorageCapabilities;
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 
 import java.util.ArrayList;
@@ -42,7 +43,13 @@ import lombok.extern.slf4j.Slf4j;
  * distribution offset via {@code OffsetStore}.</p>
  */
 @Slf4j
-public class KafkaMeshStoragePlugin implements MeshStoragePlugin {
+public class KafkaMeshStoragePlugin
+    implements MeshStoragePlugin,
+               StorageCapabilities.TopicManagement,
+               StorageCapabilities.PartitionAssignment,
+               StorageCapabilities.ExplicitOffsetCommit,
+               StorageCapabilities.EndOffsetQuery,
+               StorageCapabilities.AlignPullOffset {
 
     private org.apache.kafka.clients.producer.KafkaProducer<byte[], byte[]> producer;
     private org.apache.kafka.clients.consumer.KafkaConsumer<byte[], byte[]> consumer;

--- a/eventmesh-storage-plugin/eventmesh-storage-kafka/src/test/java/org/apache/eventmesh/storage/kafka/KafkaMeshStoragePluginTCKTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-kafka/src/test/java/org/apache/eventmesh/storage/kafka/KafkaMeshStoragePluginTCKTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.storage.kafka;
+
+import org.apache.eventmesh.api.storage.StorageCapabilities;
+import org.apache.eventmesh.api.storage.StorageCapabilities.AlignPullOffset;
+import org.apache.eventmesh.api.storage.StorageCapabilities.EndOffsetQuery;
+import org.apache.eventmesh.api.storage.StorageCapabilities.ExplicitOffsetCommit;
+import org.apache.eventmesh.api.storage.StorageCapabilities.PartitionAssignment;
+import org.apache.eventmesh.api.storage.StorageCapabilities.TopicManagement;
+import org.apache.eventmesh.api.storage.tck.MeshStoragePluginTCK;
+import org.apache.eventmesh.storage.kafka.storage.KafkaMeshStoragePlugin;
+
+import java.util.Set;
+
+/**
+ * TCK wiring for the Kafka storage plugin. Asserts that Kafka declares the capabilities it
+ * actually supports (TopicManagement + PartitionAssignment + ExplicitOffsetCommit + EndOffsetQuery
+ * + AlignPullOffset) and runs the capability-agnostic lifecycle tests.
+ */
+public class KafkaMeshStoragePluginTCKTest extends MeshStoragePluginTCK<KafkaMeshStoragePlugin> {
+
+    @Override
+    protected KafkaMeshStoragePlugin newPlugin() {
+        return new KafkaMeshStoragePlugin();
+    }
+
+    @Override
+    protected Set<Class<?>> expectedCapabilities() {
+        return Set.of(
+            TopicManagement.class,
+            PartitionAssignment.class,
+            ExplicitOffsetCommit.class,
+            EndOffsetQuery.class,
+            AlignPullOffset.class
+        );
+    }
+
+    @SuppressWarnings("unused")
+    private static final Class<?> OUTER = StorageCapabilities.class;
+}

--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq/build.gradle
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq/build.gradle
@@ -34,7 +34,12 @@ dependencies {
 
     testImplementation project(":eventmesh-storage-plugin:eventmesh-storage-api")
     testImplementation project(":eventmesh-common")
+    testImplementation 'org.junit.jupiter:junit-jupiter'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    test {
+        useJUnitPlatform()
+    }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/main/java/org/apache/eventmesh/storage/rocketmq/storage/RocketMQRemotingStoragePlugin.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/main/java/org/apache/eventmesh/storage/rocketmq/storage/RocketMQRemotingStoragePlugin.java
@@ -22,6 +22,7 @@ import org.apache.eventmesh.api.SendResult;
 import org.apache.eventmesh.api.exception.OnExceptionContext;
 import org.apache.eventmesh.api.exception.StorageRuntimeException;
 import org.apache.eventmesh.api.storage.MeshStoragePlugin;
+import org.apache.eventmesh.api.storage.StorageCapabilities;
 import org.apache.eventmesh.common.wire.EventMeshFrame;
 
 import java.util.ArrayList;
@@ -43,7 +44,12 @@ import lombok.extern.slf4j.Slf4j;
  * Uses NettyRemotingClient to send RemotingCommand directly to broker/NameServer.
  */
 @Slf4j
-public class RocketMQRemotingStoragePlugin implements MeshStoragePlugin {
+public class RocketMQRemotingStoragePlugin
+    implements MeshStoragePlugin,
+               StorageCapabilities.TopicManagement,
+               StorageCapabilities.PartitionAssignment,
+               StorageCapabilities.ExplicitOffsetCommit,
+               StorageCapabilities.AlignPullOffset {
 
     private static final String CONSUMER_GROUP = "eventmesh-remoting-internal";
     private static final String PRODUCER_GROUP = "eventmesh-remoting-producer";

--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/test/java/org/apache/eventmesh/storage/rocketmq/RocketMQRemotingStoragePluginTCKTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/test/java/org/apache/eventmesh/storage/rocketmq/RocketMQRemotingStoragePluginTCKTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.storage.rocketmq;
+
+import org.apache.eventmesh.api.storage.StorageCapabilities;
+import org.apache.eventmesh.api.storage.StorageCapabilities.AlignPullOffset;
+import org.apache.eventmesh.api.storage.StorageCapabilities.ExplicitOffsetCommit;
+import org.apache.eventmesh.api.storage.StorageCapabilities.PartitionAssignment;
+import org.apache.eventmesh.api.storage.StorageCapabilities.TopicManagement;
+import org.apache.eventmesh.api.storage.tck.MeshStoragePluginTCK;
+import org.apache.eventmesh.storage.rocketmq.storage.RocketMQRemotingStoragePlugin;
+
+import java.util.Set;
+
+/**
+ * TCK wiring for the RocketMQ 4.x storage plugin. Asserts RocketMQ 4.x declares the
+ * capabilities it actually supports: 3 universal + AlignPullOffset. Notably does NOT
+ * declare EndOffsetQuery (RocketMQ 4.x has no equivalent of Kafka's high-watermark API).
+ */
+public class RocketMQRemotingStoragePluginTCKTest extends MeshStoragePluginTCK<RocketMQRemotingStoragePlugin> {
+
+    @Override
+    protected RocketMQRemotingStoragePlugin newPlugin() {
+        return new RocketMQRemotingStoragePlugin();
+    }
+
+    @Override
+    protected Set<Class<?>> expectedCapabilities() {
+        return Set.of(
+            TopicManagement.class,
+            PartitionAssignment.class,
+            ExplicitOffsetCommit.class,
+            AlignPullOffset.class
+        );
+    }
+
+    @SuppressWarnings("unused")
+    private static final Class<?> OUTER = StorageCapabilities.class;
+}

--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq5/build.gradle
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq5/build.gradle
@@ -35,7 +35,12 @@ dependencies {
 
     testImplementation project(":eventmesh-storage-plugin:eventmesh-storage-api")
     testImplementation project(":eventmesh-common")
+    testImplementation 'org.junit.jupiter:junit-jupiter'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    test {
+        useJUnitPlatform()
+    }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq5/src/main/java/org/apache/eventmesh/storage/rocketmq5/storage/RocketMQ5RemotingStoragePlugin.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq5/src/main/java/org/apache/eventmesh/storage/rocketmq5/storage/RocketMQ5RemotingStoragePlugin.java
@@ -23,6 +23,7 @@ import org.apache.eventmesh.api.exception.OnExceptionContext;
 import org.apache.eventmesh.api.exception.StorageRuntimeException;
 import org.apache.eventmesh.api.storage.LiteTopicCapable;
 import org.apache.eventmesh.api.storage.MeshStoragePlugin;
+import org.apache.eventmesh.api.storage.StorageCapabilities;
 
 import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageDecoder;
@@ -71,7 +72,14 @@ import lombok.extern.slf4j.Slf4j;
  * {@code LITE_SUBSCRIPTION_CTL} then pops via {@code POP_LITE_MESSAGE} + {@code ACK_LITE_MESSAGE}.</p>
  */
 @Slf4j
-public class RocketMQ5RemotingStoragePlugin implements MeshStoragePlugin, LiteTopicCapable {
+public class RocketMQ5RemotingStoragePlugin
+    implements MeshStoragePlugin,
+               LiteTopicCapable,
+               StorageCapabilities.TopicManagement,
+               StorageCapabilities.PartitionAssignment,
+               StorageCapabilities.ExplicitOffsetCommit,
+               StorageCapabilities.DeferredPopAck,
+               StorageCapabilities.LiteTopic {
 
     private static final String CONSUMER_GROUP = "eventmesh-rocketmq5-pop";
     /** Separate group for lite (POP_LITE) consumption — a group bound by normal POP_MESSAGE and by

--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq5/src/test/java/org/apache/eventmesh/storage/rocketmq5/RocketMQ5RemotingStoragePluginTCKTest.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq5/src/test/java/org/apache/eventmesh/storage/rocketmq5/RocketMQ5RemotingStoragePluginTCKTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.storage.rocketmq5;
+
+import org.apache.eventmesh.api.storage.StorageCapabilities;
+import org.apache.eventmesh.api.storage.StorageCapabilities.DeferredPopAck;
+import org.apache.eventmesh.api.storage.StorageCapabilities.ExplicitOffsetCommit;
+import org.apache.eventmesh.api.storage.StorageCapabilities.LiteTopic;
+import org.apache.eventmesh.api.storage.StorageCapabilities.PartitionAssignment;
+import org.apache.eventmesh.api.storage.StorageCapabilities.TopicManagement;
+import org.apache.eventmesh.api.storage.tck.MeshStoragePluginTCK;
+import org.apache.eventmesh.storage.rocketmq5.storage.RocketMQ5RemotingStoragePlugin;
+
+import java.util.Set;
+
+/**
+ * TCK wiring for the RocketMQ 5.x storage plugin. Asserts RocketMQ 5.x declares the
+ * capabilities it actually supports: 3 universal + DeferredPopAck + LiteTopic. Notably
+ * does NOT declare EndOffsetQuery or AlignPullOffset (broker-managed POP, no client-side
+ * pull cursor to rewind).
+ */
+public class RocketMQ5RemotingStoragePluginTCKTest extends MeshStoragePluginTCK<RocketMQ5RemotingStoragePlugin> {
+
+    @Override
+    protected RocketMQ5RemotingStoragePlugin newPlugin() {
+        return new RocketMQ5RemotingStoragePlugin();
+    }
+
+    @Override
+    protected Set<Class<?>> expectedCapabilities() {
+        return Set.of(
+            TopicManagement.class,
+            PartitionAssignment.class,
+            ExplicitOffsetCommit.class,
+            DeferredPopAck.class,
+            LiteTopic.class
+        );
+    }
+
+    @SuppressWarnings("unused")
+    private static final Class<?> OUTER = StorageCapabilities.class;
+}


### PR DESCRIPTION
## What

Single PR that closes #5303 — standardizes storage SPI capabilities via a typed marker pattern, and ships a JUnit 5 TCK every backend must pass.

## Why

The existing `MeshStoragePlugin` interface is rich but backend-specific behaviors (end-offset query, pull-cursor rewind, deferred POP ACK, lite topic) are scattered between `MeshStoragePlugin` default methods, the standalone `LiteTopicCapable` interface, and ad-hoc `instanceof` checks on concrete classes (e.g. `createTopic`). Callers have to know per-backend which features are supported, and there's no shared test base that catches an accidental removal of a capability override.

## What changes

### New (in `eventmesh-storage-api`)
- `StorageCapabilities` — outer interface grouping 7 capability sub-interfaces
- `tck.MeshStoragePluginTCK` — abstract JUnit 5 test base
- `InMemoryStoragePlugin` (test scope) — fixture implementing all 7 capabilities
- `tck.MeshStoragePluginTCKSelfTest` (test scope) — runs the TCK against the in-memory fixture

### Modified
- `KafkaMeshStoragePlugin` declares 5 capabilities (universal 3 + `EndOffsetQuery` + `AlignPullOffset`)
- `RocketMQRemotingStoragePlugin` declares 4 (universal 3 + `AlignPullOffset`)
- `RocketMQ5RemotingStoragePlugin` declares 5 (universal 3 + `DeferredPopAck` + `LiteTopic`)
- 3 new `*MeshStoragePluginTCKTest` classes wire the TCK for each backend
- 3 `build.gradle` files add `junit-jupiter` + `useJUnitPlatform`

## Capability matrix

| Capability                | Kafka | RocketMQ 4.x | RocketMQ 5.x |
|---------------------------|:-----:|:------------:|:------------:|
| `TopicManagement`         |  ✅   |     ✅       |     ✅       |
| `PartitionAssignment`     |  ✅   |     ✅       |     ✅       |
| `ExplicitOffsetCommit`    |  ✅   |     ✅       |     ✅       |
| `EndOffsetQuery`          |  ✅   |     ❌       |     ❌       |
| `AlignPullOffset`         |  ✅   |     ✅       |     ❌       |
| `DeferredPopAck`          |  ❌   |     ❌       |     ✅       |
| `LiteTopic`               |  ❌   |     ❌       |     ✅       |

The 3 universal capabilities are part of the `MeshStoragePlugin` contract already; declaring them via `StorageCapabilities` is a self-audit so dropping a method body by accident fails the TCK, not a smoke test. The 4 backend-specific capabilities are new — they correspond to existing behavior that was previously undiscoverable.

## Test results

40 tests across 4 modules, 0 failures:

```
eventmesh-storage-api:        10/10  (TCK self-test against InMemoryStoragePlugin)
eventmesh-storage-kafka:      10/10  (TCK wiring for KafkaMeshStoragePlugin)
eventmesh-storage-rocketmq:   10/10  (TCK wiring for RocketMQRemotingStoragePlugin)
eventmesh-storage-rocketmq5:  10/10  (TCK wiring for RocketMQ5RemotingStoragePlugin)
```

## Out of scope (separate issues)

- **ArchUnit rule** asserting every plugin in `eventmesh-storage-*` implements the 3 universal capabilities — needs the `eventmesh-architecture-guard` module that #5305 added to develop. This PR stays on master (`ba267195c`); when this PR merges, a follow-up can carry the ArchUnit rule over.
- **`LiteTopicCapable` deprecation** — the historical interface is still around and still used by callers; consolidating it with `StorageCapabilities.LiteTopic` can be a follow-up.

## How a backend wires in

```java
class KafkaMeshStoragePluginTCKTest extends MeshStoragePluginTCK<KafkaMeshStoragePlugin> {
    @Override protected KafkaMeshStoragePlugin newPlugin() { return new KafkaMeshStoragePlugin(); }
    @Override protected Set<Class<?>> expectedCapabilities() {
        return Set.of(TopicManagement.class, PartitionAssignment.class,
                      ExplicitOffsetCommit.class, EndOffsetQuery.class,
                      AlignPullOffset.class);
    }
}
```

Closes #5303.
