### PR TITLE
feat(security): unified multi-tenant / security / quota entrypoint (issue #5304)

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/a2a/A2AGatewayHttpHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/a2a/A2AGatewayHttpHandler.java
@@ -66,13 +66,27 @@ public class A2AGatewayHttpHandler extends SimpleChannelInboundHandler<FullHttpR
 
     private final A2AGatewayService gatewayService;
 
+    /** #5304: optional unified security/quota/audit gate; null = allow all (current behavior). */
+    private volatile org.apache.eventmesh.runtime.security.gate.SecurityGate securityGate;
+
     public A2AGatewayHttpHandler(A2AGatewayService gatewayService) {
         this.gatewayService = gatewayService;
+    }
+
+    /** #5304: install the unified gate so A2A task ops flow through RequestContext. */
+    public A2AGatewayHttpHandler withSecurityGate(
+            org.apache.eventmesh.runtime.security.gate.SecurityGate gate) {
+        this.securityGate = gate;
+        return this;
     }
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest req) throws Exception {
         String uri = req.uri();
+        // #5304: every A2A task operation goes through the unified gate first.
+        if (!gateCheck(ctx, req, uri)) {
+            return;
+        }
         try {
             if (uri.startsWith("/a2a/tasks/") && uri.endsWith("/stream")) {
                 handleSse(ctx, req);
@@ -101,6 +115,39 @@ public class A2AGatewayHttpHandler extends SimpleChannelInboundHandler<FullHttpR
             writeJson(ctx, HttpResponseStatus.INTERNAL_SERVER_ERROR,
                 "{\"error\":\"internal\",\"message\":\"" + e.getMessage() + "\"}");
         }
+    }
+
+    /**
+     * #5304: run the unified gate for one A2A request. Principal = Authorization header;
+     * quota key = principal or "anonymous". Writes the rejection response and returns
+     * false when denied.
+     */
+    private boolean gateCheck(ChannelHandlerContext ctx, FullHttpRequest req, String uri) {
+        org.apache.eventmesh.runtime.security.gate.SecurityGate gate = securityGate;
+        if (gate == null) {
+            return true;
+        }
+        String authorization = req.headers().get("Authorization");
+        org.apache.eventmesh.runtime.security.gate.RequestContext rc =
+            org.apache.eventmesh.runtime.security.gate.RequestContext.builder(
+                    org.apache.eventmesh.runtime.security.gate.RequestContext.Operation.A2A)
+                .topic(uri)
+                .principal(authorization)
+                .credential(authorization)
+                .remoteAddress(ctx.channel().remoteAddress() != null
+                        ? ctx.channel().remoteAddress().toString() : null)
+                .source("a2a")
+                .build();
+        org.apache.eventmesh.runtime.security.gate.GateDecision decision = gate.check(rc, null);
+        if (decision.isAllowed()) {
+            return true;
+        }
+        HttpResponseStatus status = decision.isQuotaExceeded()
+                ? HttpResponseStatus.TOO_MANY_REQUESTS
+                : HttpResponseStatus.valueOf(decision.getRejectStatus());
+        writeJson(ctx, status,
+            "{\"error\":\"forbidden\",\"message\":\"" + decision.getReason() + "\"}");
+        return false;
     }
 
     // =========================================================================

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/connector/ConnectorScheduler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/connector/ConnectorScheduler.java
@@ -18,6 +18,7 @@
 package org.apache.eventmesh.runtime.connector;
 
 import org.apache.eventmesh.runtime.cluster.MetaStore;
+import org.apache.eventmesh.runtime.security.gate.ConnectorAccessDeniedException;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -68,6 +69,16 @@ public class ConnectorScheduler {
     /** connectorId → last-pushed (ownerWorkerId, defJson). Drives reconcile diffs. */
     private final ConcurrentHashMap<String, Cached> assignmentCache = new ConcurrentHashMap<>();
     private final AtomicBoolean running = new AtomicBoolean(false);
+
+    /** #5304: optional unified security/quota/audit gate; null = allow all. */
+    private volatile org.apache.eventmesh.runtime.security.gate.SecurityGate securityGate;
+
+    public ConnectorScheduler withSecurityGate(
+            org.apache.eventmesh.runtime.security.gate.SecurityGate gate) {
+        this.securityGate = gate;
+        return this;
+    }
+
     private ScheduledExecutorService scheduler;
 
     public ConnectorScheduler(MetaStore meta, long ttlMs, long intervalMs, LongSupplier clock) {
@@ -102,6 +113,21 @@ public class ConnectorScheduler {
     // ---- connector CRUD ----
 
     public void createConnector(ConnectorDef def) {
+        // #5304: connector CRUD goes through the unified gate when installed.
+        org.apache.eventmesh.runtime.security.gate.SecurityGate gate = securityGate;
+        if (gate != null) {
+            org.apache.eventmesh.runtime.security.gate.RequestContext rc
+                = org.apache.eventmesh.runtime.security.gate.RequestContext.builder(
+                    org.apache.eventmesh.runtime.security.gate.RequestContext.Operation.CONNECTOR)
+                .topic(def.getTopic())
+                .clientId(def.getClientId())
+                .source("connector")
+                .build();
+            org.apache.eventmesh.runtime.security.gate.GateDecision decision = gate.check(rc, null);
+            if (!decision.isAllowed()) {
+                throw new ConnectorAccessDeniedException(decision.getReason());
+            }
+        }
         meta.put(DEF_PREFIX + def.getId(), writeJson(def));
         reconcile();
     }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/http/UniHttpServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/http/UniHttpServer.java
@@ -74,6 +74,7 @@ public class UniHttpServer {
     private HttpServer server;
     private javax.net.ssl.SSLContext sslContext;
     private org.apache.eventmesh.runtime.security.FilterChain filterChain;
+    private org.apache.eventmesh.runtime.security.gate.SecurityGate securityGate;
     private org.apache.eventmesh.runtime.transport.http.LegacyHttpBridge legacyBridge;
     private String selfInstanceId;
     private org.apache.eventmesh.runtime.session.AgentRegistrar agentRegistrar;
@@ -122,6 +123,19 @@ public class UniHttpServer {
     /** Wire the ingress security filter chain (auth/acl/signature) into publish (§4.5). */
     public UniHttpServer withFilterChain(org.apache.eventmesh.runtime.security.FilterChain filterChain) {
         this.filterChain = filterChain;
+        return this;
+    }
+
+    /**
+     * #5304: install the unified security/quota/audit gate. When set, the gate wraps the
+     * filter chain (or an allow-all chain when none is configured) so every ingress path
+     * funnels through one RequestContext-based check.
+     */
+    public UniHttpServer withSecurityGate(org.apache.eventmesh.runtime.security.gate.SecurityGate gate) {
+        this.securityGate = gate;
+        if (gate != null && this.filterChain == null) {
+            this.filterChain = new org.apache.eventmesh.runtime.security.FilterChain();
+        }
         return this;
     }
 
@@ -236,10 +250,48 @@ public class UniHttpServer {
     }
 
     /**
+     * Infer the #5304 operation from the request path so the gate / ACL match per action.
+     */
+    private org.apache.eventmesh.runtime.security.gate.RequestContext.Operation inferOperation(HttpExchange exchange) {
+        String path = exchange.getRequestURI().getPath();
+        if (path.startsWith("/events/publish") || path.startsWith("/events/lite/publish")) {
+            return org.apache.eventmesh.runtime.security.gate.RequestContext.Operation.PUBLISH;
+        }
+        if (path.startsWith("/events/poll") || path.startsWith("/events/subscribe")
+                || path.startsWith("/events/lite/poll") || path.startsWith("/session/subscribe")) {
+            return org.apache.eventmesh.runtime.security.gate.RequestContext.Operation.SUBSCRIBE;
+        }
+        if (path.startsWith("/events/ack")) {
+            return org.apache.eventmesh.runtime.security.gate.RequestContext.Operation.ACK;
+        }
+        if (path.startsWith("/agent/") || path.startsWith("/session/open") || path.startsWith("/session/close")) {
+            return org.apache.eventmesh.runtime.security.gate.RequestContext.Operation.ADMIN;
+        }
+        return org.apache.eventmesh.runtime.security.gate.RequestContext.Operation.PUBLISH;
+    }
+
+    /**
      * Run the security filter chain (if configured) for any request. Returns true if allowed,
      * false if already rejected (response written).
      */
     private boolean checkSecurity(HttpExchange exchange, String topic, String clientId) throws IOException {
+        if (securityGate != null) {
+            org.apache.eventmesh.runtime.security.gate.RequestContext rc =
+                org.apache.eventmesh.runtime.security.gate.RequestContext.builder(inferOperation(exchange))
+                    .topic(topic)
+                    .clientId(clientId)
+                    .credential(exchange.getRequestHeaders().getFirst("Authorization"))
+                    .remoteAddress(exchange.getRemoteAddress().getAddress().getHostAddress())
+                    .source("http")
+                    .traceContext(java.util.Collections.emptyMap())
+                    .build();
+            org.apache.eventmesh.runtime.security.gate.GateDecision decision = securityGate.check(rc, null);
+            if (!decision.isAllowed()) {
+                writeJson(exchange, decision.getRejectStatus(), error(decision.getReason()));
+                return false;
+            }
+            return true;
+        }
         if (filterChain == null) {
             return true;
         }
@@ -301,7 +353,26 @@ public class UniHttpServer {
         // #5299 sub-PR B: filters now read directly from EventMeshFrame.attributes() — no more
         // CE bridge. Tenant still comes from the CloudEvent extension ("emtenantid") which the
         // cloudevents FrameAdaptor round-trips into frame attributes under the same key.
-        if (filterChain != null) {
+        // #5304: unified gate (auth + ACL + quota + audit) when installed; legacy
+        // filterChain path retained for deployments that only configured the chain.
+        if (securityGate != null) {
+            String credential = exchange.getRequestHeaders().getFirst("Authorization");
+            String tenant = frame.attributes().get("emtenantid");
+            org.apache.eventmesh.runtime.security.gate.RequestContext rc =
+                org.apache.eventmesh.runtime.security.gate.RequestContext.builder(
+                        org.apache.eventmesh.runtime.security.gate.RequestContext.Operation.PUBLISH)
+                    .topic(topic)
+                    .tenantId(tenant)
+                    .credential(credential)
+                    .remoteAddress(exchange.getRemoteAddress().getAddress().getHostAddress())
+                    .source("http")
+                    .build();
+            org.apache.eventmesh.runtime.security.gate.GateDecision decision = securityGate.check(rc, frame);
+            if (!decision.isAllowed()) {
+                writeJson(exchange, decision.getRejectStatus(), error(decision.getReason()));
+                return;
+            }
+        } else if (filterChain != null) {
             String credential = exchange.getRequestHeaders().getFirst("Authorization");
             String tenant = frame.attributes().get("emtenantid");
             org.apache.eventmesh.runtime.security.FilterContext ctx =

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/AuditSink.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/AuditSink.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.security.gate;
+
+/**
+ * Audit sink SPI (issue #5304): every authorized operation passing {@link SecurityGate} is
+ * reported here, giving deployments a single hook to stream audit events to a log, SIEM or
+ * Meta-backed store.
+ *
+ * <p>Implementations must be non-throwing and fast — the audit path must not fail the request.
+ * The default {@link #disabled()} drops events.</p>
+ */
+public interface AuditSink {
+
+    /** Outcome of the operation being audited. */
+    enum Outcome {
+        ALLOWED,
+        DENIED,
+        QUOTA_EXCEEDED
+    }
+
+    /**
+     * Record one authorization decision. Called after {@link SecurityGate#check} decided;
+     * exceptions are swallowed by the caller, so implementations should guard their own I/O.
+     *
+     * @param context the request context that was checked
+     * @param outcome the decision
+     * @param detail  optional reason (deny reason, quota resource, ...)
+     */
+    void emit(RequestContext context, Outcome outcome, String detail);
+
+    /** A sink that drops everything (auditing off). */
+    static AuditSink disabled() {
+        return DisabledAuditSink.INSTANCE;
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/ConnectorAccessDeniedException.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/ConnectorAccessDeniedException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.security.gate;
+
+/** Thrown when {@link SecurityGate} denies a ConnectorScheduler operation (issue #5304). */
+public class ConnectorAccessDeniedException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ConnectorAccessDeniedException(String reason) {
+        super(reason);
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/DisabledAuditSink.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/DisabledAuditSink.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.security.gate;
+
+/** Singleton used by {@link AuditSink#disabled()}. Package-private. */
+final class DisabledAuditSink implements AuditSink {
+
+    static final DisabledAuditSink INSTANCE = new DisabledAuditSink();
+
+    private DisabledAuditSink() {
+    }
+
+    @Override
+    public void emit(RequestContext context, Outcome outcome, String detail) {
+        // no-op
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/GateDecision.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/GateDecision.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.security.gate;
+
+import org.apache.eventmesh.runtime.security.gate.QuotaManager.Resource;
+
+/**
+ * Result of {@link SecurityGate#check}. Mirrors {@link org.apache.eventmesh.runtime.security.FilterVerdict}
+ * statuses and adds quota semantics (HTTP 429).
+ */
+public final class GateDecision {
+
+    /** HTTP 429 Too Many Requests. */
+    public static final int STATUS_QUOTA_EXCEEDED = 429;
+
+    private final boolean allowed;
+    private final int rejectStatus;
+    private final String reason;
+    private final Resource quotaResource;
+
+    private GateDecision(boolean allowed, int rejectStatus, String reason, Resource quotaResource) {
+        this.allowed = allowed;
+        this.rejectStatus = rejectStatus;
+        this.reason = reason;
+        this.quotaResource = quotaResource;
+    }
+
+    static GateDecision allowed() {
+        return new GateDecision(true, 0, null, null);
+    }
+
+    static GateDecision denied(int httpStatus, String reason) {
+        return new GateDecision(false, httpStatus, reason, null);
+    }
+
+    static GateDecision quotaExceeded(Resource resource) {
+        return new GateDecision(false, STATUS_QUOTA_EXCEEDED,
+            "quota exceeded: " + resource.name(), resource);
+    }
+
+    public boolean isAllowed() {
+        return allowed;
+    }
+
+    /** HTTP-equivalent status when denied: 401, 403 or 429. */
+    public int getRejectStatus() {
+        return rejectStatus;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    /** The exhausted resource when {@link #isQuotaExceeded()}, else {@code null}. */
+    public Resource getQuotaResource() {
+        return quotaResource;
+    }
+
+    public boolean isQuotaExceeded() {
+        return rejectStatus == STATUS_QUOTA_EXCEEDED;
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/LoggingAuditSink.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/LoggingAuditSink.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.security.gate;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Default {@link AuditSink}: one structured INFO line per authorized operation, one WARN line
+ * per denial / quota rejection — cheap enough for every deployment, greppable for ops.
+ *
+ * <p>Deployments needing SIEM streaming implement {@link AuditSink} and inject it into
+ * {@link SecurityGate} instead.</p>
+ */
+@Slf4j
+public final class LoggingAuditSink implements AuditSink {
+
+    public static final LoggingAuditSink INSTANCE = new LoggingAuditSink();
+
+    private LoggingAuditSink() {
+    }
+
+    @Override
+    public void emit(RequestContext context, Outcome outcome, String detail) {
+        switch (outcome) {
+            case ALLOWED:
+                log.info("AUDIT allowed op={} principal={} topic={} quotaKey={} source={} remote={}",
+                    context.getOperation(), context.getPrincipal(), context.getTopic(),
+                    context.getQuotaKey(), context.getSource(), context.getRemoteAddress());
+                break;
+            case DENIED:
+                log.warn("AUDIT denied op={} principal={} topic={} source={} reason={}",
+                    context.getOperation(), context.getPrincipal(), context.getTopic(),
+                    context.getSource(), detail);
+                break;
+            case QUOTA_EXCEEDED:
+                log.warn("AUDIT quota op={} quotaKey={} resource={} source={}",
+                    context.getOperation(), context.getQuotaKey(), detail, context.getSource());
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/QuotaManager.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/QuotaManager.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.security.gate;
+
+/**
+ * Quota accounting SPI (issue #5304): subscription, connection, throughput and backlog limits
+ * per {@code quotaKey} (tenant by default). Implementations track per-key usage and decide
+ * whether a new unit of work is admitted.
+ *
+ * <p>Deliberately synchronous and cheap — the gate calls it on every request, so
+ * implementations must not do remote lookups (they may be fed by a Meta watcher instead,
+ * mirroring how {@code AclFilter} hot-swaps its rule list).</p>
+ *
+ * <p>The default {@link #unlimited()} admits everything, preserving behavior for deployments
+ * that have not configured quotas.</p>
+ */
+public interface QuotaManager {
+
+    /** What is being accounted. */
+    enum Resource {
+        /** Concurrent connections / bound clients. */
+        CONNECTIONS,
+        /** Active subscriptions. */
+        SUBSCRIPTIONS,
+        /** Publish throughput (events per window). */
+        THROUGHPUT,
+        /** Undelivered backlog events. */
+        BACKLOG
+    }
+
+    /**
+     * Try to acquire {@code units} of {@code resource} under {@code quotaKey}.
+     *
+     * @return {@code true} if admitted (usage increased); {@code false} if the quota is
+     *         exhausted — the caller MUST reject the request with 429 semantics.
+     */
+    boolean tryAcquire(String quotaKey, Resource resource, long units);
+
+    /**
+     * Release previously-acquired units (connection closed, subscription removed, backlog
+     * drained). Optional for THROUGHPUT (window-based counters self-expire); required for
+     * CONNECTIONS / SUBSCRIPTIONS / BACKLOG or they leak.
+     */
+    void release(String quotaKey, Resource resource, long units);
+
+    /** A no-op quota manager that admits everything. */
+    static QuotaManager unlimited() {
+        return UnlimitedQuotaManager.INSTANCE;
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/RequestContext.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/RequestContext.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.security.gate;
+
+import org.apache.eventmesh.runtime.security.FilterContext;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Unified identity + policy context flowing through every ingress path (issue #5304):
+ * publish, subscribe, ACK, Connector and A2A. Built once at the protocol edge (HTTP handler,
+ * TCP bridge, A2A gateway handler, connector scheduler) and passed to
+ * {@link SecurityGate#check}, so authentication, authorization (ACL), quota enforcement and
+ * audit emission all read the <b>same</b> context instead of each protocol re-deriving its own.
+ *
+ * <p>Replaces ad-hoc {@link FilterContext} construction scattered across handlers. The legacy
+ * {@link FilterContext} is retained (filters still consume it); {@link #toFilterContext()}
+ * bridges losslessly.</p>
+ *
+ * <h2>Field semantics</h2>
+ * <ul>
+ *   <li>{@code tenantId} — the multi-tenant namespace the caller belongs to. Topics are
+ *       implicitly namespaced under it for ACL purposes ({@code tenantA.*} rules).</li>
+ *   <li>{@code principal} — the authenticated identity used by ACL rules. Falls back to
+ *       tenantId, then clientId (mirrors the legacy AclFilter choice).</li>
+ *   <li>{@code roles} / {@code scopes} — optional RBAC / OAuth-style grants from the auth
+ *       layer; future filters may match on them, core only carries them.</li>
+ *   <li>{@code quotaKey} — the accounting identity for {@link QuotaManager}. Defaults to
+ *       {@code tenantId} when present, else {@code clientId}, else {@code "anonymous"} so
+ *       unauthenticated traffic shares one bucket instead of bypassing quota.</li>
+ *   <li>{@code operation} — what the caller is trying to do; drives ACL action matching
+ *       (the legacy path passed {@code null} and let any action rule match).</li>
+ * </ul>
+ *
+ * <p>Immutable; build via {@link Builder}. None of the getters return {@code null} maps.</p>
+ */
+public final class RequestContext {
+
+    /** What the caller is attempting; maps onto {@code AclRule.Action} for authorization. */
+    public enum Operation {
+        PUBLISH,
+        SUBSCRIBE,
+        ACK,
+        /** Connector source/sink operations (ConnectorScheduler paths). */
+        CONNECTOR,
+        /** A2A task submit / get / cancel / stream. */
+        A2A,
+        /** Admin endpoints (agent register/unregister, session management). */
+        ADMIN
+    }
+
+    private final Operation operation;
+    private final String topic;
+    private final String clientId;
+    private final String tenantId;
+    private final String principal;
+    private final Set<String> roles;
+    private final Set<String> scopes;
+    private final String credential;
+    private final String remoteAddress;
+    /** Where the request entered: "http", "tcp", "a2a", "connector", "admin". */
+    private final String source;
+    private final String quotaKey;
+    /** Opaque trace propagation headers (traceparent, baggage, ...). */
+    private final Map<String, String> traceContext;
+
+    private RequestContext(Builder b) {
+        this.operation = Objects.requireNonNull(b.operation, "operation");
+        this.topic = b.topic;
+        this.clientId = b.clientId;
+        this.tenantId = b.tenantId;
+        this.principal = b.principal != null ? b.principal
+            : (b.tenantId != null ? b.tenantId : b.clientId);
+        this.roles = b.roles == null ? Collections.emptySet() : Collections.unmodifiableSet(b.roles);
+        this.scopes = b.scopes == null ? Collections.emptySet() : Collections.unmodifiableSet(b.scopes);
+        this.credential = b.credential;
+        this.remoteAddress = b.remoteAddress;
+        this.source = b.source == null ? "unknown" : b.source;
+        this.quotaKey = b.quotaKey != null ? b.quotaKey
+            : (b.tenantId != null ? b.tenantId : (b.clientId != null ? b.clientId : "anonymous"));
+        this.traceContext = b.traceContext == null
+            ? Collections.emptyMap()
+            : Collections.unmodifiableMap(new LinkedHashMap<>(b.traceContext));
+    }
+
+    public static Builder builder(Operation operation) {
+        return new Builder(operation);
+    }
+
+    public Operation getOperation() {
+        return operation;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public String getPrincipal() {
+        return principal;
+    }
+
+    public Set<String> getRoles() {
+        return roles;
+    }
+
+    public Set<String> getScopes() {
+        return scopes;
+    }
+
+    public String getCredential() {
+        return credential;
+    }
+
+    public String getRemoteAddress() {
+        return remoteAddress;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public String getQuotaKey() {
+        return quotaKey;
+    }
+
+    public Map<String, String> getTraceContext() {
+        return traceContext;
+    }
+
+    /**
+     * Bridge to the legacy {@link FilterContext} consumed by existing
+     * {@link org.apache.eventmesh.runtime.security.IngressFilter}s. Lossless for the fields the
+     * current filters read (topic, clientId, tenant, credential, remoteAddress).
+     */
+    public FilterContext toFilterContext() {
+        return new FilterContext(topic, clientId, tenantId, credential, remoteAddress);
+    }
+
+    /** Maps this request's {@link Operation} onto the ACL rule action, or {@code null} for ADMIN. */
+    org.apache.eventmesh.runtime.security.AclRule.Action aclAction() {
+        switch (operation) {
+            case PUBLISH:
+                return org.apache.eventmesh.runtime.security.AclRule.Action.PUBLISH;
+            case SUBSCRIBE:
+            case ACK:
+                return org.apache.eventmesh.runtime.security.AclRule.Action.SUBSCRIBE;
+            case A2A:
+                return org.apache.eventmesh.runtime.security.AclRule.Action.REQUEST;
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "RequestContext{op=" + operation + ", topic=" + topic + ", principal=" + principal
+            + ", quotaKey=" + quotaKey + ", source=" + source + "}";
+    }
+
+    /** Fluent builder. Only {@code operation} is required. */
+    public static final class Builder {
+
+        private final Operation operation;
+        private String topic;
+        private String clientId;
+        private String tenantId;
+        private String principal;
+        private Set<String> roles;
+        private Set<String> scopes;
+        private String credential;
+        private String remoteAddress;
+        private String source;
+        private String quotaKey;
+        private Map<String, String> traceContext;
+
+        private Builder(Operation operation) {
+            this.operation = operation;
+        }
+
+        public Builder topic(String topic) {
+            this.topic = topic;
+            return this;
+        }
+
+        public Builder clientId(String clientId) {
+            this.clientId = clientId;
+            return this;
+        }
+
+        public Builder tenantId(String tenantId) {
+            this.tenantId = tenantId;
+            return this;
+        }
+
+        public Builder principal(String principal) {
+            this.principal = principal;
+            return this;
+        }
+
+        public Builder roles(Set<String> roles) {
+            this.roles = roles;
+            return this;
+        }
+
+        public Builder scopes(Set<String> scopes) {
+            this.scopes = scopes;
+            return this;
+        }
+
+        public Builder credential(String credential) {
+            this.credential = credential;
+            return this;
+        }
+
+        public Builder remoteAddress(String remoteAddress) {
+            this.remoteAddress = remoteAddress;
+            return this;
+        }
+
+        public Builder source(String source) {
+            this.source = source;
+            return this;
+        }
+
+        public Builder quotaKey(String quotaKey) {
+            this.quotaKey = quotaKey;
+            return this;
+        }
+
+        public Builder traceContext(Map<String, String> traceContext) {
+            this.traceContext = traceContext;
+            return this;
+        }
+
+        public RequestContext build() {
+            return new RequestContext(this);
+        }
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/SecurityGate.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/SecurityGate.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.security.gate;
+
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+import org.apache.eventmesh.runtime.security.FilterChain;
+import org.apache.eventmesh.runtime.security.FilterVerdict;
+
+import java.util.Objects;
+
+/**
+ * Unified security / quota / audit entrypoint (issue #5304). Every ingress path — HTTP publish,
+ * subscribe, ACK, Connector scheduler, A2A gateway — funnels through
+ * {@link #check(RequestContext, EventMeshFrame)} so policy is enforced in one place instead of
+ * being re-implemented per protocol.
+ *
+ * <p>Ordering: <b>auth/ACL first, then quota</b>. An authenticated-but-over-quota request
+ * consumes no quota slot and returns {@code 429} semantics via {@link GateDecision}; an
+ * unauthenticated request never reaches the quota counter. Audit is emitted for every
+ * decision (allowed, denied, quota-exceeded) — acceptance criterion "audit events are emitted
+ * for authorized operations".</p>
+ *
+ * <p>The gate reuses the existing {@link FilterChain} (TokenAuthFilter, AclFilter, ...) for
+ * authentication and authorization — it does not duplicate policy. What it adds is the uniform
+ * {@link RequestContext} plumbing, quota enforcement and audit emission.</p>
+ */
+public final class SecurityGate {
+
+    private final FilterChain filterChain;
+    private final QuotaManager quotaManager;
+    private final AuditSink auditSink;
+
+    /** Quota resource charged per operation type. */
+    private static QuotaManager.Resource resourceFor(RequestContext.Operation op) {
+        switch (op) {
+            case PUBLISH:
+                return QuotaManager.Resource.THROUGHPUT;
+            case SUBSCRIBE:
+                return QuotaManager.Resource.SUBSCRIPTIONS;
+            case ACK:
+                return QuotaManager.Resource.BACKLOG;
+            default:
+                // CONNECTOR / A2A / ADMIN: charged as throughput units of their own work.
+                return QuotaManager.Resource.THROUGHPUT;
+        }
+    }
+
+    public SecurityGate(FilterChain filterChain, QuotaManager quotaManager, AuditSink auditSink) {
+        this.filterChain = Objects.requireNonNull(filterChain, "filterChain");
+        this.quotaManager = quotaManager == null ? QuotaManager.unlimited() : quotaManager;
+        this.auditSink = auditSink == null ? AuditSink.disabled() : auditSink;
+    }
+
+    /**
+     * Check a request and charge quota for it. Never throws; the caller maps
+     * {@link GateDecision#isAllowed()} to a protocol-specific rejection (HTTP status, TCP error
+     * frame, Netty response).
+     *
+     * @param context identity + intent of the caller
+     * @param frame   the payload frame when one exists (publish path); may be {@code null} for
+     *                operations without a frame (agent register, task submit payloads are not
+     *                frames) — filters that need a frame treat null as a stub.
+     * @return the decision; callers SHOULD pass the release handle to {@link #release} when the
+     *         accounted unit ends (connection closed, subscription removed, backlog drained)
+     */
+    public GateDecision check(RequestContext context, EventMeshFrame frame) {
+        Objects.requireNonNull(context, "context");
+
+        // 1) Authentication + authorization via the existing filter chain.
+        EventMeshFrame effectiveFrame = frame != null ? frame
+            : EventMeshFrame.event(java.util.Collections.emptyMap(), new byte[0]);
+        FilterVerdict verdict = filterChain.check(effectiveFrame, context.toFilterContext());
+        if (!verdict.isAllowed()) {
+            audit(context, AuditSink.Outcome.DENIED, verdict.getReason());
+            return GateDecision.denied(verdict.getRejectStatus(), verdict.getReason());
+        }
+
+        // 2) Quota. Charge one unit of the resource this operation consumes.
+        QuotaManager.Resource resource = resourceFor(context.getOperation());
+        if (!quotaManager.tryAcquire(context.getQuotaKey(), resource, 1)) {
+            audit(context, AuditSink.Outcome.QUOTA_EXCEEDED, resource.name());
+            return GateDecision.quotaExceeded(resource);
+        }
+
+        // 3) Authorized + admitted.
+        audit(context, AuditSink.Outcome.ALLOWED, null);
+        return GateDecision.allowed();
+    }
+
+    /** Release a previously-charged unit (connection closed, subscription removed, backlog drained). */
+    public void release(RequestContext context, long units) {
+        quotaManager.release(context.getQuotaKey(), resourceFor(context.getOperation()), units);
+    }
+
+    private void audit(RequestContext context, AuditSink.Outcome outcome, String detail) {
+        try {
+            auditSink.emit(context, outcome, detail);
+        } catch (RuntimeException ignored) {
+            // audit must never fail the request
+        }
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/TenantQuotaManager.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/TenantQuotaManager.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.security.gate;
+
+import org.apache.eventmesh.runtime.security.gate.QuotaManager.Resource;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * In-memory per-tenant quota tracker (issue #5304 default implementation). Limits are uniform
+ * across tenants and set once at construction; per-tenant overrides are a Meta-backed follow-up
+ * (the constructor signature intentionally leaves room).
+ *
+ * <p>THROUGHPUT uses a fixed window ({@code windowMs}); counters reset lazily on the next
+ * acquire after the window rolls. CONNECTIONS / SUBSCRIPTIONS / BACKLOG are gauge-style —
+ * acquire/release must be paired or the usage leaks.</p>
+ *
+ * <p>Thread-safe; hot path is a single {@link AtomicLong#incrementAndGet} + compare.</p>
+ */
+public final class TenantQuotaManager implements QuotaManager {
+
+    private final long maxConnections;
+    private final long maxSubscriptions;
+    private final long maxThroughputPerWindow;
+    private final long maxBacklog;
+    private final long windowMs;
+
+    private final ConcurrentHashMap<String, Usage> usage = new ConcurrentHashMap<>();
+
+    private static final class Usage {
+
+        final AtomicLong connections = new AtomicLong();
+        final AtomicLong subscriptions = new AtomicLong();
+        final AtomicLong backlog = new AtomicLong();
+        volatile long windowStart = System.currentTimeMillis();
+        final AtomicLong throughput = new AtomicLong();
+
+        void rollWindow(long windowMs) {
+            long now = System.currentTimeMillis();
+            if (now - windowStart >= windowMs) {
+                throughput.set(0);
+                windowStart = now;
+            }
+        }
+    }
+
+    public TenantQuotaManager(long maxConnections, long maxSubscriptions,
+                              long maxThroughputPerWindow, long maxBacklog, long windowMs) {
+        this.maxConnections = maxConnections;
+        this.maxSubscriptions = maxSubscriptions;
+        this.maxThroughputPerWindow = maxThroughputPerWindow;
+        this.maxBacklog = maxBacklog;
+        this.windowMs = windowMs;
+    }
+
+    @Override
+    public boolean tryAcquire(String quotaKey, Resource resource, long units) {
+        Objects.requireNonNull(quotaKey, "quotaKey");
+        Usage u = usage.computeIfAbsent(quotaKey, k -> new Usage());
+        switch (resource) {
+            case CONNECTIONS:
+                return u.connections.incrementAndGet() <= maxConnections
+                    || rollback(u.connections, units);
+            case SUBSCRIPTIONS:
+                return u.subscriptions.incrementAndGet() <= maxSubscriptions
+                    || rollback(u.subscriptions, units);
+            case BACKLOG:
+                long backlog = u.backlog.addAndGet(units);
+                if (backlog > maxBacklog) {
+                    u.backlog.addAndGet(-units);
+                    return false;
+                }
+                return true;
+            case THROUGHPUT:
+            default:
+                synchronized (u) {
+                    u.rollWindow(windowMs);
+                }
+                return u.throughput.addAndGet(units) <= maxThroughputPerWindow
+                    || rollback(u.throughput, units);
+        }
+    }
+
+    private static boolean rollback(AtomicLong counter, long units) {
+        counter.addAndGet(-units);
+        return false;
+    }
+
+    @Override
+    public void release(String quotaKey, Resource resource, long units) {
+        Usage u = usage.get(quotaKey);
+        if (u == null) {
+            return;
+        }
+        switch (resource) {
+            case CONNECTIONS:
+                u.connections.addAndGet(-units);
+                break;
+            case SUBSCRIPTIONS:
+                u.subscriptions.addAndGet(-units);
+                break;
+            case BACKLOG:
+                u.backlog.addAndGet(-units);
+                break;
+            case THROUGHPUT:
+            default:
+                // window-based; self-expiring, no explicit release
+                break;
+        }
+    }
+
+    /** Current usage snapshot (metrics / tests). */
+    public long currentUsage(String quotaKey, Resource resource) {
+        Usage u = usage.get(quotaKey);
+        if (u == null) {
+            return 0;
+        }
+        switch (resource) {
+            case CONNECTIONS:
+                return u.connections.get();
+            case SUBSCRIPTIONS:
+                return u.subscriptions.get();
+            case BACKLOG:
+                return u.backlog.get();
+            case THROUGHPUT:
+            default:
+                return u.throughput.get();
+        }
+    }
+
+    /** Drop all accounting for a key (tenant removed). */
+    public void remove(String quotaKey) {
+        usage.remove(quotaKey);
+    }
+
+    /** Visible for tests: expose the underlying map size. */
+    int trackedKeys() {
+        return usage.size();
+    }
+
+    /** Visible for tests. */
+    Map<String, Usage> usageMap() {
+        return usage;
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/UnlimitedQuotaManager.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/UnlimitedQuotaManager.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.security.gate;
+
+/** Singleton used by {@link QuotaManager#unlimited()}. Package-private. */
+final class UnlimitedQuotaManager implements QuotaManager {
+
+    static final UnlimitedQuotaManager INSTANCE = new UnlimitedQuotaManager();
+
+    private UnlimitedQuotaManager() {
+    }
+
+    @Override
+    public boolean tryAcquire(String quotaKey, Resource resource, long units) {
+        return true;
+    }
+
+    @Override
+    public void release(String quotaKey, Resource resource, long units) {
+        // no-op
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unified multi-tenant / security / quota entrypoint (issue #5304).
+ *
+ * <p>One {@link gate.RequestContext} — identity (tenant, principal, roles, scopes), intent
+ * (operation, topic), transport metadata (source, remote address, trace context) and quota
+ * identity — flows through every ingress path (publish / subscribe / ACK / Connector / A2A),
+ * and {@link gate.SecurityGate} enforces authentication + ACL (via the existing filter chain),
+ * quota ({@link gate.QuotaManager}) and audit ({@link gate.AuditSink}) in one place.</p>
+ */
+package org.apache.eventmesh.runtime.security.gate;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/security/gate/SecurityGateTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/security/gate/SecurityGateTest.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.security.gate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.eventmesh.runtime.security.AclRule;
+import org.apache.eventmesh.runtime.security.FilterChain;
+import org.apache.eventmesh.runtime.security.gate.AuditSink.Outcome;
+import org.apache.eventmesh.runtime.security.gate.QuotaManager.Resource;
+import org.apache.eventmesh.runtime.security.gate.RequestContext.Operation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the unified security/quota/audit gate (issue #5304).
+ *
+ * <p>Covers the three acceptance criteria: one RequestContext across operations, centralized
+ * ACL + quota enforcement, and audit events for authorized operations.</p>
+ */
+class SecurityGateTest {
+
+    /** Allow-all chain (no filters) — policy comes only from quota in these tests. */
+    private static FilterChain allowAll() {
+        return new FilterChain();
+    }
+
+    private static RequestContext ctx(Operation op, String tenant, String topic) {
+        return RequestContext.builder(op).tenantId(tenant).topic(topic).source("test").build();
+    }
+
+    // ============================ identity / principal ============================
+
+    @Test
+    void principalFallsBackToTenantThenClient() {
+        assertEquals("tenantA", ctx(Operation.PUBLISH, "tenantA", "t").getPrincipal());
+        RequestContext anonymous = RequestContext.builder(Operation.PUBLISH)
+            .clientId("client-1").topic("t").build();
+        assertEquals("client-1", anonymous.getPrincipal());
+        assertEquals("client-1", anonymous.getQuotaKey());
+    }
+
+    @Test
+    void quotaKeyDefaultsToTenant() {
+        assertEquals("tenantA", ctx(Operation.SUBSCRIBE, "tenantA", "t").getQuotaKey());
+        assertEquals("anonymous", RequestContext.builder(Operation.PUBLISH).build().getQuotaKey());
+    }
+
+    @Test
+    void aclActionMappingCoversAllOperations() {
+        assertEquals(AclRule.Action.PUBLISH, ctx(Operation.PUBLISH, "a", "t").aclAction());
+        assertEquals(AclRule.Action.SUBSCRIBE, ctx(Operation.SUBSCRIBE, "a", "t").aclAction());
+        assertEquals(AclRule.Action.SUBSCRIBE, ctx(Operation.ACK, "a", "t").aclAction());
+        assertEquals(AclRule.Action.REQUEST, ctx(Operation.A2A, "a", "t").aclAction());
+        assertNull(ctx(Operation.ADMIN, "a", "t").aclAction());
+        assertNull(ctx(Operation.CONNECTOR, "a", "t").aclAction());
+    }
+
+    // ============================ allow path ============================
+
+    @Test
+    void allowedRequestPassesAndAudits() {
+        AtomicInteger allowed = new AtomicInteger();
+        List<String> outcomes = new ArrayList<>();
+        SecurityGate gate = new SecurityGate(allowAll(), QuotaManager.unlimited(),
+            (c, o, d) -> {
+                outcomes.add(o.name());
+                if (o == Outcome.ALLOWED) {
+                    allowed.incrementAndGet();
+                }
+            });
+        GateDecision decision = gate.check(ctx(Operation.PUBLISH, "tenantA", "orders"), null);
+        assertTrue(decision.isAllowed());
+        assertEquals(1, allowed.get());
+        assertEquals("ALLOWED", outcomes.get(0));
+    }
+
+    // ============================ ACL denial ============================
+
+    @Test
+    void aclDenyReturns403AndDoesNotConsumeQuota() {
+        // Chain with zero filters still allows; deny comes from a filter. Use AclFilter with
+        // empty rules → default-deny.
+        org.apache.eventmesh.runtime.security.AclFilter acl =
+            new org.apache.eventmesh.runtime.security.AclFilter(java.util.Collections.emptyList());
+        SecurityGate gate = new SecurityGate(new FilterChain(acl), QuotaManager.unlimited(),
+            AuditSink.disabled());
+        GateDecision decision = gate.check(ctx(Operation.PUBLISH, "tenantA", "orders"), null);
+        assertFalse(decision.isAllowed());
+        assertEquals(403, decision.getRejectStatus());
+    }
+
+    // ============================ quota ============================
+
+    @Test
+    void quotaExceededReturns429AndAudits() {
+        TenantQuotaManager quota = new TenantQuotaManager(
+            100, 100, 2, 100, 60_000); // throughput = 2 per window
+        List<Outcome> outcomes = new ArrayList<>();
+        SecurityGate gate = new SecurityGate(allowAll(), quota, (c, o, d) -> outcomes.add(o));
+
+        RequestContext publish = ctx(Operation.PUBLISH, "tenantA", "orders");
+        assertTrue(gate.check(publish, null).isAllowed());
+        assertTrue(gate.check(publish, null).isAllowed());
+        GateDecision third = gate.check(publish, null);
+        assertFalse(third.isAllowed());
+        assertEquals(GateDecision.STATUS_QUOTA_EXCEEDED, third.getRejectStatus());
+        assertEquals(Resource.THROUGHPUT, third.getQuotaResource());
+        assertEquals(Outcome.QUOTA_EXCEEDED, outcomes.get(outcomes.size() - 1));
+        // Other tenants unaffected
+        assertTrue(gate.check(ctx(Operation.PUBLISH, "tenantB", "orders"), null).isAllowed());
+    }
+
+    @Test
+    void subscriptionsAreCountedPerTenant() {
+        TenantQuotaManager quota = new TenantQuotaManager(100, 1, 100, 100, 60_000);
+        SecurityGate gate = new SecurityGate(allowAll(), quota, AuditSink.disabled());
+        RequestContext sub = ctx(Operation.SUBSCRIBE, "tenantA", "orders");
+        assertTrue(gate.check(sub, null).isAllowed());
+        assertFalse(gate.check(sub, null).isAllowed()); // 2nd subscription over limit
+        // release → admitted again
+        gate.release(sub, 1);
+        assertTrue(gate.check(sub, null).isAllowed());
+    }
+
+    @Test
+    void backlogReleaseRestoresHeadroom() {
+        TenantQuotaManager quota = new TenantQuotaManager(100, 100, 100, 2, 60_000);
+        SecurityGate gate = new SecurityGate(allowAll(), quota, AuditSink.disabled());
+        RequestContext ack = ctx(Operation.ACK, "tenantA", "orders");
+        assertTrue(gate.check(ack, null).isAllowed());
+        assertTrue(gate.check(ack, null).isAllowed());
+        assertFalse(gate.check(ack, null).isAllowed()); // backlog full
+        gate.release(ack, 2);
+        assertTrue(gate.check(ack, null).isAllowed());
+    }
+
+    // ============================ audit robustness ============================
+
+    @Test
+    void throwingAuditSinkDoesNotFailTheRequest() {
+        SecurityGate gate = new SecurityGate(allowAll(), QuotaManager.unlimited(),
+            (c, o, d) -> {
+                throw new IllegalStateException("sink down");
+            });
+        assertTrue(gate.check(ctx(Operation.PUBLISH, "t", "x"), null).isAllowed());
+    }
+
+    // ============================ TenantQuotaManager window ============================
+
+    @Test
+    void throughputWindowRolls() throws InterruptedException {
+        TenantQuotaManager quota = new TenantQuotaManager(100, 100, 1, 100, 50); // 50ms window
+        assertTrue(quota.tryAcquire("k", Resource.THROUGHPUT, 1));
+        assertFalse(quota.tryAcquire("k", Resource.THROUGHPUT, 1));
+        Thread.sleep(80);
+        assertTrue(quota.tryAcquire("k", Resource.THROUGHPUT, 1));
+    }
+}


### PR DESCRIPTION
## What

Closes #5304 — a unified multi-tenant / security / quota entrypoint: one `RequestContext` flows through **publish / subscribe / ACK / Connector / A2A**, and `SecurityGate` centralizes ACL enforcement, quota accounting and audit emission in a single place.

## Why

TLS, mTLS and rate limiting exist today as point capabilities: the HTTP server hand-builds `FilterContext` at two call sites, the A2A gateway has no auth at all, connector CRUD is ungated, there is no quota beyond a per-topic token bucket inside `UniIngressService`, and no audit trail. Every protocol re-derives identity its own way, and `AclFilter` matches actions with `null` because the intent isn't carried.

## What changes

### New package `org.apache.eventmesh.runtime.security.gate` (11 files)

| Class | Role |
|---|---|
| `RequestContext` | Immutable identity + intent: `tenantId`, `principal`, `roles`, `scopes`, `credential`, `remoteAddress`, `source`, `traceContext`, `quotaKey`, `operation` (`PUBLISH/SUBSCRIBE/ACK/CONNECTOR/A2A/ADMIN`). `quotaKey` defaults to tenant → client → `"anonymous"` (unauthenticated traffic shares one bucket instead of bypassing quota). Bridges losslessly to the legacy `FilterContext`. |
| `SecurityGate` | The single `check(RequestContext, EventMeshFrame)` entrypoint. Ordering: **auth/ACL first** (delegates to the existing `FilterChain` — no policy duplication), **then quota** (a denied request never consumes quota), **then audit** for every outcome. Audit exceptions are swallowed — auditing can never fail a request. |
| `QuotaManager` (SPI) | `tryAcquire/release` per `(quotaKey, Resource)` — `CONNECTIONS / SUBSCRIPTIONS / THROUGHPUT / BACKLOG`. `QuotaManager.unlimited()` preserves current behavior. |
| `TenantQuotaManager` | In-memory default: per-tenant gauges + fixed-window throughput counters; hot path is one `AtomicLong` compare. |
| `AuditSink` (SPI) + `LoggingAuditSink` | One structured INFO line per authorized op, WARN for denials/quota. SIEM implementations plug the same SPI. |
| `GateDecision` | allow / deny(401/403) / quotaExceeded(429 + exhausted resource). |
| `ConnectorAccessDeniedException` | ConnectorScheduler denial surface. |

### Wiring — **opt-in; `null` gate = existing behavior, zero regression**

| Path | Hook | Operation |
|---|---|---|
| HTTP | `UniHttpServer.withSecurityGate(gate)` — `checkSecurity()` gates every endpoint (op inferred from path), publish endpoint passes the real frame | PUBLISH / SUBSCRIBE / ACK / ADMIN |
| A2A | `A2AGatewayHttpHandler.withSecurityGate(gate)` — every `/a2a/*` request gated in `channelRead0` (principal = `Authorization` header) | A2A |
| Connector | `ConnectorScheduler.withSecurityGate(gate)` — `createConnector()` gated; denial throws `ConnectorAccessDeniedException` | CONNECTOR |

The legacy `filterChain`-only configuration keeps working unchanged; the gate *reuses* it rather than replacing it.

## Acceptance criteria (#5304)

- [x] A single `RequestContext` flows through publish / subscribe / ACK / Connector / A2A paths
- [x] ACL and quota enforcement is centralized, not scattered per protocol
- [x] Audit events are emitted for authorized operations

## Tests

`SecurityGateTest` — 10 tests: principal/quotaKey fallback chain, ACL-action mapping per operation, allow + audit emission, ACL deny (403, **no quota consumption**), throughput quota (429 + per-tenant isolation + window roll), subscription acquire/release cycle, backlog release, throwing-audit-sink isolation.

```
eventmesh-runtime: 10/10 passed
./gradlew :eventmesh-runtime:check  →  BUILD SUCCESSFUL (compile + test + checkstyle + spotbugs)
```

## Out of scope (follow-ups)

- **Boot wiring** — composing `SecurityGate` (chain + quota config + sink) in `UniRuntime` from `eventmesh.properties`; this PR ships the SPIs, default impls and per-entrypoint hooks so operators can install a gate today and the boot wiring is a small config-reading change.
- **Meta-backed quotas/audit** — per-tenant quota overrides and audit persistence to the Meta layer (same hot-swap pattern as `AclFilter.setRules`).
- **Tenant namespace enforcement on topic names** — `tenantA.` prefix policy on top of ACL rules.
