### PR TITLE
Fix broken deployment links in the top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,7 @@ Apache EventMesh is packed with features that help users build event-driven appl
 
 ## Quick start
 
-This section of the guide will show you the steps to deploy EventMesh from [Local](#run-eventmesh-runtime-locally), [Docker](#run-eventmesh-runtime-in-docker), [K8s](#run-eventmesh-runtime-in-kubernetes).  
-
-This section guides the launch of EventMesh according to the default configuration, if you need more detailed EventMesh deployment steps, please visit the [EventMesh official document](https://eventmesh.apache.org/docs/introduction).
+This quick start deploys EventMesh Runtime with Docker using the default configuration. For other deployment options and detailed instructions, see the [EventMesh documentation](https://eventmesh.apache.org/docs/introduction).
 
 #### 1. Pull EventMesh Image
 


### PR DESCRIPTION
## Summary
- fix the README Quick start text to match the Docker-only steps that follow
- remove three broken internal links to sections that do not exist
- point readers to the official documentation for other deployment options

## Validation
- `git diff --check && git diff -- README.md`
- focused Python check confirms the README has no broken internal anchors


<!-- repo-agent-case:a4932942-9f43-4b01-b9e2-3a9220b26e8a -->