### PR TITLE
docs: downgrade Connector Runtime Beta -> Experimental (follow-up to #5326, sync with #5328)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ status. See [docs](docs/) for the per-capability guides.
 | [HTTP + CloudEvents](docs/eventmesh-client-guide.md) | **GA target** | Recommended — the primary user path (`CloudEventsClient` + `/events/*`) | Primary path |
 | [Kafka / RocketMQ storage](eventmesh-storage-plugin/) (4.x, 5.x) | **GA target** | Recommended — pluggable WAL backends, TCK-covered (`MeshStoragePluginTCK`) | Primary path |
 | SSE / WebSocket push | **Beta** | Usable — integration-tested; unified ACK/redelivery semantics still landing | Unified push transports |
-| Connector Runtime | **Beta** | Usable — 24 connector plugins on the standalone runtime | New connector SPI migration |
+| Connector Runtime | **Experimental** | Working end-to-end, but only 4 of 23 plugins (file/kafka/pulsar/rocketmq) have unit tests — the rest are templates; data-loss hardening landed in [#5328](https://github.com/apache/eventmesh/pull/5328) | SPI split into `eventmesh-connector-api` (#5328); remaining plugin tests + GA criteria tracked under the #5296 architecture review |
 | [A2A / Agent Gateway](docs/eventmesh-a2a-protocol.md) | **Experimental** | Evaluate — task store + runtime bridge landed (#5302/#5304); reaper & Meta-backed agent cards pending | Unified Runtime A2A |
 | TCP / gRPC / OpenMessaging SDKs | **Legacy-compatible** | Existing users only — kept so old clients run unmodified; not extended | [HTTP + CloudEvents](docs/eventmesh-client-guide.md) |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -65,7 +65,7 @@ Apache EventMesh 提供了丰富的能力，帮助用户轻松构建事件驱动
 | [HTTP + CloudEvents](docs/eventmesh-client-guide.md) | **GA 目标** | 推荐——主用户路径（`CloudEventsClient` + `/events/*`） | 主路径 |
 | [Kafka / RocketMQ 存储](eventmesh-storage-plugin/)（4.x、5.x） | **GA 目标** | 推荐——可插拔 WAL 后端，TCK 覆盖（`MeshStoragePluginTCK`） | 主路径 |
 | SSE / WebSocket 推送 | **Beta** | 可用——已有集成测试；统一 ACK/重投递语义仍在收敛 | 统一推送传输 |
-| Connector Runtime | **Beta** | 可用——独立运行时上的 24 个连接器插件 | 新连接器 SPI 迁移 |
+| Connector Runtime | **Experimental** | 端到端可用，但 23 个插件中仅 4 个（file/kafka/pulsar/rocketmq）有单元测试，其余为模板实现；数据丢失加固已由 [#5328](https://github.com/apache/eventmesh/pull/5328) 落地 | SPI 拆分至 `eventmesh-connector-api`（#5328）；剩余插件测试与 GA 标准由 #5296 架构 review 跟踪 |
 | [A2A / Agent 网关](docs/eventmesh-a2a-protocol.md) | **实验性** | 评估——TaskStore + Runtime 桥已落地（#5302/#5304）；reaper 与 Meta 化 AgentCard 待做 | 统一 Runtime A2A |
 | TCP / gRPC / OpenMessaging SDK | **Legacy 兼容** | 仅存量用户——保持老客户端零改动运行；不再扩展 | [HTTP + CloudEvents](docs/eventmesh-client-guide.md) |
 

--- a/docs/eventmesh-features.md
+++ b/docs/eventmesh-features.md
@@ -285,7 +285,7 @@ Plugins shipping today cover the common categories:
 
 **Where the code lives.**
 
-* SPI: `eventmesh-connector-plugin/eventmesh-connector-api/`
+* SPI: `eventmesh-connector-api/` (top-level module since #5328)
 * Host: `eventmesh-connector-runtime/.../ConnectorManager.java`,
   `eventmesh-connector-runtime/.../ConnectorAdminServer.java`
 * Per-connector source: `eventmesh-connector-plugin/eventmesh-connector-<name>/`
@@ -300,9 +300,12 @@ eventmesh.connector.<id>.mode = source-sink
 eventmesh.connector.<id>.topic = persistent://public/default/file-events
 ```
 
-**Status.** **Beta** (capability status table). The 24 plugins are
-production-usable; the new connector SPI migration (#5288) is still being
-rolled out across the plugins.
+**Status.** **Experimental** (capability status table). The runtime
+itself is end-to-end working and hardened against the data-loss failure
+class of #5231/#5232/#5233 (#5328), and the SPI now lives in its own
+`eventmesh-connector-api` module. But of the 23 plugins only four
+(file/kafka/pulsar/rocketmq) carry unit tests — the rest are template
+implementations. GA requires tests across the plugin matrix.
 
 ---
 


### PR DESCRIPTION
### Motivation

Follow-up to the docs-status sync (#5326, issue #5306): the capability status table marks **Connector Runtime as Beta**, but the connector review (under the #5296 architecture review) found that only 4 of 23 plugins (file/kafka/pulsar/rocketmq) carry unit tests — the rest are template implementations. Beta overstates maturity; this downgrades it to **Experimental** with an accurate note about what has actually landed.

### Modifications

- `README.md` — Connector Runtime row: `Beta` → `Experimental`, notes the 4/23 test coverage and links #5328 (data-loss hardening + SPI split)
- `README.zh-CN.md` — same row, Chinese
- `docs/eventmesh-features.md` §8 — status paragraph rewritten (Experimental + rationale); SPI module path corrected to the new top-level `eventmesh-connector-api/` (introduced by #5328; the old path under `eventmesh-connector-plugin/` never existed)
- Removed a stale `#5288` reference from the features doc (that issue is the sticky-mode heartbeat bug, unrelated to connector SPI migration)

### Documentation

Self-documenting: this PR *is* a docs change; the status tags in `docs/eventmesh-features.md` remain the single source of truth per #5306.

### Verifying this patch

Docs-only change; rendered both README tables and the §8 paragraph locally to confirm formatting.
