### PR TITLE
docs(#5295): attribute RocketMQ 5 POP broker-ACK barrier to PR #5316 (zhang-arvin)

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/UniIngressService.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/UniIngressService.java
@@ -372,7 +372,9 @@ public class UniIngressService {
                 // Frame architecture: the POP check key rides in frame attributes (empopck) and the
                 // deferred broker ACK fires on client ACK — same at-least-once goal, Frame-native.
                 long offset = nextOffset(topic);
-                // P2 fix: if the frame carries a POP check key (RocketMQ 5.x deferred ACK), build a
+                // P2 fix (PR #5316 by zhang-arvin, fixes #5295): if the frame carries a POP check
+                // key (RocketMQ 5.x deferred ACK), build a callback that ACKs the broker on
+                // client ACK (restoring at-least-once).
                 // callback that ACKs the broker on client ACK (restoring at-least-once).
                 String popCk = f.attributes().get("empopck");
                 List<Subscription> targets = subscriptionManager.targetsFor(topic, f);


### PR DESCRIPTION
Adds a one-line attribution Javadoc in front of the RocketMQ 5 POP broker-ACK barrier block in `UniIngressService.deliver`, expanding the single-line `// P2 fix:` comment (preserved from the #5330 merge of PR #5316) into a 3-line block that references the originating PR (#5316) and the issue it fixes (#5295). The author is recorded as zhang-arvin (`arvin.zhang@htx-inc.com`) and the commit message carries the matching `Co-authored-by` trailer so the next reader can trace the broker-ACK semantics back to the original contribution.

**No behavior change.** The barrier logic (AtomicInteger + per-delivery decrement + late broker ack) is byte-identical to the #5330 merge of #5316; this PR only extends the immediately-preceding comment.

**Why a separate PR for a comment-only change?** The author/co-authored-by trailer on the squash-merged #5330 commit (`c7de75b`) does not include zhang-arvin — the squash merger (`Eason Chen <qqeasonchen@gmail.com>`) replaced the original author in the squash. The companion fix for #5325 (PR #5331) used this same pattern (a 0-diff PR with a `Co-authored-by: wangyusheng1985` trailer) to record that contributor's credit; this PR mirrors that approach for #5316.

**Author attribution** (commit metadata, not the GH UI):
- author: `zhang-arvin <arvin.zhang@htx-inc.com>`
- author date: 2026-08-30T15:24:59+08:00 (matches zhang-arvin's original #5316 commit)
- committer: `qqeasonchen <qqeasonchen@gmail.com>`
- committer date: now

**Files changed**: 1 file, +3 / -1 (comment block only)
- `eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/UniIngressService.java`

**References**:
- Original PR: https://github.com/apache/eventmesh/pull/5316
- zhang-arvin's original commit: `1cdca51f` (`fix/5295-pop-broker-ack-barrier`)
- Issue: #5295
- Code landed in #5330 (squash-merged as `c7de75b`)
- Companion attribution PR for #5325: #5331

cc @zhang-arvin — please let me know if you'd prefer a different attribution form (e.g. moving the comment to the class-level Javadoc) and I'll adjust.