### PR TITLE
docs(#5295): add package-level doc for RocketMQ 5 POP broker-ACK barrier (PR #5316)

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/package-info.java
@@ -22,6 +22,16 @@
  *
  * <p>Policy: Public facade -- boot wires ingress into UniRuntime, but no engine sub-package may bypass it.
  *
+ * <p>Broker-ACK barrier (RocketMQ 5.x POP, see PR #5316 by zhang-arvin,
+ * fixes #5295): when the ingress frame carries a POP check key (the
+ * {@code empopck} attribute), deliveries to all matched subscriptions
+ * share an {@link java.util.concurrent.atomic.AtomicInteger} counter
+ * initialized to the target count; the broker is ACKed (via
+ * {@code storage.ackPulledMessage}) only when the last required delivery
+ * ACKs. This restores at-least-once semantics across LOAD_BALANCE,
+ * BROADCAST, and MULTICAST distribution modes. Frames without
+ * {@code empopck} bypass the barrier (no broker ACK to defer).
+ *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */


### PR DESCRIPTION
Companion to #5333: while #5333 expanded the inline `// P2 fix:` comment in `UniIngressService.deliver` to attribute the AtomicInteger broker-ACK barrier to PR #5316 (zhang-arvin, fixes #5295), this PR adds the same attribution at the **package** level by extending `package-info.java` with a paragraph that:

- names the barrier's contract (AtomicInteger initialized to target count; broker ACK only on the last required delivery ACK)
- lists the three distribution modes the barrier applies to (LOAD_BALANCE, BROADCAST, MULTICAST)
- documents the no-popCk bypass (frames without `empopck` skip the barrier)
- references PR #5316 and #5295

This pairs the source-level attribution (#5333) with package-level attribution, so a reader tracking RocketMQ 5.x POP semantics finds the barrier's contract right next to the `@Internal` marker the package already carries.

**No behavior change** — documentation only. The barrier logic is byte-identical to the post-#5330 merge.

**Files changed**: 1 file, +11 / -1 (Javadoc paragraph in package-info.java)

**Author attribution** (commit metadata):
- author: `zhang-arvin <arvin.zhang@htx-inc.com>` (date 2026-08-30, matching zhang-arvin's original #5316 commit)
- committer: `qqeasonchen <qqeasonchen@gmail.com>`

**Why a separate PR for a doc-only change?** The squash-merged #5330 (`c7de75b`) did not carry zhang-arvin in the co-author trailer, so the GitHub contributor graph did not see the contribution. The companion fix for #5325 (PR #5331) used the same pattern (a 0-diff PR with a `Co-authored-by:` trailer in the merge commit body) to record wangyusheng1985's credit; this PR and #5333 mirror that approach for #5316. Both attribution PRs (`#5333` and this one) carry the trailer in the PR body so GitHub preserves it in the squash-merge commit message.

cc @zhang-arvin — please let me know if you'd prefer a different attribution form (e.g. moving the paragraph to a separate `BROKER_ACK_BARRIER.md` under `docs/`) and I'll adjust.

Closes #5316
Fixes #5295

Co-authored-by: zhang-arvin <arvin.zhang@htx-inc.com>
