### PR TITLE
fix(#5295): gate RocketMQ 5 POP broker ACK on distribution completion (PR #5316, with both contributor trailers)

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/UniIngressService.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/UniIngressService.java
@@ -372,13 +372,32 @@ public class UniIngressService {
                 // Frame architecture: the POP check key rides in frame attributes (empopck) and the
                 // deferred broker ACK fires on client ACK — same at-least-once goal, Frame-native.
                 long offset = nextOffset(topic);
-                // P2 fix: if the frame carries a POP check key (RocketMQ 5.x deferred ACK), build a
-                // callback that ACKs the broker on client ACK (restoring at-least-once).
+                // P2 fix (#5295, PR #5316 by zhang-arvin): if the frame carries a POP check key
+                // (RocketMQ 5.x deferred ACK), build a per-frame AtomicInteger counter
+                // initialized to the target count; the broker is ACKed only when the last
+                // required delivery ACKs (counter reaches 0). This restores at-least-once
+                // semantics across LOAD_BALANCE (1 target), BROADCAST (N targets), and
+                // MULTICAST (matched targets) without firing the broker ACK prematurely on
+                // the first client ACK of a multi-target delivery.
                 String popCk = f.attributes().get("empopck");
-                Runnable mqAck = (popCk != null) ? () -> storage.ackPulledMessage(topic, popCk) : null;
-                for (Subscription target : subscriptionManager.targetsFor(topic, f)) {
-                    dispatcher.deliver(topic, partition, offset, f, target.getClientId(),
-                        channelFor(target.getClientId()), mqAck);
+                List<Subscription> targets = subscriptionManager.targetsFor(topic, f);
+                if (popCk != null && !targets.isEmpty()) {
+                    java.util.concurrent.atomic.AtomicInteger pending =
+                        new java.util.concurrent.atomic.AtomicInteger(targets.size());
+                    Runnable mqAck = () -> {
+                        if (pending.decrementAndGet() == 0) {
+                            storage.ackPulledMessage(topic, popCk);
+                        }
+                    };
+                    for (Subscription target : targets) {
+                        dispatcher.deliver(topic, partition, offset, f, target.getClientId(),
+                            channelFor(target.getClientId()), mqAck);
+                    }
+                } else {
+                    for (Subscription target : targets) {
+                        dispatcher.deliver(topic, partition, offset, f, target.getClientId(),
+                            channelFor(target.getClientId()), null);
+                    }
                 }
             }
             UniTrace.end(dispatchSpan);

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/package-info.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/package-info.java
@@ -22,6 +22,16 @@
  *
  * <p>Policy: Public facade -- boot wires ingress into UniRuntime, but no engine sub-package may bypass it.
  *
+ * <p>Broker-ACK barrier (RocketMQ 5.x POP, PR #5316 by zhang-arvin,
+ * fixes #5295): when the ingress frame carries a POP check key (the
+ * {@code empopck} attribute), deliveries to all matched subscriptions
+ * share an {@link java.util.concurrent.atomic.AtomicInteger} counter
+ * initialized to the target count; the broker is ACKed (via
+ * {@code storage.ackPulledMessage}) only when the last required delivery
+ * ACKs. This restores at-least-once semantics across LOAD_BALANCE,
+ * BROADCAST, and MULTICAST distribution modes. Frames without
+ * {@code empopck} bypass the barrier (no broker ACK to defer).
+ *
  * <p>Marked {@link org.apache.eventmesh.common.Internal @Internal} as a
  * whole package; public types must carry {@link org.apache.eventmesh.common.Public @Public}.
  */


### PR DESCRIPTION
Combined re-land of the four earlier #5330 / #5331 / #5333 / #5334 commits (all reverted by #5335) as a single commit on develop, with both contributor trailers preserved.

**What this PR does**

- Reapplies the RocketMQ 5 POP broker-ACK barrier from PR #5316 (zhang-arvin, fixes #5295) onto the post-#5301-Sub-PR-B/C `UniIngressService.deliver` structure. The barrier is the AtomicInteger-based pattern: per-frame counter initialized to the target count; the broker is ACKed only when the last required delivery ACKs.
- Adds a 6-line source-level Javadoc in `UniIngressService.java` attributing the barrier block to PR #5316 and zhang-arvin.
- Adds a package-level paragraph in `ingress/package-info.java` describing the barrier's contract (AtomicInteger counter, broker ACK on last delivery, LOAD_BALANCE / BROADCAST / MULTICAST semantics, no-popCk bypass).
- Leaves README content unchanged: the 3 broken anchors originally targeted by #5325 (wangyusheng1985) were already removed by #5326 (docs: sync documentation with implementation status), so the README is already in its post-#5326 state.

**Why a single commit instead of four**

GitHub's contributor graph counts both `commit author` and `Co-authored-by:` trailers in the commit message. The earlier four-commit approach split the attribution across squash merges with inconsistent trailer handling. Consolidating into one PR with two trailers (zhang-arvin for #5316, wangyusheng1985 for #5325) preserves both contributors' graph credit in a single squash-merge commit.

**Files changed**: 2 files
- `eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/UniIngressService.java` (barrier block + attribution Javadoc)
- `eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/package-info.java` (package-level barrier doc)

**Closes #5316, Closes #5325, Fixes #5295**

cc @zhang-arvin @wangyusheng1985

Co-authored-by: zhang-arvin <arvin.zhang@htx-inc.com>
Co-authored-by: wangyusheng1985 <wangyusheng1985@users.noreply.github.com>
