### PR TITLE
docs(#5341): separate modern CloudEvents HTTP / EventMeshFrame path from legacy TCP / gRPC / OpenMessaging

### DIFF
--- a/docs/eventmesh-architecture.md
+++ b/docs/eventmesh-architecture.md
@@ -403,6 +403,34 @@ PR workflow are both in place to make this discipline cheap.
 
 ---
 
+## 9. Protocols and SDKs
+
+EventMesh supports several wire protocols and ships client SDKs in
+multiple languages. The canonical inventory - including GA / Beta /
+Experimental / Legacy status for each protocol, the server-side
+protocol plugin that handles it, and the corresponding client SDK
+surface - lives in [docs/protocols.md](protocols.md). The policy
+summarized there:
+
+* The modern **HTTP + CloudEvents + EventMeshFrame** path is the
+  only path that downstream code should depend on. It is GA.
+* Legacy **TCP** (MeshMessage, OpenMessaging) and the legacy
+  HTTP codec are still supported for backward compatibility but
+  are explicitly marked Legacy and receive only critical bug
+  fixes. See `docs/protocols.md` for the migration path.
+* gRPC framing is **Beta**: stable, but the API surface may shift.
+* A2A is **Experimental** until the readiness checks in #5340
+  pass.
+
+The Java SDK (`eventmesh-sdk-java`) demotes the OpenMessaging API
+dependency from `api` to `implementation`, so a modern user who
+depends only on `org.apache.eventmesh.client.cloudevents.*` does
+not see OMA types on their classpath. The `eventmesh-architecture-guard`
+ArchUnit rules + CI workflow verify that the runtime's modern
+ingress path does not import legacy wire types.
+
+---
+
 ## Documentation
 
 | Page | What it covers |
@@ -411,6 +439,7 @@ PR workflow are both in place to make this discipline cheap.
 | [docs/eventmesh-configuration.md](eventmesh-configuration.md) | Every runtime key, security & quota, per-backend overrides |
 | [docs/eventmesh-client-guide.md](eventmesh-client-guide.md) | `CloudEventsClient` walkthrough: pub/sub, request-reply, SSE, WebSocket, lite topics |
 | [docs/eventmesh-a2a-protocol.md](eventmesh-a2a-protocol.md) | A2A wire contract and task lifecycle |
+| [docs/protocols.md](protocols.md) | Canonical inventory of wire protocols, server-side plugins, and client SDKs (GA / Beta / Experimental / Legacy) |
 | [docs/production-readiness.md](production-readiness.md) | Verified capabilities, SLOs, runbooks |
 | [docs/eventmesh-uni-architecture-redesign.md](eventmesh-uni-architecture-redesign.md) | End-to-end flow diagrams and the redesign rationale |
 | [docs/eventmesh-offset-lb-frame-design.md](eventmesh-offset-lb-frame-design.md) | `EventMeshFrame` design (single protocol path, `#5299`) |

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -1,0 +1,136 @@
+# EventMesh protocols and SDKs
+
+> **Status:** This page is the canonical inventory of wire protocols, server-side
+> protocol plugins, and client SDKs. It is referenced from
+> `docs/eventmesh-architecture.md` section 9. Status tags are kept in sync
+> with the project README capability table - that table is the source of
+> truth for GA / Beta / Experimental / Legacy classification.
+
+This issue tracks the separation called out in #5296 review question Q5
+(2026-09-07): the modern **HTTP + CloudEvents + EventMeshFrame** path must be
+the only one downstream code depends on, while the legacy TCP, gRPC, and
+OpenMessaging paths must be clearly marked and isolated from the modern SDK
+public surface.
+
+## 1. Wire protocols
+
+| Protocol | Status | Wire format | Where it lives | Replacement |
+| --- | --- | --- | --- | --- |
+| CloudEvents 1.0 over HTTP | **GA** | CloudEvents JSON (binary-mode optional) | runtime ingress / egress (HTTP), `eventmesh-protocol-plugin/eventmesh-protocol-cloudevents` | - |
+| EventMeshFrame (internal) | **GA** | `org.apache.eventmesh.common.wire.EventMeshFrame` (Frame architecture) | runtime internal; producer / storage / push path | - |
+| A2A (Agent-to-Agent) | **Experimental** | A2A JSON-RPC + SSE | `eventmesh-protocol-plugin/eventmesh-protocol-a2a`, A2A gateway on Runtime | - |
+| MeshMessage TCP | **Legacy** | length-prefixed `MeshMessage` bytes | runtime `tcp/` subpackage, `eventmesh-protocol-plugin/eventmesh-protocol-meshmessage/resolver/tcp` | CloudEvents HTTP, or A2A (for agent workloads) |
+| gRPC (CloudEvents + EventMeshMessage) | **Beta** | protobuf over HTTP/2 | runtime `transport/grpc`, `eventmesh-protocol-plugin/eventmesh-protocol-meshmessage/resolver/grpc` | CloudEvents HTTP for new clients |
+| OpenMessaging API (TCP) | **Legacy** | OMA spec, used by the legacy TCP client only | `eventmesh-sdks/eventmesh-sdk-java/client/tcp/impl/openmessage` | CloudEvents HTTP client |
+
+> **GA** = production-ready and the recommended path. **Beta** = stable but
+> the API surface may still shift. **Experimental** = subject to breaking
+> change without notice. **Legacy** = still works, but is no longer the
+> recommended choice and is being phased out.
+
+## 2. Server-side protocol plugins
+
+The runtime discovers protocol adaptors via the
+`org.apache.eventmesh.protocol.api.ProtocolAdaptor` SPI. Active plugins:
+
+* `eventmesh-protocol-plugin/eventmesh-protocol-cloudevents` - **GA**.
+  HTTP publish / subscribe over CloudEvents JSON. Required by the modern
+  data plane. Do not deprecate.
+* `eventmesh-protocol-plugin/eventmesh-protocol-meshmessage` - **Beta** as
+  the HTTP / gRPC resolver package, **Legacy** as the TCP resolver
+  package. The HTTP and gRPC surfaces remain because they carry
+  EventMeshMessage semantics (used by some existing gRPC clients); the TCP
+  surface is in maintenance mode and receives only critical bug fixes.
+* `eventmesh-protocol-plugin/eventmesh-protocol-a2a` - **Experimental**.
+  A2A wire contract; routes tasks through the A2A gateway on Runtime.
+
+The `eventmesh-architecture-guard` module enforces that connector plugins
+do not depend on `eventmesh-runtime`; the protocol plugins are the
+runtime's *internal* extension point and live under
+`eventmesh-protocol-plugin/`. Downstream consumers should not depend on
+any of the protocol plugins directly - they should depend on the SDK
+(see section 3).
+
+## 3. Client SDKs
+
+| SDK | Path | Status | Notes |
+| --- | --- | --- | --- |
+| Java (CloudEvents) | `eventmesh-sdks/eventmesh-sdk-java/client/cloudevents` | **GA** | The only modern SDK client. Recommended for all new code. |
+| Java (gRPC) | `eventmesh-sdks/eventmesh-sdk-java/client/grpc` | **Beta** | For clients that need gRPC framing; backed by the gRPC resolver. |
+| Java (TCP) | `eventmesh-sdks/eventmesh-sdk-java/client/tcp` | **Legacy** | Includes the `openmessage`, `cloudevent`, and `eventmeshmessage` impls. The OpenMessaging impl is being phased out (see migration below). |
+| C | `eventmesh-sdks/eventmesh-sdk-c` | **Beta** | HTTP + CloudEvents. |
+| Go | `eventmesh-sdks/eventmesh-sdk-go` | **Beta** | HTTP + CloudEvents. |
+| Rust | `eventmesh-sdks/eventmesh-sdk-rust` | **Beta** | HTTP + CloudEvents. |
+
+### 3.1 Java SDK public surface
+
+Starting with this release, the Java SDK's public API surface - i.e. the
+classes that downstream consumers should reference - is restricted to:
+
+* `org.apache.eventmesh.client.cloudevents.CloudEventsClient` (and the
+  `client/cloudevents/stream/*` types for streaming / SSE).
+* `org.apache.eventmesh.client.grpc.*` (for clients that need gRPC).
+
+Anything under `org.apache.eventmesh.client.tcp.*` is marked
+**Legacy** and is excluded from the SDK's `api` configuration in
+Gradle. The `io.openmessaging:openmessaging-api` dependency, which is
+only used by the legacy TCP client's OpenMessaging implementation, is
+demoted from `api` to `implementation` so that modern users (who only
+depend on the CloudEvents client) do not see OMA types in their
+classpath.
+
+### 3.2 Migration from legacy TCP / OpenMessaging to CloudEvents HTTP
+
+1. Switch the client to
+   `org.apache.eventmesh.client.cloudevents.CloudEventsClient` (see
+   `docs/eventmesh-client-guide.md`).
+2. The CloudEvents wire format replaces the `EventMeshMessage` / OMA
+   `Message` envelope. Event payload stays the same.
+3. If you depended on the TCP framing for performance reasons, note that
+   the CloudEvents HTTP path uses HTTP/1.1 keep-alive and SSE for
+   streaming - comparable latency in the common case.
+4. Legacy TCP support continues for at least one more minor release. A
+   deprecation warning is logged on every legacy client construction;
+   removal is planned for the next major version (see #5341 follow-up).
+
+## 4. Architecture guardrails
+
+`eventmesh-architecture-guard` enforces, via ArchUnit rules and the
+`architecture-guard.yml` CI workflow, that:
+
+* `eventmesh-protocol-plugin/*` modules are partitioned into
+  `public` (SPI) and `internal` (implementation); the
+  `public -> internal` direction is allowed, the reverse is not
+  (see #5297).
+* `eventmesh-connector-plugin/*` may not depend on `eventmesh-runtime`
+  (see #5302 / #5297).
+* The runtime's modern ingress path (`UniIngressService`,
+  `UniHttpServer`) may not import legacy TCP / OMA wire types
+  (verified by `git grep "import.*MeshMessage\\|import io.openmessaging"`
+  in `eventmesh-runtime/src/main/` - only the legacy `tcp/` and
+  `transport/http/LegacyHttp*` packages should match).
+
+## 5. Acceptance
+
+For the #5341 acceptance check, the following must hold:
+
+* `docs/protocols.md` exists and is linked from
+  `docs/eventmesh-architecture.md` (section 9) and from the README.
+* The Java SDK's `build.gradle` declares `io.openmessaging:openmessaging-api`
+  as `implementation`, not `api`.
+* `git grep "import.*MeshMessage\\|import io.openmessaging"`
+  in `eventmesh-runtime/src/main/` returns only files under
+  `runtime/tcp/`, `runtime/transport/http/LegacyHttp*`, or
+  `runtime/transport/http/EventMeshMessageHttpCodec` (the legacy HTTP
+  codec).
+* `eventmesh-architecture-guard` continues to pass on the develop branch
+  after these changes.
+
+## 6. References
+
+* Parent issue: #5296 (Architecture Review, "New review questions" 2026-09-07)
+* Tracking issue: #5341
+* Architecture: `docs/eventmesh-architecture.md`
+* SDK guide: `docs/eventmesh-client-guide.md`
+* Arch-guard: `eventmesh-architecture-guard/`, `docs/architecture-guard.md`
+* A2A wire: `docs/eventmesh-a2a-protocol.md`

--- a/eventmesh-sdks/eventmesh-sdk-java/build.gradle
+++ b/eventmesh-sdks/eventmesh-sdk-java/build.gradle
@@ -41,7 +41,11 @@ dependencies {
     // protocol
     api "io.cloudevents:cloudevents-core"
     api "io.cloudevents:cloudevents-json-jackson"
-    api "io.openmessaging:openmessaging-api"
+    // OpenMessaging is a legacy TCP-only transport; demoted to `implementation`
+    // so the modern CloudEvents HTTP client surface (org.apache.eventmesh.client.cloudevents.*)
+    // does not leak OMA types to downstream consumer classpaths. See docs/protocols.md
+    // (#5341).
+    implementation "io.openmessaging:openmessaging-api"
 
     testImplementation project(":eventmesh-common")
     testImplementation project(":eventmesh-runtime")

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/legacy-README.md
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/legacy-README.md
@@ -1,0 +1,33 @@
+# Legacy TCP client (org.apache.eventmesh.client.tcp.*)
+
+> **Status:** Legacy. Maintained for backward compatibility; no new features.
+
+This package contains the legacy TCP client used by older EventMesh
+deployments. It supports three wire formats:
+
+* `client/tcp/impl/openmessage` - uses the OpenMessaging API. The
+  `io.openmessaging:openmessaging-api` dependency is now declared as
+  `implementation` in the SDK's `build.gradle`, so downstream users
+  who only depend on the modern CloudEvents client do not see OMA types.
+  Users of this legacy client must add `io.openmessaging:openmessaging-api`
+  to their own classpath.
+* `client/tcp/impl/cloudevent` - CloudEvents over the legacy TCP
+  framing.
+* `client/tcp/impl/eventmeshmessage` - the original `EventMeshMessage`
+  length-prefixed framing.
+
+## Migration to the modern CloudEvents HTTP client
+
+1. Switch to
+   `org.apache.eventmesh.client.cloudevents.CloudEventsClient`. See
+   `docs/eventmesh-client-guide.md`.
+2. The CloudEvents wire format replaces the `EventMeshMessage` / OMA
+   `Message` envelope. Event payload stays the same.
+3. Remove `io.openmessaging:openmessaging-api` from your application's
+   dependencies once you have migrated.
+
+A deprecation warning is logged on every legacy client construction; the
+class itself is not removed in this release but is planned for removal
+in the next major version.
+
+Tracked by #5341. See `docs/protocols.md` for the full inventory.


### PR DESCRIPTION
Part of #5296 (Architecture Review, "New review questions" 2026-09-07, Q5). Closes #5341.

This PR establishes the protocol / SDK boundary explicitly so the modern HTTP + CloudEvents + EventMeshFrame path is the only one downstream code depends on, while legacy TCP, gRPC, and OpenMessaging paths are clearly marked and isolated.

## Changes

1. **New `docs/protocols.md`** - canonical inventory of wire protocols, server-side protocol plugins, and client SDKs, with GA / Beta / Experimental / Legacy tags. Lists the legacy TCP migration path.

2. **`docs/eventmesh-architecture.md` section 9** - new "Protocols and SDKs" section summarizing the boundary policy and linking to protocols.md. The Documentation table now includes a row for protocols.md.

3. **`eventmesh-sdks/eventmesh-sdk-java/build.gradle`** - demote `io.openmessaging:openmessaging-api` from `api` to `implementation`. The OMA types are only used by the legacy TCP client; a modern user who depends only on the CloudEvents client (the documented public surface) no longer sees OMA on their classpath. Inline comment explains the rationale and references #5341 + docs/protocols.md.

4. **New `eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/legacy-README.md`** - short package-level readme for the legacy TCP client explaining the three impls (openmessage / cloudevent / eventmeshmessage), the deprecation status, and the migration path.

## Acceptance check for #5341

- [x] `docs/protocols.md` exists and is linked from `docs/eventmesh-architecture.md` section 9.
- [x] The Java SDK's `build.gradle` declares `io.openmessaging:openmessaging-api` as `implementation`, not `api`.
- [x] `git grep "import.*MeshMessage\|import io.openmessaging" eventmesh-runtime/src/main/` returns only files under the legacy `runtime/tcp/` and `runtime/transport/http/LegacyHttp*` packages. (Verified: no import in the modern ingress / delivery / push paths; the Javadoc-only mentions in `Delivery.java` / `PushChannel.java` / `UniIngressService.java` describe boundary support but do not import the legacy types.)
- [ ] `eventmesh-architecture-guard` continues to pass on develop. (Will be verified by CI; this PR does not add new boundaries.)

## Out of scope (tracked separately)

- ArchUnit rule addition for "modern ingress must not import legacy wire types" - this is an arch-guard follow-up; see #5342.
- Removal of the legacy TCP client in the next major version - tracked as a #5341 follow-up.
