### PR TITLE
fix(#5356): fail fast on PARTITION_OWNED_PULL without shared MetaStore + arch-guard

### DIFF
--- a/eventmesh-architecture-guard/build.gradle
+++ b/eventmesh-architecture-guard/build.gradle
@@ -20,6 +20,17 @@
 // sub-packages. WARN in 1.13.0 (so existing violations don't break the build);
 // FAIL on violation starting 1.14.0.
 
+// Both kafka-clients (org.lz4:lz4-java) and rocketmq-common (at.yawk.lz4:lz4-java)
+// publish the same 'org.lz4:lz4-java' capability, and this module pulls both plugins
+// onto one test classpath. Pick the newer fork explicitly so Gradle can resolve.
+configurations.all {
+    resolutionStrategy.capabilitiesResolution.withCapability('org.lz4:lz4-java') {
+        def toBeSelected = candidates.find { it.id instanceof ModuleComponentIdentifier && it.id.module == 'lz4-java' && it.id.group == 'at.yawk.lz4' }
+        if (toBeSelected != null) { select(toBeSelected) }
+        because 'at.yawk.lz4:lz4-java is the maintained fork superseding org.lz4:lz4-java'
+    }
+}
+
 dependencies {
     implementation 'com.tngtech.archunit:archunit-junit5:1.3.0'
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'
@@ -51,6 +62,10 @@ dependencies {
     // needs the other plugins in scope. For now, kafka is the
     // only plugin we sample, matching the connector-file pattern.
     testImplementation project(':eventmesh-storage-plugin:eventmesh-storage-kafka')
+    // :eventmesh-storage-plugin:eventmesh-storage-rocketmq5 added with #5367: the
+    // FakeStorageCanary (#5348) imports a class from the rocketmq5 plugin package,
+    // which is not on the classpath via kafka (no transitive deps between plugins).
+    testImplementation project(':eventmesh-storage-plugin:eventmesh-storage-rocketmq5')
 }
 
 tasks.named('test') {

--- a/eventmesh-architecture-guard/src/main/java/org/apache/eventmesh/architecture/guard/ArchitectureRules.java
+++ b/eventmesh-architecture-guard/src/main/java/org/apache/eventmesh/architecture/guard/ArchitectureRules.java
@@ -137,12 +137,11 @@ public final class ArchitectureRules {
             .resideInAnyPackage(
                 "org.apache.eventmesh.storage.rocketmq..",
                 "org.apache.eventmesh.storage.rocketmq5..")
-            .orShould().dependOnClassesThat()
-            .resideInAnyPackage(
-                "org.apache.eventmesh.storage.rocketmq..",
-                "org.apache.eventmesh.storage.rocketmq5..")
             .because("storage plugins are independent backends; cross-plugin"
-                + " dependencies indicate accidental coupling");
+                + " dependencies indicate accidental coupling (kafka must not"
+                + " import rocketmq/rocketmq5; the symmetric directions are"
+                + " covered by the module graph, this rule guards the sampled"
+                + " canary direction)");
 
     /**
      * Storage plugins must not depend on eventmesh-runtime or connector
@@ -151,7 +150,8 @@ public final class ArchitectureRules {
      * MQ client library (org.apache.kafka, org.apache.rocketmq, etc.).
      */
     public static ArchRule ruleStoragePluginsDependOnlyOnApi = noClasses()
-            .that().resideInAPackage("org.apache.eventmesh.storage.kafka..")
+            .that().resideInAPackage("org.apache.eventmesh.storage..")
+            .and().resideOutsideOfPackage("org.apache.eventmesh.storage.api..")
             .should().dependOnClassesThat()
             .resideInAnyPackage(
                 "org.apache.eventmesh.runtime..",
@@ -159,4 +159,41 @@ public final class ArchitectureRules {
             .because("storage plugins are backend adapters; they depend on"
                 + " eventmesh-storage-api and the MQ client, not on runtime"
                 + " internals");
+
+    // ---- Production HA guardrails (issue #5356) ----
+
+    /**
+     * {@code InMemoryMetaStore} is the documented single-instance store. It may only be
+     * constructed (i.e. depended on at class level) from the boot package, which owns the
+     * LOCAL_STICKY_PULL vs cluster decision and the fail-fast contract of #5356: any other
+     * production class reaching for it indicates a silent isolation fallback (an instance
+     * that should share Meta state but quietly keeps it in-process).
+     */
+    public static ArchRule ruleInMemoryMetaStoreOnlyFromBoot = noClasses()
+            .that().resideInAPackage("org.apache.eventmesh..")
+            .and().resideOutsideOfPackage("org.apache.eventmesh.runtime.boot..")
+            .should().dependOnClassesThat()
+            .haveFullyQualifiedName("org.apache.eventmesh.runtime.cluster.InMemoryMetaStore")
+            .because("InMemoryMetaStore is the single-instance store; only the boot"
+                + " package may choose it (issue #5356: no silent isolation fallback)");
+
+    /**
+     * {@code PartitionOwnership} coordinates multiple instances through the shared
+     * {@code MetaStore}. Only the boot package (which wires the real MetaStore in) and the
+     * cluster package itself (the class + its unit-tested collaborators) may depend on it;
+     * in particular the HTTP/admin layer must go through the runtime, not construct its own
+     * ownership view.
+     */
+    public static ArchRule rulePartitionOwnershipOnlyFromBootAndCluster = noClasses()
+            .that().resideInAPackage("org.apache.eventmesh..")
+            .and().resideOutsideOfPackages(
+                "org.apache.eventmesh.runtime.boot..",
+                "org.apache.eventmesh.runtime.cluster..",
+                "org.apache.eventmesh.runtime.ingress..",
+                "org.apache.eventmesh.runtime.admin..")
+            .should().dependOnClassesThat()
+            .haveFullyQualifiedName("org.apache.eventmesh.runtime.cluster.PartitionOwnership")
+            .because("PartitionOwnership is cluster coordination state; only boot (wiring),"
+                + " cluster (implementation), ingress (poll filter) and admin (read-only view)"
+                + " may use it (issue #5356)");
 }

--- a/eventmesh-architecture-guard/src/test/java/org/apache/eventmesh/architecture/guard/ArchitectureRulesTest.java
+++ b/eventmesh-architecture-guard/src/test/java/org/apache/eventmesh/architecture/guard/ArchitectureRulesTest.java
@@ -113,6 +113,18 @@ class ArchitectureRulesTest {
         ArchitectureRules.ruleStoragePluginsDependOnlyOnApi.check(classes);
     }
 
+    // ---- Production HA guardrails (issue #5356) ----
+
+    @Test
+    void ruleInMemoryMetaStoreOnlyFromBoot_check() {
+        ArchitectureRules.ruleInMemoryMetaStoreOnlyFromBoot.check(classes);
+    }
+
+    @Test
+    void rulePartitionOwnershipOnlyFromBootAndCluster_check() {
+        ArchitectureRules.rulePartitionOwnershipOnlyFromBootAndCluster.check(classes);
+    }
+
     @Test
     void ruleStoragePluginsIsolated_catches() {
         // Canary: FakeStorageCanary lives in
@@ -122,7 +134,7 @@ class ArchitectureRulesTest {
         // explicitly and assert the rule fails with the canary named in
         // the violation report.
         JavaClasses withCanary = new com.tngtech.archunit.core.importer.ClassFileImporter()
-                .importPackages("org.apache.eventmesh.storage.fakeplugin");
+                .importPackages("org.apache.eventmesh.storage.kafka");
         AssertionError expected = assertThrows(AssertionError.class,
             () -> ArchitectureRules.ruleStoragePluginsIsolated.check(withCanary));
         assertTrue(expected.getMessage().contains("FakeStorageCanary"),

--- a/eventmesh-architecture-guard/src/test/java/org/apache/eventmesh/storage/kafka/FakeStorageCanary.java
+++ b/eventmesh-architecture-guard/src/test/java/org/apache/eventmesh/storage/kafka/FakeStorageCanary.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.eventmesh.storage.fakeplugin;
+package org.apache.eventmesh.storage.kafka;
 
 /**
  * Test canary for {@code ruleStoragePluginsIsolated}: a fake storage plugin

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/a2a/MetaAgentCardRegistry.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/a2a/MetaAgentCardRegistry.java
@@ -19,10 +19,8 @@ package org.apache.eventmesh.runtime.a2a;
 
 import org.apache.eventmesh.protocol.a2a.AgentIdentity;
 import org.apache.eventmesh.protocol.a2a.model.AgentCard;
-import org.apache.eventmesh.runtime.cluster.MetaListener;
 import org.apache.eventmesh.runtime.cluster.MetaStore;
 
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshApplication.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshApplication.java
@@ -20,6 +20,7 @@ package org.apache.eventmesh.runtime.boot;
 import org.apache.eventmesh.api.storage.MeshStoragePlugin;
 import org.apache.eventmesh.runtime.admin.UniAdminServer;
 import org.apache.eventmesh.runtime.admin.UniAdminService;
+import org.apache.eventmesh.runtime.cluster.DeliveryTopology;
 import org.apache.eventmesh.runtime.http.UniHttpServer;
 import org.apache.eventmesh.runtime.offset.OffsetStore;
 import org.apache.eventmesh.spi.EventMeshExtensionFactory;
@@ -345,11 +346,17 @@ public class EventMeshApplication {
         boolean clustered = !metaType.isEmpty() && !metaAddr.isEmpty();
         org.apache.eventmesh.runtime.cluster.MetaStore metaStore;
         if (clustered) {
-            metaStore = "nacos".equalsIgnoreCase(metaType)
-                ? new org.apache.eventmesh.runtime.cluster.NacosMetaStore(metaAddr)
-                : new org.apache.eventmesh.runtime.cluster.InMemoryMetaStore();
+            // #5356: in cluster mode an unknown meta type must fail fast — an in-memory store
+            // here would silently isolate this instance (no shared assignments, no fencing).
+            if (!"nacos".equalsIgnoreCase(metaType)) {
+                throw new IllegalStateException("unsupported eventmesh.meta.type='" + metaType
+                    + "': cluster mode requires a shared MetaStore (supported: nacos)");
+            }
+            metaStore = new org.apache.eventmesh.runtime.cluster.NacosMetaStore(metaAddr);
             log.info("meta store: type={} addr={}", metaType, metaAddr);
         } else {
+            // Single-instance (LOCAL_STICKY_PULL default): in-process store is the documented,
+            // intended mode — ConnectorScheduler keeps defs + worker registry local.
             metaStore = new org.apache.eventmesh.runtime.cluster.InMemoryMetaStore();
             log.info("meta store: in-memory (single-instance; cluster coordination disabled)");
         }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/UniRuntime.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/UniRuntime.java
@@ -21,7 +21,6 @@ import org.apache.eventmesh.api.storage.MeshStoragePlugin;
 import org.apache.eventmesh.runtime.cluster.ClusterMembership;
 import org.apache.eventmesh.runtime.cluster.DeliveryTopology;
 import org.apache.eventmesh.runtime.cluster.FencingToken;
-import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
 import org.apache.eventmesh.runtime.cluster.MetaStore;
 import org.apache.eventmesh.runtime.cluster.PartitionOwnership;
 import org.apache.eventmesh.runtime.ingress.UniIngressService;
@@ -168,14 +167,22 @@ public class UniRuntime {
     /**
      * Boot the {@link PartitionOwnership} state machine for {@link DeliveryTopology#PARTITION_OWNED_PULL}
      * topology (§13.2.3 / §13.2.8). Constructs a {@link ClusterMembership} + {@link PartitionOwnership}
-     * backed by an {@link InMemoryMetaStore} (production deployments inject a Nacos/etcd/ZK
-     * {@link MetaStore} via {@link #clusterMeta} before {@link #start()}). The ownership loop
+     * backed by the shared {@link MetaStore} injected via {@link #clusterMeta} (Nacos/etcd/ZK;
+     * {@link EventMeshApplication} wires it from eventmesh.meta.type/addr). Missing MetaStore
+     * fails fast (issue #5356) — never a silent in-process fallback. The ownership loop
      * acquires a strict subset of topic partitions via Meta CAS + fencing, and the pull loop polls
      * only owned partitions (no duplicate consumption across instances).
      */
     private void startPartitionOwnership() {
         if (clusterMeta == null) {
-            clusterMeta = new InMemoryMetaStore();
+            // #5356: PARTITION_OWNED_PULL must fail fast without a shared MetaStore. Silently
+            // degrading to an isolated in-process store would make a misconfigured cluster
+            // look healthy while every instance polls every partition (duplicate consumption,
+            // CAS/fencing ineffective). Production deployments inject the MetaStore via
+            // EventMeshApplication (eventmesh.meta.type/addr) or withClusterMeta before start().
+            throw new IllegalStateException(
+                "PARTITION_OWNED_PULL requires a shared MetaStore: set eventmesh.meta.type/addr"
+                    + " (e.g. nacos + address) or use LOCAL_STICKY_PULL for single-instance");
         }
         FencingToken token = new FencingToken();
         ClusterMembership membership = new ClusterMembership(

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/ClusterSubscriptionStore.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/ClusterSubscriptionStore.java
@@ -126,6 +126,12 @@ public class ClusterSubscriptionStore implements SubscriptionStore {
             ConcurrentHashMap<String, ClusterSub> subs = cache.get(topic);
             if (subs != null) {
                 subs.remove(clientId);
+                // Drop the topic bucket once the last subscriber leaves, so topics()
+                // reflects live topics only (StateStoreDurabilityTest Scenario 2; the
+                // poll loop iterates topics() every tick and must not retain ghosts).
+                if (subs.isEmpty()) {
+                    cache.remove(topic, subs);
+                }
             }
             return;
         }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/a2a/A2AGatewayFailureModeTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/a2a/A2AGatewayFailureModeTest.java
@@ -23,12 +23,11 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.apache.eventmesh.protocol.a2a.AgentIdentity;
 import org.apache.eventmesh.protocol.a2a.A2AMessageTransport;
+import org.apache.eventmesh.protocol.a2a.AgentIdentity;
 import org.apache.eventmesh.protocol.a2a.model.AgentCard;
 import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
 import org.apache.eventmesh.runtime.state.MetaBackedTaskStore;
-import org.apache.eventmesh.runtime.state.TaskStore;
 import org.apache.eventmesh.runtime.state.fault.MetaPartitionSwitch;
 import org.apache.eventmesh.runtime.state.fault.MetaPartitionSwitch.MetaPartitionException;
 
@@ -38,11 +37,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.cloudevents.CloudEvent;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import io.cloudevents.CloudEvent;
 
 /**
  * Issue #5340 D2a acceptance item 4: failure-mode test. The Meta backing the

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/a2a/MetaAgentCardRegistryTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/a2a/MetaAgentCardRegistryTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.eventmesh.protocol.a2a.AgentIdentity;
 import org.apache.eventmesh.protocol.a2a.model.AgentCard;
 import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
-import org.apache.eventmesh.runtime.cluster.MetaStore;
 
 import org.junit.jupiter.api.Test;
 

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/a2a/TaskExpirerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/a2a/TaskExpirerTest.java
@@ -59,11 +59,11 @@ class TaskExpirerTest {
     void evictsIdleTasksPastTtl() throws Exception {
         InMemoryMetaStore meta = new InMemoryMetaStore();
         TaskStore store = new MetaBackedTaskStore(meta);
-        // Use a 200ms TTL so the test does not need to sleep for 24h.
-        TaskExpirer reaper = new TaskExpirer(store, 200L, 60_000L, null);
         store.createTask("stale-1", "agent-A", "client-X", "{}");
         store.createTask("stale-2", "agent-A", "client-X", "{}");
         store.createTask("fresh-1", "agent-B", "client-Y", "{}");
+        // Use a 200ms TTL so the test does not need to sleep for 24h.
+        TaskExpirer reaper = new TaskExpirer(store, 200L, 60_000L, null);
         // No task is past the TTL yet.
         assertEquals(0, reaper.scan().size(),
             "no task is past the 200ms TTL immediately after creation");
@@ -104,12 +104,12 @@ class TaskExpirerTest {
         TaskStore store = new MetaBackedTaskStore(meta);
         AtomicReference<List<String>> lastEvicted = new AtomicReference<>();
         AtomicInteger calls = new AtomicInteger();
+        store.createTask("a", "agent-A", "client-X", "{}");
+        store.createTask("b", "agent-A", "client-X", "{}");
         TaskExpirer reaper = new TaskExpirer(store, 100L, 60_000L, ids -> {
             lastEvicted.set(new ArrayList<>(ids));
             calls.incrementAndGet();
         });
-        store.createTask("a", "agent-A", "client-X", "{}");
-        store.createTask("b", "agent-A", "client-X", "{}");
         advanceClock(150);
         reaper.scan();
         assertEquals(1, calls.get(), "listener was called exactly once");

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/boot/UniRuntimeTopologyWiringTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/boot/UniRuntimeTopologyWiringTest.java
@@ -58,6 +58,18 @@ class UniRuntimeTopologyWiringTest {
     private static final int PARTITIONS = 6;
 
     @Test
+    void partitionOwnedPullWithoutMetaStoreFailsFast() {
+        // #5356: PARTITION_OWNED_PULL + missing MetaStore must throw at start(), never
+        // silently degrade to an isolated in-process store (poll-all duplicate consumption).
+        UniRuntime runtime = new UniRuntime(new RecordingStorage(), new InMemoryOffsetStore(),
+            20L, 50L, 100, 50L, DeliveryTopology.PARTITION_OWNED_PULL, "A", "A:8080");
+        // clusterMeta deliberately left null
+        IllegalStateException ex = assertThrows(IllegalStateException.class, runtime::start);
+        assertTrue(ex.getMessage().contains("PARTITION_OWNED_PULL requires a shared MetaStore"),
+            "fail-fast message should explain the fix, got: " + ex.getMessage());
+    }
+
+    @Test
     void partitionOwnedPullSplitsPartitionsAcrossInstances() throws Exception {
         InMemoryMetaStore sharedMeta = new InMemoryMetaStore();
         RecordingStorage storageA = new RecordingStorage();

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/StateStoreDurabilityTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/StateStoreDurabilityTest.java
@@ -26,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.eventmesh.runtime.cluster.ClusterSubscriptionStore;
 import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
-import org.apache.eventmesh.runtime.offset.OffsetStore;
 import org.apache.eventmesh.runtime.offset.RocksDBOffsetStore;
 import org.apache.eventmesh.runtime.session.SessionRegistry;
 import org.apache.eventmesh.runtime.state.fault.MetaPartitionSwitch;
@@ -202,9 +201,9 @@ class StateStoreDurabilityTest {
 
             // Final state on A: the entry is either present (last write was a put)
             // or absent (last write was a remove). Both instances must agree.
-            String aView = a.instanceOf("storm-client");
-            String bView = b.instanceOf("storm-client");
-            assertEquals(aView, bView,
+            String viewA = a.instanceOf("storm-client");
+            String viewB = b.instanceOf("storm-client");
+            assertEquals(viewA, viewB,
                 "both instances must agree on the final binding (convergence)");
             // The first-scenario write (topic-1 / client-1) must still be
             // visible to both - watch prefix is durable across put/remove storms.
@@ -245,7 +244,6 @@ class StateStoreDurabilityTest {
             // A and B share the same Meta. Each has its own SessionRegistry (a
             // real deployment would have one per JVM).
             SessionRegistry a = new SessionRegistry(meta, 60_000L);
-            SessionRegistry b = new SessionRegistry(meta, 60_000L);
 
             // A registers agent X.
             List<String> caps = new ArrayList<>();
@@ -264,6 +262,7 @@ class StateStoreDurabilityTest {
             // B sees the unregister via the underlying Meta (no watch on
             // /em/agents/ in the production SessionRegistry; the matcher
             // re-reads on demand). The agent is gone.
+            SessionRegistry b = new SessionRegistry(meta, 60_000L);
             assertNull(b.agent("agent-X"));
 
             // B takes over: registers a fresh agent-X with a new capability set.


### PR DESCRIPTION
## What this PR does

Closes #5356 — Phase 0 enforcement of the production-HA plan (#5354): **`PARTITION_OWNED_PULL` must never silently degrade to an isolated in-process MetaStore.** Also repairs the compile/test/checkstyle breaks that landed on develop via the 2026-09-07/08 Actions-outage blind merges — all found by running the **complete CI pipeline locally** (same gradle tasks as `.github/workflows`).

### 1. Boot fail-fast (the #5356 core)

| Site | Before | After |
|---|---|---|
| `UniRuntime.startPartitionOwnership()` | `clusterMeta == null` → `new InMemoryMetaStore()` — a misconfigured cluster *looks* healthy while every instance polls every partition | `IllegalStateException`: `PARTITION_OWNED_PULL requires a shared MetaStore: set eventmesh.meta.type/addr (e.g. nacos + address) or use LOCAL_STICKY_PULL for single-instance` |
| `EventMeshApplication` cluster mode | unknown `eventmesh.meta.type` → silently `new InMemoryMetaStore()` in cluster mode | `IllegalStateException`: `unsupported eventmesh.meta.type='<type>': cluster mode requires a shared MetaStore (supported: nacos)` |

Single-instance mode (`LOCAL_STICKY_PULL` default) keeps the documented in-memory store.

### 2. ArchUnit guardrails (12 → 14 rules)

- **`ruleInMemoryMetaStoreOnlyFromBoot`** — only `runtime.boot..` may depend on `InMemoryMetaStore`.
- **`rulePartitionOwnershipOnlyFromBootAndCluster`** — `PartitionOwnership` visible only to boot / cluster / ingress / admin (read-only view).

### 3. Outage blind-merge repairs

| Break | Origin | Fix |
|---|---|---|
| `compileJava` **failed on develop** — missing `DeliveryTopology` import | #5344 | add import |
| guard module missing rocketmq5 dep + `org.lz4`/`at.yawk.lz4` capability conflict | #5348 | add dep + capabilitiesResolution |
| canary in `storage.fakeplugin..` never matched rule's that-clause → `_catches` always failed | #5348 | move canary to `storage.kafka` test pkg |
| `ClusterSubscriptionStore` empty-bucket leak → `topics()` returned ghost topics | #5345 | `cache.remove(topic, subs)` when empty |
| checkstyle `maxWarnings=0`: unused imports, import order, `aView`/`bView` naming, declaration-usage distance (`reaper` ×2, `SessionRegistry b`) | #5345/#5346 | all fixed |

### 4. Full local CI parity (Temurin 21.0.11)

Mirrors `.github/workflows/ci.yml` + `architecture-guard.yml` exactly:

```
./gradlew clean generateGrammarSource                              BUILD SUCCESSFUL
./gradlew :eventmesh-architecture-guard:architectureCheck          BUILD SUCCESSFUL
./gradlew clean build dist jacocoTestReport --parallel --daemon     -x spotlessJava -x generateGrammarSource -x generateDistLicense     -x checkDeniedLicense -x :eventmesh-architecture-guard:test   BUILD SUCCESSFUL (511 tasks, 10m47s)
./gradlew installPlugin                                            BUILD SUCCESSFUL
```

New tests: `partitionOwnedPullWithoutMetaStoreFailsFast`, `ruleInMemoryMetaStoreOnlyFromBoot_check`, `rulePartitionOwnershipOnlyFromBootAndCluster_check`.

### Relations

- Closes #5356 (Phase 0, P0)
- Parent: #5354 · Plan: `docs/architecture-review/production-ha-plan.md` (PR #5366)
- Unblocks #5359

Co-authored-by: qqeasonchen <qqeasonchen@gmail.com>