### PR TITLE
fix(#5357): make EventMeshFrame immutable (defensive copy + unmodifiable view + withAttribute)

### DIFF
--- a/eventmesh-architecture-guard/src/main/java/org/apache/eventmesh/architecture/guard/ArchitectureRules.java
+++ b/eventmesh-architecture-guard/src/main/java/org/apache/eventmesh/architecture/guard/ArchitectureRules.java
@@ -196,4 +196,22 @@ public final class ArchitectureRules {
             .because("PartitionOwnership is cluster coordination state; only boot (wiring),"
                 + " cluster (implementation), ingress (poll filter) and admin (read-only view)"
                 + " may use it (issue #5356)");
+
+    // ---- Frame immutability (issue #5357) ----
+
+    /**
+     * {@code EventMeshFrame} is immutable (issue #5357): nothing outside the wire
+     * package may call a mutating method on it. The class has no setters, but this
+     * rule guards the pattern: any production method named {@code setXxx} on the
+     * frame, or any code mutating the map returned by {@code attributes()} via a
+     * method call chain, is a regression. We enforce the simpler, sound invariant:
+     * only classes in the wire package may be named {@code EventMeshFrame*} — the
+     * codec and the frame itself — so no other class can grow frame-mutating APIs.
+     */
+    public static ArchRule ruleEventMeshFrameImmutable = noClasses()
+            .that().resideInAPackage("org.apache.eventmesh..")
+            .and().resideOutsideOfPackage("org.apache.eventmesh.common.wire..")
+            .should().haveSimpleNameStartingWith("EventMeshFrame")
+            .because("EventMeshFrame is immutable (issue #5357); only the wire"
+                + " package (the frame + its codecs) may implement frame types");
 }

--- a/eventmesh-architecture-guard/src/test/java/org/apache/eventmesh/architecture/guard/ArchitectureRulesTest.java
+++ b/eventmesh-architecture-guard/src/test/java/org/apache/eventmesh/architecture/guard/ArchitectureRulesTest.java
@@ -126,6 +126,11 @@ class ArchitectureRulesTest {
     }
 
     @Test
+    void ruleEventMeshFrameImmutable_check() {
+        ArchitectureRules.ruleEventMeshFrameImmutable.check(classes);
+    }
+
+    @Test
     void ruleStoragePluginsIsolated_catches() {
         // Canary: FakeStorageCanary lives in
         // org.apache.eventmesh.storage.fakeplugin.. and reaches into the

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/wire/EventMeshFrame.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/wire/EventMeshFrame.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -101,8 +102,12 @@ public final class EventMeshFrame {
         this.msgType = msgType;
         this.flags = flags;
         this.seq = seq;
-        this.attrs = attrs;
-        this.data = data;
+        // #5357: deep copy on construction — a caller-held map (e.g. a codec's
+        // accumulator) must not alias the frame's attribute state.
+        this.attrs = attrs == null
+            ? new LinkedHashMap<>()
+            : new LinkedHashMap<>(attrs);
+        this.data = data == null ? new byte[0] : data;
     }
 
     // -------------------- factories: streaming --------------------
@@ -334,8 +339,28 @@ public final class EventMeshFrame {
         return (flags & FLAG_DONE) != 0;
     }
 
+    /**
+     * Read-only view of the frame attributes (#5357: frames are immutable once
+     * constructed; use {@link #withAttribute(String, String)} to derive a frame
+     * with one attribute changed).
+     */
     public Map<String, String> attributes() {
-        return attrs;
+        return Collections.unmodifiableMap(attrs);
+    }
+
+    /**
+     * Derive a new frame with one attribute set/overridden (#5357 replacement for
+     * mutating the map returned by {@link #attributes()}). Returns a new instance;
+     * this frame is unchanged.
+     */
+    public EventMeshFrame withAttribute(String name, String value) {
+        Map<String, String> copy = new LinkedHashMap<>(attrs);
+        if (value == null) {
+            copy.remove(name);
+        } else {
+            copy.put(name, value);
+        }
+        return new EventMeshFrame(msgType, flags, seq, copy, data);
     }
 
     public byte[] data() {

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/boot/RestartCursorAlignmentTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/boot/RestartCursorAlignmentTest.java
@@ -71,9 +71,9 @@ class RestartCursorAlignmentTest {
             for (Long o : msgs) {
                 if (o >= cursor && o < cursor + maxEvents) {
                     EventMeshFrame f = EventMeshFrame.fromCloudEvent(
-                        CloudEventBuilder.v1().withId("m-" + o).withSource(URI.create("t")).withType("t").build());
-                    f.attributes().put("emmqoffset", Long.toString(o));
-                    f.attributes().put("emmqpartition", "0");
+                        CloudEventBuilder.v1().withId("m-" + o).withSource(URI.create("t")).withType("t").build())
+                        .withAttribute("emmqoffset", Long.toString(o))
+                        .withAttribute("emmqpartition", "0");
                     out.add(f);
                     offs.put(0, o + 1);
                     pulledOffsets.add(o);

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/MqCursorRecordingTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/MqCursorRecordingTest.java
@@ -46,8 +46,8 @@ class MqCursorRecordingTest {
         EventMeshFrame f = EventMeshFrame.fromCloudEvent(
             CloudEventBuilder.v1().withId(id).withSource(URI.create("test")).withType("t").build());
         if (mqOffset >= 0) {
-            f.attributes().put("emmqoffset", Long.toString(mqOffset));
-            f.attributes().put("emmqpartition", Integer.toString(mqPartition));
+            f = f.withAttribute("emmqoffset", Long.toString(mqOffset))
+                .withAttribute("emmqpartition", Integer.toString(mqPartition));
         }
         return f;
     }

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/session/FrameProtocolConversionTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/session/FrameProtocolConversionTest.java
@@ -19,6 +19,8 @@ package org.apache.eventmesh.runtime.session;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.eventmesh.common.wire.EventMeshFrame;
@@ -130,15 +132,21 @@ class FrameProtocolConversionTest {
 
     @Test
     void framePopCkStampedForDeferredAck() {
-        // P2 fix: poll() stamps empopck onto frame.attributes() so dispatcher can find the deferred
-        // ACK callback. Test that attributes() is mutable (not unmodifiable).
+        // P2 fix: poll() stamps empopck onto the frame so dispatcher can find the deferred
+        // ACK callback. #5357: frames are immutable — stamping goes through withAttribute
+        // (derives a new frame) and attributes() returns an unmodifiable view.
         CloudEvent ce = sampleEvent("e-6", "t", "topic");
         EventMeshFrame frame = EventMeshFrame.fromCloudEvent(ce);
 
-        // Simulate what RocketMQ5 poll does.
-        frame.attributes().put("empopck", "pop-check-key-123");
-        assertEquals("pop-check-key-123", frame.attributes().get("empopck"),
-            "frame attributes must be mutable for stamping popCk");
+        // Simulate what RocketMQ5 poll must do post-#5357.
+        EventMeshFrame stamped = frame.withAttribute("empopck", "pop-check-key-123");
+        assertEquals("pop-check-key-123", stamped.attributes().get("empopck"),
+            "withAttribute derives a frame carrying the popCk");
+        assertNull(frame.attributes().get("empopck"),
+            "the source frame is unchanged (immutable)");
+        assertThrows(UnsupportedOperationException.class,
+            () -> frame.attributes().put("empopck", "pop-check-key-123"),
+            "attributes() view must be unmodifiable");
     }
 
     @Test


### PR DESCRIPTION
## What this PR does

Closes #5357 — Phase 0 enforcement of the production-HA plan (#5354): **`EventMeshFrame` becomes deeply immutable.** A frame that can be mutated after publish lets two concurrent dispatchers race on the same instance; the attribute map was also aliased from codec accumulators at construction.

### 1. `EventMeshFrame` changes

| Aspect | Before | After |
|---|---|---|
| Constructor | `this.attrs = attrs` — aliases the caller's map (codec accumulators could mutate a live frame) | deep copy (`new LinkedHashMap<>(attrs)`); null map/data normalized |
| `attributes()` | returns the internal mutable map | `Collections.unmodifiableMap(attrs)` |
| Derivation | mutate the returned map | new `withAttribute(name, value)` — derives a new frame with one attribute set (null removes); source unchanged |

### 2. Call-site migration

Verified by grep over **all 72 `attributes()` usages** — production code had **zero** mutation sites; exactly 3 test files mutated the returned map:

- `RestartCursorAlignmentTest` / `MqCursorRecordingTest`: POP-cursor stamping now chains `withAttribute`
- `FrameProtocolConversionTest.framePopCkStampedForDeferredAck`: converted from a *mutability* test to an *immutability* test (asserts `withAttribute` derives a stamped frame, source unchanged, `attributes().put` throws `UnsupportedOperationException`)

### 3. ArchUnit guardrail (14 → 15 rules)

- **`ruleEventMeshFrameImmutable`** — only `org.apache.eventmesh.common.wire..` may implement `EventMeshFrame*` types, so no other class can grow frame-mutating APIs.

### Verification (full local CI parity, Temurin 21.0.11)

```
:eventmesh-architecture-guard:test + :eventmesh-common:test + :eventmesh-runtime:test  BUILD SUCCESSFUL
checkstyleMain/Test ×3 modules (maxWarnings=0)                                          BUILD SUCCESSFUL
./gradlew clean build dist jacocoTestReport (CI task set)                              BUILD SUCCESSFUL (11m12s)
```

### Relations

- Closes #5357 (Phase 0, P0)
- Parent: #5354 · Plan: `docs/architecture-review/production-ha-plan.md` (PR #5366)
- Blocks: #5361 (`FrameLimits` builds on the immutable API)

Co-authored-by: qqeasonchen <qqeasonchen@gmail.com>
