### PR TITLE
fix(#5358): QuotaHandle (AutoCloseable) + gate-scoped QuotaManager access

### DIFF
--- a/eventmesh-architecture-guard/src/main/java/org/apache/eventmesh/architecture/guard/ArchitectureRules.java
+++ b/eventmesh-architecture-guard/src/main/java/org/apache/eventmesh/architecture/guard/ArchitectureRules.java
@@ -214,4 +214,21 @@ public final class ArchitectureRules {
             .should().haveSimpleNameStartingWith("EventMeshFrame")
             .because("EventMeshFrame is immutable (issue #5357); only the wire"
                 + " package (the frame + its codecs) may implement frame types");
+
+    // ---- Quota lifecycle (issue #5358) ----
+
+    /**
+     * {@code QuotaManager.tryAcquire/release} may only be called from the
+     * {@code security.gate} package (the gate + its handle own the pairing;
+     * issue #5358). Any other production class calling the manager directly
+     * bypasses the release-handle contract and reintroduces the leak class
+     * where acquire has no guaranteed release.
+     */
+    public static ArchRule ruleQuotaManagerOnlyFromGate = noClasses()
+            .that().resideInAPackage("org.apache.eventmesh..")
+            .and().resideOutsideOfPackage("org.apache.eventmesh.runtime.security.gate..")
+            .should().dependOnClassesThat()
+            .haveFullyQualifiedName("org.apache.eventmesh.runtime.security.gate.QuotaManager")
+            .because("quota acquire/release must be paired through SecurityGate +"
+                + " QuotaHandle (issue #5358); direct QuotaManager calls leak slots");
 }

--- a/eventmesh-architecture-guard/src/test/java/org/apache/eventmesh/architecture/guard/ArchitectureRulesTest.java
+++ b/eventmesh-architecture-guard/src/test/java/org/apache/eventmesh/architecture/guard/ArchitectureRulesTest.java
@@ -131,6 +131,11 @@ class ArchitectureRulesTest {
     }
 
     @Test
+    void ruleQuotaManagerOnlyFromGate_check() {
+        ArchitectureRules.ruleQuotaManagerOnlyFromGate.check(classes);
+    }
+
+    @Test
     void ruleStoragePluginsIsolated_catches() {
         // Canary: FakeStorageCanary lives in
         // org.apache.eventmesh.storage.fakeplugin.. and reaches into the

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/QuotaExceededException.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/QuotaExceededException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.security.gate;
+
+/**
+ * Thrown by {@link SecurityGate#acquire} when the quota for the operation's
+ * resource is exhausted (issue #5358). No quota slot is consumed when thrown.
+ * HTTP handlers map this to {@code 429 Too Many Requests}.
+ */
+public final class QuotaExceededException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public QuotaExceededException(String message) {
+        super(message);
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/QuotaHandle.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/QuotaHandle.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.security.gate;
+
+/**
+ * Paired release handle for a quota acquisition (issue #5358 / plan #5354 Phase 0).
+ *
+ * <p>Gauge-style {@link QuotaManager.Resource} types (CONNECTIONS, SUBSCRIPTIONS,
+ * BACKLOG) must be released when the unit of work ends — connection closed,
+ * subscription removed, backlog drained. Calling {@code tryAcquire} without a
+ * guaranteed {@code release} leaks the slot. This handle makes the pairing
+ * structural: acquire returns it, {@link #close()} releases it exactly once,
+ * and try-with-resources keeps the release on the exception path.</p>
+ *
+ * <p>Window-style resources (THROUGHPUT counters self-expiring per window) may
+ * ignore the handle — closing is a no-op when {@code releasable} is false.</p>
+ */
+public final class QuotaHandle implements AutoCloseable {
+
+    private final QuotaManager manager;
+    private final String quotaKey;
+    private final QuotaManager.Resource resource;
+    private final long units;
+    private final boolean releasable;
+    private boolean closed;
+
+    QuotaHandle(QuotaManager manager, String quotaKey, QuotaManager.Resource resource,
+                long units, boolean releasable) {
+        this.manager = manager;
+        this.quotaKey = quotaKey;
+        this.resource = resource;
+        this.units = units;
+        this.releasable = releasable;
+    }
+
+    /** The resource this handle was acquired against. */
+    public QuotaManager.Resource resource() {
+        return resource;
+    }
+
+    /**
+     * Release the acquired units. Idempotent: a second {@code close()} is a no-op.
+     * No-op for non-releasable (window-style) acquisitions.
+     */
+    @Override
+    public void close() {
+        if (closed || !releasable) {
+            closed = true;
+            return;
+        }
+        closed = true;
+        manager.release(quotaKey, resource, units);
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/SecurityGate.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/SecurityGate.java
@@ -107,6 +107,35 @@ public final class SecurityGate {
         quotaManager.release(context.getQuotaKey(), resourceFor(context.getOperation()), units);
     }
 
+    /**
+     * Acquire one unit of this operation's resource and return a paired release
+     * handle (#5358). Auth/ACL runs first exactly like {@link #check}; the caller
+     * wraps the unit of work in try-with-resources so the slot is returned on
+     * success, failure and cancellation alike:
+     *
+     * <pre>{@code
+     * try (QuotaHandle h = gate.acquire(ctx, frame)) {
+     *     // gauge-style work (connection / subscription / backlog)
+     * }
+     * }</pre>
+     *
+     * <p>THROUGHPUT (window-style) handles are non-releasable — the counter
+     * self-expires per window; closing is a documented no-op.</p>
+     *
+     * @throws QuotaExceededException when the quota is exhausted (no slot consumed)
+     */
+    public QuotaHandle acquire(RequestContext context, EventMeshFrame frame) {
+        GateDecision decision = check(context, frame);
+        if (!decision.isAllowed()) {
+            throw new QuotaExceededException(decision.getReason());
+        }
+        QuotaManager.Resource resource = resourceFor(context.getOperation());
+        boolean releasable = resource == QuotaManager.Resource.CONNECTIONS
+            || resource == QuotaManager.Resource.SUBSCRIPTIONS
+            || resource == QuotaManager.Resource.BACKLOG;
+        return new QuotaHandle(quotaManager, context.getQuotaKey(), resource, 1, releasable);
+    }
+
     private void audit(RequestContext context, AuditSink.Outcome outcome, String detail) {
         try {
             auditSink.emit(context, outcome, detail);

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/security/gate/QuotaHandleTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/security/gate/QuotaHandleTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.security.gate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #5358 acceptance: the {@link QuotaHandle} pairing contract —
+ * acquire returns a handle, close releases exactly once, double-close is a
+ * no-op, and THROUGHPUT (window-style) handles do not release.
+ */
+class QuotaHandleTest {
+
+    /** Recording manager: captures tryAcquire/release pairs. */
+    private static final class RecordingManager implements QuotaManager {
+
+        final List<String> events = new ArrayList<>();
+
+        @Override
+        public boolean tryAcquire(String quotaKey, Resource resource, long units) {
+            events.add("acquire:" + resource + ":" + units);
+            return true;
+        }
+
+        @Override
+        public void release(String quotaKey, Resource resource, long units) {
+            events.add("release:" + resource + ":" + units);
+        }
+    }
+
+    private static SecurityGate gate(QuotaManager manager) {
+        // A bare FilterChain has no filters installed: every check passes, so the
+        // recording manager captures exactly the quota events we assert on.
+        return new SecurityGate(new org.apache.eventmesh.runtime.security.FilterChain(),
+            manager, null);
+    }
+
+    private static RequestContext ctx(RequestContext.Operation op) {
+        return RequestContext.builder(op).tenantId("t1").build();
+    }
+
+    @Test
+    void closeReleasesGaugeResourceExactlyOnce() {
+        RecordingManager recorder = new RecordingManager();
+        SecurityGate g = gate(recorder);
+        RequestContext context = ctx(RequestContext.Operation.SUBSCRIBE);
+        QuotaHandle handle = g.acquire(context, null);
+        handle.close();
+        handle.close();
+        assertEquals(List.of(
+            "acquire:SUBSCRIPTIONS:1",
+            "release:SUBSCRIPTIONS:1"),
+            recorder.events,
+            "gauge acquire must pair with exactly one release (double-close is a no-op)");
+    }
+
+    @Test
+    void tryWithResourcesReleasesOnException() {
+        RecordingManager recorder = new RecordingManager();
+        SecurityGate g = gate(recorder);
+        assertThrows(IllegalStateException.class, () -> {
+            try (QuotaHandle h = g.acquire(ctx(RequestContext.Operation.SUBSCRIBE), null)) {
+                throw new IllegalStateException("boom");
+            }
+        });
+        assertEquals(List.of(
+            "acquire:SUBSCRIPTIONS:1",
+            "release:SUBSCRIPTIONS:1"),
+            recorder.events,
+            "the release must run on the exception path");
+    }
+
+    @Test
+    void throughputHandleDoesNotRelease() {
+        RecordingManager recorder = new RecordingManager();
+        SecurityGate g = gate(recorder);
+        try (QuotaHandle h = g.acquire(ctx(RequestContext.Operation.PUBLISH), null)) {
+            assertEquals(QuotaManager.Resource.THROUGHPUT, h.resource());
+        }
+        assertEquals(List.of("acquire:THROUGHPUT:1"),
+            recorder.events,
+            "window-style THROUGHPUT counters self-expire; close is a documented no-op");
+    }
+
+    @Test
+    void acquireThrowsWhenQuotaExhaustedWithoutConsuming() {
+        QuotaManager exhausted = new QuotaManager() {
+            @Override
+            public boolean tryAcquire(String quotaKey, Resource resource, long units) {
+                return false;
+            }
+
+            @Override
+            public void release(String quotaKey, Resource resource, long units) {
+                throw new AssertionError("release must not be called when acquire was denied");
+            }
+        };
+        SecurityGate g = gate(exhausted);
+        QuotaExceededException ex = assertThrows(QuotaExceededException.class,
+            () -> g.acquire(ctx(RequestContext.Operation.SUBSCRIBE), null));
+        assertTrue(ex.getMessage() != null, "exception should carry the gate's reason");
+    }
+}


### PR DESCRIPTION
## What this PR does

Closes #5358 — Phase 0 enforcement of the production-HA plan (#5354): **quota acquire must have a guaranteed paired release.** Gauge-style resources (CONNECTIONS / SUBSCRIPTIONS / BACKLOG) leak when acquired and never returned; today nothing structural prevents the next call site from doing exactly that.

### 1. New API (`security.gate`)

| Class | Purpose |
|---|---|
| **`QuotaHandle`** (new) | `AutoCloseable` release handle. `close()` releases exactly once; double-close is a no-op; non-releasable (THROUGHPUT) handles don't release — window counters self-expire. |
| **`SecurityGate.acquire(ctx, frame)`** (new) | Same auth/ACL-first flow as `check()`, then returns the paired handle. Throws `QuotaExceededException` (new) when exhausted — no slot consumed. |
| `QuotaExceededException` (new) | HTTP handlers map to `429`. |

Callers wrap gauge work in try-with-resources so release runs on success, failure and cancellation alike:

```java
try (QuotaHandle h = gate.acquire(ctx, frame)) {
    // gauge-style work (connection / subscription / backlog)
}
```

### 2. ArchUnit guardrail (15 → 16 rules)

- **`ruleQuotaManagerOnlyFromGate`** — `QuotaManager.tryAcquire/release` may only be called from the `security.gate` package. Any direct manager call outside the gate bypasses the pairing contract and **fails the build**.

### 3. Verification (full local CI parity, Temurin 21.0.11)

```
QuotaHandleTest (new, 4 cases): close-releases-exactly-once · try-with-resources on exception ·
                                 THROUGHPUT no-release · exhausted-throws-without-consuming   PASS
checkstyleMain/Test + guard tests (maxWarnings=0)                                           BUILD SUCCESSFUL
./gradlew clean build dist jacocoTestReport (CI task set)                                  BUILD SUCCESSFUL (7m59s)
```

### Relations

- Closes #5358 (Phase 0, P0) — completes Phase 0 (all three guardrail issues #5356/#5357/#5358 landed)
- Parent: #5354 · Plan: `docs/architecture-review/production-ha-plan.md` (PR #5366)
- Unblocks #5362 (QuotaHandle + A2A operation classification builds on this API)

Co-authored-by: qqeasonchen <qqeasonchen@gmail.com>
