### PR TITLE
fix(#5360): fence stale owners from durable side effects (offsets / broker ACK)

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcher.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcher.java
@@ -247,6 +247,24 @@ public class ReliableDispatcher {
         this.deadLetterStore = deadLetterStore;
     }
 
+    /**
+     * Ownership view consulted before durable side effects (#5360). When non-null, {@link #ack}
+     * verifies this instance still owns the delivery's partition; a fenced owner drops the
+     * delivery (no offset write, no broker ACK) and raises {@link StaleOwnerException} to the
+     * trace, preserving at-least-once via broker POP redelivery to the new owner.
+     */
+    private volatile java.util.function.BiPredicate<String, Integer> ownershipGuard;
+
+    /**
+     * Install the ownership guard (topic, partition) -> stillOwner? (#5360). Wired from
+     * PartitionOwnership by UniRuntime/EventMeshApplication after the cluster meta is in;
+     * null (single-instance) keeps the unguarded behaviour.
+     */
+    public ReliableDispatcher withOwnershipGuard(java.util.function.BiPredicate<String, Integer> guard) {
+        this.ownershipGuard = guard;
+        return this;
+    }
+
     public UniMetrics metrics() {
         return metrics;
     }
@@ -296,6 +314,18 @@ public class ReliableDispatcher {
             liveDeliveries.remove(deliveryId);
             org.apache.eventmesh.runtime.metrics.UniTrace.end(ackSpan);
             return false;
+        }
+        // #5360: a fenced owner must not write offsets or ACK the broker — the partition has a
+        // newer owner in Meta. Drop the delivery (remove from the live/state stores) and let the
+        // broker's POP invisibleTime redeliver to the new owner; at-least-once is preserved and
+        // the new owner's offset state stays authoritative.
+        java.util.function.BiPredicate<String, Integer> guard = ownershipGuard;
+        if (guard != null && !guard.test(d.getTopic(), d.getPartition())) {
+            stateStore.remove(deliveryId);
+            liveDeliveries.remove(deliveryId);
+            metrics.incDlq();
+            org.apache.eventmesh.runtime.metrics.UniTrace.end(ackSpan);
+            throw new StaleOwnerException(d.getTopic(), d.getPartition());
         }
         boolean persisted = offsetStore.writeOffset(d.getTopic(), d.getClientId(), d.getPartition(), d.getOffset());
         if (!persisted) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/StaleOwnerException.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/StaleOwnerException.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.delivery;
+
+/**
+ * A stale partition owner tried to produce a durable side effect after being fenced
+ * (issue #5360, plan #5354 Phase 1). The ownership layer (Meta CAS + {@code FencingToken})
+ * moved the partition to a new instance; the old owner must drop the partition instead of
+ * writing offsets, ACKing the broker or routing to DLQ — otherwise the new owner's state
+ * and the stale owner's writes interleave (split-brain duplicates).
+ *
+ * <p>Carried effect: the pull loop removes the partition from its owned set on the next
+ * ownership refresh; the broker's POP invisibleTime redelivers in-flight messages to the
+ * new owner, preserving at-least-once.</p>
+ */
+public final class StaleOwnerException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String topic;
+    private final int partition;
+
+    public StaleOwnerException(String topic, int partition) {
+        super("stale owner fenced on " + topic + "#" + partition
+            + " (a newer FencingToken holds the Meta assignment; dropping the partition)");
+        this.topic = topic;
+        this.partition = partition;
+    }
+
+    /** The topic of the fenced partition. */
+    public String topic() {
+        return topic;
+    }
+
+    /** The fenced partition index. */
+    public int partition() {
+        return partition;
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/UniIngressService.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/UniIngressService.java
@@ -333,6 +333,9 @@ public class UniIngressService {
         java.util.List<Integer> owned = partitionOwnership == null ? null : partitionOwnership.ownedPartitions(topic);
         int total;
         if (owned == null) {
+            // #5360: no ownership view (single-instance / LOCAL_STICKY_PULL) -> poll all.
+            // In PARTITION_OWNED_PULL the runtime always installs the ownership view at boot
+            // (#5359), so a null here means single-instance — poll-all is the documented mode.
             total = pullAndDispatchPartition(topic, -1, maxEvents, timeoutMs);
         } else if (owned.isEmpty()) {
             total = 0; // owns none -> do not poll (avoids duplicate with the real owners)
@@ -648,6 +651,13 @@ public class UniIngressService {
      */
     public void withPartitionOwnership(org.apache.eventmesh.runtime.cluster.PartitionOwnership ownership) {
         this.partitionOwnership = ownership;
+        // #5360: propagate the ownership view to the dispatcher so a fenced owner cannot write
+        // offsets / ACK the broker after takeover. Guard semantics: still owning (topic, partition)
+        // per the CURRENT ownership snapshot — a partition that left our owned set fails the test.
+        dispatcher.withOwnershipGuard((topic, partition) -> {
+            java.util.List<Integer> owned = ownership.ownedPartitions(topic);
+            return owned != null && owned.contains(partition);
+        });
     }
 
     /** Wire the load meter; ingress/egress points call its record* methods. */

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/StaleOwnerFencingTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/StaleOwnerFencingTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.delivery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+import org.apache.eventmesh.runtime.offset.OffsetStore;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #5360 acceptance (plan #5354 Phase 1): a fenced (stale) owner must not produce durable
+ * side effects after takeover. The dispatcher's ownership guard rejects the ack — no offset
+ * write, no broker ACK callback — so the new owner's state stays authoritative and the broker's
+ * POP invisibleTime redelivers the message (at-least-once preserved).
+ */
+class StaleOwnerFencingTest {
+
+    /** Recording offset store: counts writes (the durable side effect under test). */
+    private static final class RecordingOffsetStore implements OffsetStore {
+
+        final Map<String, Long> writes = new HashMap<>();
+        final AtomicInteger writeCount = new AtomicInteger();
+
+        @Override
+        public boolean writeOffset(String topic, String clientId, int partition, long offset) {
+            writeCount.incrementAndGet();
+            writes.put(topic + "#" + clientId + "#" + partition, offset);
+            return true;
+        }
+
+        @Override
+        public long readOffset(String topic, String clientId, int partition) {
+            Long v = writes.get(topic + "#" + clientId + "#" + partition);
+            return v == null ? -1L : v;
+        }
+
+        @Override
+        public Map<String, Long> readAllOffsets(String topic) {
+            Map<String, Long> out = new HashMap<>();
+            writes.forEach((k, v) -> {
+                if (k.startsWith(topic + "#")) {
+                    out.put(k, v);
+                }
+            });
+            return out;
+        }
+
+        @Override
+        public void flush() {
+            // no-op
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+
+    private static EventMeshFrame frame(String id) {
+        return EventMeshFrame.event(new java.util.LinkedHashMap<>(Map.of("id", id)),
+            id.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void fencedOwnerAckWritesNoOffsetAndSkipsBrokerAck() {
+        RecordingOffsetStore offsets = new RecordingOffsetStore();
+        ReliableDispatcher dispatcher = new ReliableDispatcher(10_000L, 3, System::currentTimeMillis,
+            offsets, null, new org.apache.eventmesh.runtime.metrics.UniMetrics(),
+            0.0d, new org.apache.eventmesh.runtime.state.InMemoryDeliveryStateStore());
+
+        // Simulate takeover: this instance owns topic "orders" partition 1, but NOT partition 0
+        // (a newer owner holds partition 0 in Meta).
+        dispatcher.withOwnershipGuard((topic, partition) -> "orders".equals(topic) && partition == 1);
+
+        // Two deliveries: one on the still-owned partition, one on the fenced partition.
+        String owned = dispatcher.deliver("orders", 1, 10L, frame("owned"), "client",
+            (deliveryId, event, cb) -> { }, null);
+        final AtomicInteger fencedBrokerAcks = new AtomicInteger();
+        final String fenced = dispatcher.deliver("orders", 0, 5L, frame("fenced"), "client",
+            (deliveryId, event, cb) -> { }, fencedBrokerAcks::incrementAndGet);
+
+        // ack on the still-owned partition: normal path, offset written.
+        assertTrue(dispatcher.ack(owned), "still-owned partition ack must succeed");
+        assertEquals(1, offsets.writeCount.get(), "owned-partition ack writes its offset");
+        assertEquals(0, fencedBrokerAcks.get(),
+            "broker ACK must fire only from the still-owned ack path (this delivery had none yet)");
+
+        // ack on the fenced partition: rejected BEFORE any durable side effect.
+        StaleOwnerException ex = assertThrows(StaleOwnerException.class, () -> dispatcher.ack(fenced),
+            "a fenced owner's ack must throw");
+        assertEquals("orders", ex.topic());
+        assertEquals(0, ex.partition());
+        assertEquals(1, offsets.writeCount.get(),
+            "the fenced ack must NOT write any offset (no side effect)");
+        assertEquals(0, fencedBrokerAcks.get(), "the fenced ack must NOT ACK the broker");
+        assertFalse(dispatcher.ack(fenced), "the dropped delivery is no longer pending");
+    }
+
+    @Test
+    void noGuardKeepsSingleInstanceBehaviour() {
+        RecordingOffsetStore offsets = new RecordingOffsetStore();
+        ReliableDispatcher dispatcher = new ReliableDispatcher(10_000L, 3, System::currentTimeMillis,
+            offsets, null, new org.apache.eventmesh.runtime.metrics.UniMetrics(),
+            0.0d, new org.apache.eventmesh.runtime.state.InMemoryDeliveryStateStore());
+
+        String id = dispatcher.deliver("orders", 0, 5L, frame("x"), "client",
+            (deliveryId, event, cb) -> { }, null);
+        assertTrue(dispatcher.ack(id), "unguarded (single-instance) ack must succeed");
+        assertEquals(1, offsets.writeCount.get());
+        assertEquals(5L, offsets.readOffset("orders", "client", 0),
+            "unguarded ack persists the offset");
+    }
+}


### PR DESCRIPTION
## What this PR does

Closes #5360 — Phase 1 of the production-HA plan (#5354): **a fenced (stale) partition owner must not produce durable side effects after takeover** (acceptance B3 / C2 / C3).

### 1. The gap this fixes

`PartitionOwnership` acquires partitions via Meta CAS + `FencingToken`, but the dispatcher **never consulted the ownership view**. A stale owner whose lease was taken over kept writing offsets and ACKing the broker — the new owner's offset state and the stale owner's writes interleaved (split-brain duplicates).

### 2. Changes

| Change | Effect |
|---|---|
| `ReliableDispatcher.withOwnershipGuard(BiPredicate<topic, partition>)` | Installed by `UniIngressService.withPartitionOwnership` from the live `PartitionOwnership` snapshot |
| `ack()` consults the guard **before any durable effect** | A fenced owner drops the delivery (state + live stores), writes **no offset**, fires **no broker ACK**, and raises `StaleOwnerException` (new — carries topic/partition) |
| At-least-once preserved | The broker's POP invisibleTime redelivers the message to the new owner; the new owner's offsets stay authoritative |
| Pull-loop null window documented | With #5359 the ownership view is always installed at boot in `PARTITION_OWNED_PULL`, so `null` = single-instance (poll-all is the documented mode), not a gap |

### 3. Tests (new `StaleOwnerFencingTest`, 2 cases)

- **`fencedOwnerAckWritesNoOffsetAndSkipsBrokerAck`** — partition 1 owned / partition 0 fenced: owned ack writes its offset; fenced ack throws `StaleOwnerException` with **zero** additional offset writes and **zero** broker ACK callbacks; the dropped delivery is no longer pending.
- **`noGuardKeepsSingleInstanceBehaviour`** — no guard installed → ack persists the offset (single-instance path unchanged).

Local verification (Temurin 21.0.11): runtime tests + checkstyle (maxWarnings=0) all green.

### Relations

- Closes #5360 (Phase 1, P0)
- Parent: #5354 · Plan: `docs/architecture-review/production-ha-plan.md` (PR #5366)
- Builds on #5359 (merged `b3f9f75b4`) — the boot wiring that makes the guard installable
- Unblocks #5363 (cross-instance takeover tests exercise this guard end-to-end)

Co-authored-by: qqeasonchen <qqeasonchen@gmail.com>
