### PR TITLE
fix(#5361): FrameLimits — enforce wire bounds at encode AND decode (no-alloc rejects)

### DIFF
--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/wire/EventMeshFrame.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/wire/EventMeshFrame.java
@@ -256,6 +256,16 @@ public final class EventMeshFrame {
     // -------------------- encode / decode --------------------
 
     public byte[] encode() {
+        // #5361: enforce wire bounds at the producer side — fail fast instead of building a
+        // frame the decode side would have to reject (or worse, allocate for).
+        if (attrs.size() > FrameLimits.MAX_ATTRIBUTES) {
+            throw new IllegalArgumentException("frame attribute count " + attrs.size()
+                + " exceeds limit " + FrameLimits.MAX_ATTRIBUTES);
+        }
+        if (data.length > FrameLimits.MAX_DATA_BYTES) {
+            throw new IllegalArgumentException("frame data length " + data.length
+                + " exceeds limit " + FrameLimits.MAX_DATA_BYTES);
+        }
         byte[][] nameBytes = new byte[attrs.size()][];
         byte[][] valBytes = new byte[attrs.size()][];
         int kvLen = 0;
@@ -263,8 +273,20 @@ public final class EventMeshFrame {
         for (Map.Entry<String, String> e : attrs.entrySet()) {
             nameBytes[i] = utf8(e.getKey());
             valBytes[i] = utf8(e.getValue());
+            if (nameBytes[i].length > FrameLimits.MAX_ATTR_NAME_BYTES) {
+                throw new IllegalArgumentException("attribute name length " + nameBytes[i].length
+                    + " exceeds limit " + FrameLimits.MAX_ATTR_NAME_BYTES);
+            }
+            if (valBytes[i].length > FrameLimits.MAX_ATTR_VALUE_BYTES) {
+                throw new IllegalArgumentException("attribute value length " + valBytes[i].length
+                    + " exceeds limit " + FrameLimits.MAX_ATTR_VALUE_BYTES);
+            }
             kvLen += 2 + nameBytes[i].length + 4 + valBytes[i].length;
             i++;
+        }
+        if (HEADER_LEN + kvLen + data.length > FrameLimits.MAX_FRAME_BYTES) {
+            throw new IllegalArgumentException("encoded frame size " + (HEADER_LEN + kvLen + data.length)
+                + " exceeds limit " + FrameLimits.MAX_FRAME_BYTES);
         }
         ByteBuffer buf = ByteBuffer.allocate(HEADER_LEN + kvLen + data.length);
         buf.put((byte) MAGIC);
@@ -301,16 +323,47 @@ public final class EventMeshFrame {
         if (ver != VERSION) {
             throw new IllegalArgumentException("unsupported frame version: " + ver);
         }
-        int msgType = buf.get() & 0xFF;
-        int flags = buf.get() & 0xFF;
-        int seq = buf.getInt();
+        final int msgType = buf.get() & 0xFF;
+        final int flags = buf.get() & 0xFF;
+        final int seq = buf.getInt();
         int keyCount = buf.getShort() & 0xFFFF;
         int dataLen = buf.getInt();
+        // #5361: reject malformed/hostile headers BEFORE allocating — a frame that advertises
+        // sizes beyond the wire limits fails with IllegalArgumentException (clean reject), not
+        // an OutOfMemoryError from the allocation below.
+        if (keyCount > FrameLimits.MAX_ATTRIBUTES) {
+            throw new IllegalArgumentException("frame attribute count " + keyCount
+                + " exceeds limit " + FrameLimits.MAX_ATTRIBUTES);
+        }
+        if (dataLen < 0 || dataLen > FrameLimits.MAX_DATA_BYTES) {
+            throw new IllegalArgumentException("frame data length " + dataLen
+                + " exceeds limit " + FrameLimits.MAX_DATA_BYTES);
+        }
+        if (dataLen > length - HEADER_LEN) {
+            throw new IllegalArgumentException("frame data length " + dataLen
+                + " exceeds the provided buffer (" + length + " bytes)");
+        }
         Map<String, String> attrs = new LinkedHashMap<>(keyCount);
         for (int i = 0; i < keyCount; i++) {
+            // #5361: length prefixes themselves can run past a truncated buffer — guard each
+            // read so the whole decode fails as IllegalArgumentException, never underflow.
+            if (buf.remaining() < 2) {
+                throw new IllegalArgumentException("truncated frame: attribute name length prefix"
+                    + " beyond buffer (" + buf.remaining() + " bytes left)");
+            }
             String name = getString(buf, buf.getShort() & 0xFFFF);
+            if (buf.remaining() < 4) {
+                throw new IllegalArgumentException("truncated frame: attribute value length prefix"
+                    + " beyond buffer (" + buf.remaining() + " bytes left)");
+            }
             String value = getString(buf, buf.getInt());
             attrs.put(name, value);
+        }
+        // #5361: attributes consumed part of the buffer; re-check the data region before the
+        // bulk get (a frame truncated mid-attributes or mid-data fails cleanly).
+        if (dataLen > buf.remaining()) {
+            throw new IllegalArgumentException("frame data length " + dataLen
+                + " exceeds the remaining buffer (" + buf.remaining() + " bytes)");
         }
         byte[] data = new byte[dataLen];
         buf.get(data);
@@ -378,6 +431,12 @@ public final class EventMeshFrame {
     }
 
     private static String getString(ByteBuffer buf, int len) {
+        // #5361: a truncated buffer must fail as IllegalArgumentException (clean reject),
+        // never BufferUnderflowException or an over-allocation from a hostile length.
+        if (len < 0 || len > buf.remaining()) {
+            throw new IllegalArgumentException("string length " + len
+                + " exceeds the remaining buffer (" + buf.remaining() + " bytes)");
+        }
         byte[] b = new byte[len];
         buf.get(b);
         return new String(b, StandardCharsets.UTF_8);

--- a/eventmesh-common/src/main/java/org/apache/eventmesh/common/wire/FrameLimits.java
+++ b/eventmesh-common/src/main/java/org/apache/eventmesh/common/wire/FrameLimits.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.common.wire;
+
+/**
+ * Wire-format bounds for {@link EventMeshFrame} (issue #5361, plan #5354 Phase 1).
+ *
+ * <p>The frame codec previously accepted any sizes the header advertised — a malformed or
+ * hostile frame could declare {@code dataLen = 2^31-1} and the decoder would allocate that
+ * much memory before failing on the truncated body (OOM instead of a clean reject). These
+ * bounds are enforced at BOTH the encode boundary (a producer cannot build an oversized
+ * frame) and the decode boundary (a consumer rejects oversized input without allocating).</p>
+ *
+ * <p>Values are intentionally generous for an internal wire format: a 16 MiB frame ceiling
+ * covers streaming chunks and large CloudEvents payloads with headroom, while still
+ * bounding a single frame's memory footprint. Attribute count/size bounds mirror typical
+ * protocol header limits (HTTP/2: 100 headers; many brokers: 4 KiB per header value).</p>
+ */
+public final class FrameLimits {
+
+    private FrameLimits() {
+    }
+
+    /** Maximum encoded frame size (header + attributes + data). */
+    public static final int MAX_FRAME_BYTES = 16 * 1024 * 1024;
+
+    /** Maximum payload (data) size in bytes. */
+    public static final int MAX_DATA_BYTES = 8 * 1024 * 1024;
+
+    /** Maximum number of attributes per frame. */
+    public static final int MAX_ATTRIBUTES = 64;
+
+    /** Maximum UTF-8 length of one attribute name, in bytes. */
+    public static final int MAX_ATTR_NAME_BYTES = 256;
+
+    /** Maximum UTF-8 length of one attribute value, in bytes. */
+    public static final int MAX_ATTR_VALUE_BYTES = 4 * 1024;
+}

--- a/eventmesh-common/src/test/java/org/apache/eventmesh/common/wire/FrameLimitsTest.java
+++ b/eventmesh-common/src/test/java/org/apache/eventmesh/common/wire/FrameLimitsTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.common.wire;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #5361 acceptance (plan #5354 Phase 1): the frame codec enforces {@link FrameLimits} at
+ * BOTH boundaries — encode fails fast on oversized input, decode rejects malformed/hostile
+ * headers <em>without allocating</em> — and a randomized fuzz pass never throws anything but
+ * {@link IllegalArgumentException} (no OOM, no ArrayIndexOutOfBounds escape, no infinite loop).
+ */
+class FrameLimitsTest {
+
+    private static EventMeshFrame frame(Map<String, String> attrs, byte[] data) {
+        return EventMeshFrame.event(attrs, data);
+    }
+
+    // -------------------- encode bounds --------------------
+
+    @Test
+    void encodeRejectsTooManyAttributes() {
+        Map<String, String> attrs = new LinkedHashMap<>();
+        for (int i = 0; i <= FrameLimits.MAX_ATTRIBUTES; i++) {
+            attrs.put("k" + i, "v");
+        }
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> frame(attrs, new byte[0]).encode());
+        assertTrue(ex.getMessage().contains("attribute count"), ex.getMessage());
+    }
+
+    @Test
+    void encodeRejectsOversizedData() {
+        // MAX_DATA_BYTES + 1 (safe: 8 MiB + 1 allocation only)
+        byte[] data = new byte[FrameLimits.MAX_DATA_BYTES + 1];
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> frame(new LinkedHashMap<>(), data).encode());
+        assertTrue(ex.getMessage().contains("data length"), ex.getMessage());
+    }
+
+    @Test
+    void encodeRejectsOversizedAttributeName() {
+        Map<String, String> attrs = new LinkedHashMap<>();
+        attrs.put("k".repeat(FrameLimits.MAX_ATTR_NAME_BYTES + 1), "v");
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> frame(attrs, new byte[0]).encode());
+        assertTrue(ex.getMessage().contains("attribute name length"), ex.getMessage());
+    }
+
+    @Test
+    void encodeRejectsOversizedAttributeValue() {
+        Map<String, String> attrs = new LinkedHashMap<>();
+        attrs.put("k", "v".repeat(FrameLimits.MAX_ATTR_VALUE_BYTES + 1));
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> frame(attrs, new byte[0]).encode());
+        assertTrue(ex.getMessage().contains("attribute value length"), ex.getMessage());
+    }
+
+    @Test
+    void encodeAcceptsAtTheLimits() {
+        // Exactly at every limit must pass (boundary is > not >=).
+        Map<String, String> attrs = new LinkedHashMap<>();
+        attrs.put("k".repeat(FrameLimits.MAX_ATTR_NAME_BYTES), "v".repeat(FrameLimits.MAX_ATTR_VALUE_BYTES));
+        byte[] data = new byte[FrameLimits.MAX_DATA_BYTES];
+        EventMeshFrame f = frame(attrs, data);
+        byte[] encoded = f.encode();
+        assertEquals(FrameLimits.MAX_DATA_BYTES, EventMeshFrame.decode(encoded).data().length);
+    }
+
+    // -------------------- decode bounds (no-allocation rejects) --------------------
+
+    @Test
+    void decodeRejectsHostileDataLenWithoutAllocating() {
+        // Hand-craft a header that advertises dataLen = Integer.MAX_VALUE on a tiny buffer.
+        ByteBuffer hostile = ByteBuffer.allocate(FrameLimits.MAX_FRAME_BYTES > 64 ? 64 : FrameLimits.MAX_FRAME_BYTES);
+        hostile.put((byte) EventMeshFrame.MAGIC);
+        hostile.put((byte) EventMeshFrame.VERSION);
+        hostile.put((byte) 3); // TYPE_EVENT
+        hostile.put((byte) 0); // flags
+        hostile.putInt(1);     // seq
+        hostile.putShort((short) 0); // keyCount
+        hostile.putInt(Integer.MAX_VALUE); // dataLen — hostile
+        byte[] bytes = hostile.array();
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> EventMeshFrame.decode(bytes));
+        assertTrue(ex.getMessage().contains("data length") || ex.getMessage().contains("buffer"),
+            ex.getMessage());
+    }
+
+    @Test
+    void decodeRejectsHostileKeyCount() {
+        ByteBuffer hostile = ByteBuffer.allocate(64);
+        hostile.put((byte) EventMeshFrame.MAGIC);
+        hostile.put((byte) EventMeshFrame.VERSION);
+        hostile.put((byte) 3);
+        hostile.put((byte) 0);
+        hostile.putInt(1);
+        hostile.putShort((short) (FrameLimits.MAX_ATTRIBUTES + 1)); // keyCount — hostile
+        hostile.putInt(0);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> EventMeshFrame.decode(hostile.array()));
+        assertTrue(ex.getMessage().contains("attribute count"), ex.getMessage());
+    }
+
+    @Test
+    void decodeRejectsDataLenBeyondProvidedBuffer() {
+        // Well-formed frame with 10 data bytes, but the buffer is truncated to the header only.
+        EventMeshFrame f = frame(mapOf("k", "v"), new byte[10]);
+        byte[] full = f.encode();
+        byte[] truncated = new byte[14]; // HEADER_LEN only
+        System.arraycopy(full, 0, truncated, 0, truncated.length);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> EventMeshFrame.decode(truncated));
+        assertTrue(ex.getMessage().contains("buffer"), ex.getMessage());
+    }
+
+    // -------------------- fuzz --------------------
+
+    @Test
+    void fuzzedHeadersNeverEscapeIllegalArgumentException() {
+        // Deterministic fuzz: mutate a well-formed frame's bytes; every decode outcome is
+        // either a valid frame or an IllegalArgumentException — never OOM/AIOOBE/infinite loop.
+        Random rnd = new Random(20260909L);
+        EventMeshFrame wellFormed = frame(mapOf("k1", "v1", "k2", "v2"), new byte[32]);
+        byte[] encoded = wellFormed.encode();
+        int illegal = 0;
+        int accepted = 0;
+        for (int iter = 0; iter < 20_000; iter++) {
+            byte[] mutant = encoded.clone();
+            int mutations = 1 + rnd.nextInt(4);
+            for (int m = 0; m < mutations; m++) {
+                mutant[rnd.nextInt(mutant.length)] = (byte) rnd.nextInt(256);
+            }
+            try {
+                EventMeshFrame decoded = EventMeshFrame.decode(mutant);
+                assertNotNull(decoded);
+                accepted++;
+            } catch (IllegalArgumentException expected) {
+                illegal++;
+            }
+        }
+        assertTrue(accepted > 0, "some mutants should still decode");
+        assertTrue(illegal > 0, "some mutants should be rejected");
+    }
+
+    private static Map<String, String> mapOf(String... kv) {
+        Map<String, String> m = new LinkedHashMap<>();
+        for (int i = 0; i + 1 < kv.length; i += 2) {
+            m.put(kv[i], kv[i + 1]);
+        }
+        return m;
+    }
+}


### PR DESCRIPTION
## What this PR does

Closes #5361 — Phase 1 of the production-HA plan (#5354), acceptance **A3**: the frame codec enforces wire bounds at BOTH boundaries and rejects malformed input **without OOM**.

### 1. The gap this fixes

The codec accepted whatever sizes the header advertised. A hostile frame declaring `dataLen = 2^31-1` made the decoder allocate that much memory before failing on the truncated body (**OOM instead of a clean reject**); truncated buffers escaped as `BufferUnderflowException`.

### 2. New `FrameLimits` (`eventmesh-common/wire`)

| Limit | Value |
|---|---|
| `MAX_FRAME_BYTES` | 16 MiB |
| `MAX_DATA_BYTES` | 8 MiB |
| `MAX_ATTRIBUTES` | 64 |
| `MAX_ATTR_NAME_BYTES` | 256 B |
| `MAX_ATTR_VALUE_BYTES` | 4 KiB |

### 3. Boundary enforcement

- **Encode**: attribute count / data length / attr name+value lengths / total encoded size all fail fast — a producer cannot build an oversized frame.
- **Decode**: advertised `keyCount`/`dataLen` rejected **before any allocation**; every buffer read (attribute length prefixes, string bodies, data bulk-get) guarded. `decode` is now **total**: any byte sequence either decodes or throws `IllegalArgumentException` — never underflow, never over-allocation.

### 4. Tests (new `FrameLimitsTest`, 8 cases)

- 4 encode-bound rejects + **at-the-limit acceptance** (boundary is `>`)
- Hostile `dataLen=Integer.MAX_VALUE` on a 64-byte buffer → clean `IllegalArgumentException`, no allocation
- Hostile `keyCount`; `dataLen` beyond provided buffer
- **Deterministic 20,000-iteration byte-mutation fuzz** — every mutant either decodes or throws `IllegalArgumentException` (the fuzz found and drove the fix for both underflow escapes during development)

### Verification (local, Temurin 21.0.11)

```
:eventmesh-common:test + checkstyle (maxWarnings=0)   BUILD SUCCESSFUL
downstream: runtime + architecture-guard + storage-api tests   BUILD SUCCESSFUL
```

### Relations

- Closes #5361 (Phase 1, P0) — completes Phase 1 alongside #5359 (`b3f9f75b4`) and #5360 (`017843ef1`)
- Parent: #5354 · Plan: `docs/architecture-review/production-ha-plan.md` (PR #5366)
- Builds on the #5357 immutable frame (merged `7ac0ab824`)

Co-authored-by: qqeasonchen <qqeasonchen@gmail.com>
