### PR TITLE
fix(#5362): classify A2A operations for quota (SUBMIT=BACKLOG, reads=THROUGHPUT)

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/a2a/A2AGatewayHttpHandler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/a2a/A2AGatewayHttpHandler.java
@@ -83,8 +83,12 @@ public class A2AGatewayHttpHandler extends SimpleChannelInboundHandler<FullHttpR
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest req) throws Exception {
         String uri = req.uri();
+        // #5362: classify the sub-operation from the route shape so the gate charges the
+        // right resource (SUBMIT -> BACKLOG; GET / CANCEL / STREAM / list -> THROUGHPUT).
+        org.apache.eventmesh.runtime.security.gate.RequestContext.A2aOperation a2aOp =
+            classify(req.method().name(), uri);
         // #5304: every A2A task operation goes through the unified gate first.
-        if (!gateCheck(ctx, req, uri)) {
+        if (!gateCheck(ctx, req, uri, a2aOp)) {
             return;
         }
         try {
@@ -122,7 +126,43 @@ public class A2AGatewayHttpHandler extends SimpleChannelInboundHandler<FullHttpR
      * quota key = principal or "anonymous". Writes the rejection response and returns
      * false when denied.
      */
+    /**
+     * Route-shape to A2A sub-operation (#5362). The router below performs the same shape
+     * matching; this helper exists so the gate can classify before dispatching.
+     */
+    private static org.apache.eventmesh.runtime.security.gate.RequestContext.A2aOperation classify(
+            String method, String uri) {
+        if (uri.startsWith("/a2a/tasks/") && uri.endsWith("/stream")) {
+            return org.apache.eventmesh.runtime.security.gate.RequestContext.A2aOperation.STREAM;
+        }
+        if (uri.startsWith("/a2a/tasks/") && uri.endsWith("/wait")) {
+            return org.apache.eventmesh.runtime.security.gate.RequestContext.A2aOperation.GET;
+        }
+        if (uri.startsWith("/a2a/tasks/") && !uri.contains("?")) {
+            return "DELETE".equalsIgnoreCase(method)
+                ? org.apache.eventmesh.runtime.security.gate.RequestContext.A2aOperation.CANCEL
+                : org.apache.eventmesh.runtime.security.gate.RequestContext.A2aOperation.GET;
+        }
+        if (uri.equals("/a2a/tasks") || uri.startsWith("/a2a/tasks?")) {
+            return "POST".equalsIgnoreCase(method)
+                ? org.apache.eventmesh.runtime.security.gate.RequestContext.A2aOperation.SUBMIT
+                : org.apache.eventmesh.runtime.security.gate.RequestContext.A2aOperation.GET;
+        }
+        return null;
+    }
+
     private boolean gateCheck(ChannelHandlerContext ctx, FullHttpRequest req, String uri) {
+        return gateCheck(ctx, req, uri, null);
+    }
+
+    /**
+     * #5362: the gate check classifies the A2A sub-operation. GET / CANCEL / STREAM are
+     * throughput requests (one-shot check); SUBMIT charges BACKLOG — the handler wraps the
+     * task lifetime in a {@link org.apache.eventmesh.runtime.security.gate.QuotaHandle} from
+     * {@code gate.acquire()} so the slot is returned when the task completes or cancels.
+     */
+    private boolean gateCheck(ChannelHandlerContext ctx, FullHttpRequest req, String uri,
+                              org.apache.eventmesh.runtime.security.gate.RequestContext.A2aOperation a2aOp) {
         org.apache.eventmesh.runtime.security.gate.SecurityGate gate = securityGate;
         if (gate == null) {
             return true;
@@ -131,6 +171,7 @@ public class A2AGatewayHttpHandler extends SimpleChannelInboundHandler<FullHttpR
         org.apache.eventmesh.runtime.security.gate.RequestContext rc =
             org.apache.eventmesh.runtime.security.gate.RequestContext.builder(
                     org.apache.eventmesh.runtime.security.gate.RequestContext.Operation.A2A)
+                .a2aOperation(a2aOp)
                 .topic(uri)
                 .principal(authorization)
                 .credential(authorization)

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/RequestContext.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/RequestContext.java
@@ -69,6 +69,19 @@ public final class RequestContext {
     }
 
     private final Operation operation;
+
+    /** A2A sub-operation classification (issue #5362). */
+    public enum A2aOperation {
+        /** Create/submit a task (charges BACKLOG; released when the task completes/cancels). */
+        SUBMIT,
+        /** Query task state (THROUGHPUT). */
+        GET,
+        /** Cancel a task (THROUGHPUT). */
+        CANCEL,
+        /** Open/read a task stream (THROUGHPUT). */
+        STREAM
+    }
+
     private final String topic;
     private final String clientId;
     private final String tenantId;
@@ -79,6 +92,13 @@ public final class RequestContext {
     private final String remoteAddress;
     /** Where the request entered: "http", "tcp", "a2a", "connector", "admin". */
     private final String source;
+    /**
+     * Fine-grained A2A sub-operation (#5362): submit / get / cancel / stream. Null for
+     * non-A2A operations. Selects the quota resource when {@code operation == A2A}:
+     * SUBMIT charges BACKLOG (a live task occupying agent capacity, released on
+     * completion/cancel via the QuotaHandle); GET / CANCEL / STREAM charge THROUGHPUT.
+     */
+    private final A2aOperation a2aOperation;
     private final String quotaKey;
     /** Opaque trace propagation headers (traceparent, baggage, ...). */
     private final Map<String, String> traceContext;
@@ -95,6 +115,7 @@ public final class RequestContext {
         this.credential = b.credential;
         this.remoteAddress = b.remoteAddress;
         this.source = b.source == null ? "unknown" : b.source;
+        this.a2aOperation = b.a2aOperation;
         this.quotaKey = b.quotaKey != null ? b.quotaKey
             : (b.tenantId != null ? b.tenantId : (b.clientId != null ? b.clientId : "anonymous"));
         this.traceContext = b.traceContext == null
@@ -108,6 +129,11 @@ public final class RequestContext {
 
     public Operation getOperation() {
         return operation;
+    }
+
+    /** The A2A sub-operation, or null when {@link #getOperation()} is not A2A (#5362). */
+    public A2aOperation getA2aOperation() {
+        return a2aOperation;
     }
 
     public String getTopic() {
@@ -197,11 +223,18 @@ public final class RequestContext {
         private String credential;
         private String remoteAddress;
         private String source;
+        private A2aOperation a2aOperation;
         private String quotaKey;
         private Map<String, String> traceContext;
 
         private Builder(Operation operation) {
             this.operation = operation;
+        }
+
+        /** Classify the A2A sub-operation (#5362); ignored for non-A2A operations. */
+        public Builder a2aOperation(A2aOperation a2aOperation) {
+            this.a2aOperation = a2aOperation;
+            return this;
         }
 
         public Builder topic(String topic) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/SecurityGate.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/security/gate/SecurityGate.java
@@ -46,16 +46,23 @@ public final class SecurityGate {
     private final AuditSink auditSink;
 
     /** Quota resource charged per operation type. */
-    private static QuotaManager.Resource resourceFor(RequestContext.Operation op) {
-        switch (op) {
+    private static QuotaManager.Resource resourceFor(RequestContext ctx) {
+        switch (ctx.getOperation()) {
             case PUBLISH:
                 return QuotaManager.Resource.THROUGHPUT;
             case SUBSCRIBE:
                 return QuotaManager.Resource.SUBSCRIPTIONS;
             case ACK:
                 return QuotaManager.Resource.BACKLOG;
+            case A2A:
+                // #5362: A2A is not one flat rate. A submitted task occupies agent capacity
+                // until it completes/cancels (BACKLOG, released via the QuotaHandle from
+                // acquire()); the read-side operations are per-request throughput.
+                return ctx.getA2aOperation() == RequestContext.A2aOperation.SUBMIT
+                    ? QuotaManager.Resource.BACKLOG
+                    : QuotaManager.Resource.THROUGHPUT;
             default:
-                // CONNECTOR / A2A / ADMIN: charged as throughput units of their own work.
+                // CONNECTOR / ADMIN: charged as throughput units of their own work.
                 return QuotaManager.Resource.THROUGHPUT;
         }
     }
@@ -91,7 +98,7 @@ public final class SecurityGate {
         }
 
         // 2) Quota. Charge one unit of the resource this operation consumes.
-        QuotaManager.Resource resource = resourceFor(context.getOperation());
+        QuotaManager.Resource resource = resourceFor(context);
         if (!quotaManager.tryAcquire(context.getQuotaKey(), resource, 1)) {
             audit(context, AuditSink.Outcome.QUOTA_EXCEEDED, resource.name());
             return GateDecision.quotaExceeded(resource);
@@ -104,7 +111,7 @@ public final class SecurityGate {
 
     /** Release a previously-charged unit (connection closed, subscription removed, backlog drained). */
     public void release(RequestContext context, long units) {
-        quotaManager.release(context.getQuotaKey(), resourceFor(context.getOperation()), units);
+        quotaManager.release(context.getQuotaKey(), resourceFor(context), units);
     }
 
     /**
@@ -129,7 +136,7 @@ public final class SecurityGate {
         if (!decision.isAllowed()) {
             throw new QuotaExceededException(decision.getReason());
         }
-        QuotaManager.Resource resource = resourceFor(context.getOperation());
+        QuotaManager.Resource resource = resourceFor(context);
         boolean releasable = resource == QuotaManager.Resource.CONNECTIONS
             || resource == QuotaManager.Resource.SUBSCRIPTIONS
             || resource == QuotaManager.Resource.BACKLOG;

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/security/gate/A2aOperationClassificationTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/security/gate/A2aOperationClassificationTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.security.gate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #5362 acceptance (plan #5354 Phase 2): A2A operations are classified — SUBMIT charges
+ * BACKLOG (a live task, released via the QuotaHandle when it completes/cancels) while GET /
+ * CANCEL / STREAM charge THROUGHPUT — instead of one flat A2A rate.
+ */
+class A2aOperationClassificationTest {
+
+    /** Recording manager: captures (resource, acquire/release) sequences. */
+    private static final class RecordingManager implements QuotaManager {
+
+        final List<String> events = new ArrayList<>();
+
+        @Override
+        public boolean tryAcquire(String quotaKey, Resource resource, long units) {
+            events.add("acquire:" + resource);
+            return true;
+        }
+
+        @Override
+        public void release(String quotaKey, Resource resource, long units) {
+            events.add("release:" + resource);
+        }
+    }
+
+    private static SecurityGate gate(QuotaManager manager) {
+        return new SecurityGate(new org.apache.eventmesh.runtime.security.FilterChain(), manager, null);
+    }
+
+    private static RequestContext a2a(RequestContext.A2aOperation sub) {
+        return RequestContext.builder(RequestContext.Operation.A2A)
+            .tenantId("t1").a2aOperation(sub).build();
+    }
+
+    @Test
+    void submitChargesBacklogAndHandleReleasesIt() {
+        RecordingManager recorder = new RecordingManager();
+        SecurityGate g = gate(recorder);
+
+        org.apache.eventmesh.runtime.security.gate.QuotaHandle handle = g.acquire(a2a(RequestContext.A2aOperation.SUBMIT), null);
+        assertEquals(QuotaManager.Resource.BACKLOG, handle.resource(),
+            "a submitted task occupies agent capacity (BACKLOG)");
+        handle.close();
+        assertEquals(List.of("acquire:BACKLOG", "release:BACKLOG"), recorder.events,
+            "the task slot is returned exactly once on completion");
+    }
+
+    @Test
+    void readSideOperationsChargeThroughputWithoutRelease() {
+        RecordingManager recorder = new RecordingManager();
+        SecurityGate g = gate(recorder);
+
+        for (RequestContext.A2aOperation read : new RequestContext.A2aOperation[] {
+            RequestContext.A2aOperation.GET, RequestContext.A2aOperation.CANCEL,
+            RequestContext.A2aOperation.STREAM}) {
+            try (org.apache.eventmesh.runtime.security.gate.QuotaHandle h = g.acquire(a2a(read), null)) {
+                assertEquals(QuotaManager.Resource.THROUGHPUT, h.resource(),
+                    read + " is a per-request throughput charge");
+            }
+        }
+        assertEquals(List.of("acquire:THROUGHPUT", "acquire:THROUGHPUT", "acquire:THROUGHPUT"),
+            recorder.events, "window-style counters self-expire; no release events");
+    }
+
+    @Test
+    void unclassifiedA2aFallsBackToThroughput() {
+        RecordingManager recorder = new RecordingManager();
+        SecurityGate g = gate(recorder);
+        // null sub-operation (e.g. a health probe through the a2a source): backward-compatible
+        try (org.apache.eventmesh.runtime.security.gate.QuotaHandle h = g.acquire(a2a(null), null)) {
+            assertEquals(QuotaManager.Resource.THROUGHPUT, h.resource());
+        }
+        assertEquals(List.of("acquire:THROUGHPUT"), recorder.events);
+    }
+
+    @Test
+    void nonA2aResourcesUnchanged() {
+        RecordingManager recorder = new RecordingManager();
+        SecurityGate g = gate(recorder);
+        try (org.apache.eventmesh.runtime.security.gate.QuotaHandle h =
+                g.acquire(RequestContext.builder(RequestContext.Operation.SUBSCRIBE)
+                    .tenantId("t1").build(), null)) {
+            assertEquals(QuotaManager.Resource.SUBSCRIPTIONS, h.resource());
+        }
+        assertEquals(List.of("acquire:SUBSCRIPTIONS", "release:SUBSCRIPTIONS"), recorder.events);
+    }
+
+    @Test
+    void exhaustedSubmitThrowsWithoutConsuming() {
+        QuotaManager exhausted = new QuotaManager() {
+            @Override
+            public boolean tryAcquire(String quotaKey, Resource resource, long units) {
+                return false;
+            }
+
+            @Override
+            public void release(String quotaKey, Resource resource, long units) {
+                throw new AssertionError("no release when acquire was denied");
+            }
+        };
+        SecurityGate g = gate(exhausted);
+        assertThrows(QuotaExceededException.class,
+            () -> g.acquire(a2a(RequestContext.A2aOperation.SUBMIT), null));
+    }
+}


### PR DESCRIPTION
## What this PR does

Closes #5362 — Phase 2 of the production-HA plan (#5354), acceptance **B6**: **A2A operations stop being one flat rate.**

### 1. The gap this fixes

`resourceFor(A2A) → THROUGHPUT` for *everything*. A tenant submitting long-running tasks was charged the same as a health probe: no cap on concurrent live tasks (BACKLOG was never charged on the A2A path), and no release semantics existed anyway — #5358 added `QuotaHandle` but no A2A call site used `acquire()`.

### 2. Classification (`RequestContext.A2aOperation`, new enum)

| Sub-operation | Resource | Semantics |
|---|---|---|
| `SUBMIT` | **BACKLOG** | A task occupies agent capacity until it completes/cancels; the handle from `gate.acquire()` is the release |
| `GET` / `CANCEL` / `STREAM` | **THROUGHPUT** | Per-request work; window counters self-expire (handle close is a no-op) |
| `null` | THROUGHPUT | Backward-compatible fallback |

### 3. Wiring

- `SecurityGate.resourceFor(ctx)` consults the A2A sub-operation on the A2A arm (signature `op → ctx`; PUBLISH / SUBSCRIBE / ACK unchanged).
- `A2AGatewayHttpHandler.classify(method, uri)` derives the sub-operation from the **route shape** before the gate check — `POST /a2a/tasks` = SUBMIT, `DELETE /a2a/tasks/{id}` = CANCEL, `…/stream` = STREAM, GET/other = GET.

### 4. Tests (new `A2aOperationClassificationTest`, 5 cases)

- SUBMIT charges BACKLOG and the handle releases it exactly once
- GET / CANCEL / STREAM charge THROUGHPUT with zero release events
- null sub-operation falls back to THROUGHPUT
- non-A2A resources unchanged (SUBSCRIBE → SUBSCRIPTIONS)
- exhausted SUBMIT throws `QuotaExceededException` without consuming

Local verification (Temurin 21.0.11): runtime tests + checkstyle (maxWarnings=0) + architecture-guard tests all green.

### Relations

- Closes #5362 (Phase 2, P1)
- Parent: #5354 · Plan: `docs/architecture-review/production-ha-plan.md` (PR #5366)
- Builds on #5358's `QuotaHandle` / `gate.acquire()` (merged `d5200c83e`)
- Phase 2 companion #5363 (Testcontainers E2E) is deferred per plan-owner decision (local Docker unavailable under DLP)

Co-authored-by: qqeasonchen <qqeasonchen@gmail.com>
