### PR TITLE
fix(#5376,#5377,#5378): cluster routing, single ownership lifecycle, durable delivery bootstrap

### DIFF
--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshApplication.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshApplication.java
@@ -52,6 +52,9 @@ public class EventMeshApplication {
     private org.apache.eventmesh.runtime.cluster.ClusterCoordinator clusterCoordinator;
     private org.apache.eventmesh.runtime.cluster.ClusterMembership clusterMembership;
     private org.apache.eventmesh.runtime.cluster.PartitionOwnership partitionOwnership;
+
+    /** #5378: the durable delivery-state store, closed on shutdown. */
+    private org.apache.eventmesh.runtime.state.RocksDBDeliveryStateStore durableDeliveryState;
     private java.util.concurrent.ScheduledExecutorService heartbeatScheduler;
     private String selfInstanceId;
     private String advertisedAddr;
@@ -196,6 +199,22 @@ public class EventMeshApplication {
         // 4. Dynamic config hot-reload.
         new org.apache.eventmesh.runtime.cluster.DynamicConfigWatcher(metaStore, runtime.ingress()).start();
 
+        // 6. #5376: cluster-wide subscription routing. The partition owner's poll loop must see
+        // subscribers that connected to OTHER instances: the ClusterSubscriptionStore mirrors
+        // /em/subs/* from the shared Meta (prefix watch), and the ClusterCoordinator routes each
+        // polled event to local targets (deliverLocal) or remote ones (HttpForwarder ->
+        // POST /internal/forward on the subscriber's instance). Without this wiring the owner
+        // dispatched through its LOCAL SubscriptionManager only and remote subscribers starved.
+        org.apache.eventmesh.runtime.cluster.ClusterSubscriptionStore clusterSubs =
+            new org.apache.eventmesh.runtime.cluster.ClusterSubscriptionStore(metaStore);
+        org.apache.eventmesh.runtime.cluster.ClusterCoordinator coordinator =
+            new org.apache.eventmesh.runtime.cluster.ClusterCoordinator(
+                selfInstanceId, clusterSubs,
+                runtime.ingress()::deliverLocal,
+                new org.apache.eventmesh.runtime.cluster.HttpForwarder(
+                    clusterMembership, System.getProperty("eventmesh.admin.token")));
+        runtime.ingress().withCluster(coordinator);
+
         // 5. #5359: flip the runtime's pull topology to PARTITION_OWNED_PULL and inject the shared
         // MetaStore BEFORE runtime.start() runs, so the pull loop consults this PartitionOwnership
         // (ownedPartitions) instead of polling every partition on every instance (duplicate
@@ -316,6 +335,11 @@ public class EventMeshApplication {
             connectorScheduler.stop();
         }
         runtime.shutdown();
+        // #5378: flush + close the durable delivery-state store so in-flight records survive the
+        // shutdown for restart recovery (crash-recovery contract of ReliableDispatcher.recover()).
+        if (durableDeliveryState != null) {
+            durableDeliveryState.close();
+        }
         log.info("EventMeshApplication stopped");
     }
 
@@ -410,6 +434,24 @@ public class EventMeshApplication {
 
         EventMeshApplication app = new EventMeshApplication(storage, offsets, httpPort, adminPort);
         app.runtime().withStorageConfig(props);
+
+        // #5378: durable delivery-state + DLQ ledger for the DEFAULT bootstrap. Without this the
+        // dispatcher runs on InMemoryDeliveryStateStore: a crash loses every in-flight
+        // (pulled-but-unACKed) delivery and the DLQ has no cluster-visible ledger.
+        // RocksDB under the same data path as the offsets; the Meta-backed DLQ ledger only in
+        // clustered mode (single-instance keeps the legacy sink-only path).
+        org.apache.eventmesh.runtime.state.RocksDBDeliveryStateStore deliveryState =
+            new org.apache.eventmesh.runtime.state.RocksDBDeliveryStateStore(
+                new java.io.File(offsetPath).getParentFile().getAbsolutePath() + java.io.File.separator + "delivery-state");
+        app.runtime().ingress().dispatcher().withStateStore(deliveryState);
+        org.apache.eventmesh.runtime.state.MetaBackedDeadLetterStore dlqLedger = null;
+        if (clustered) {
+            dlqLedger = new org.apache.eventmesh.runtime.state.MetaBackedDeadLetterStore(metaStore);
+            app.runtime().ingress().dispatcher().withDeadLetterStore(dlqLedger);
+        }
+        log.info("delivery-state store: RocksDB({}); dlq-ledger: {}",
+            deliveryState.getClass().getSimpleName(),
+            dlqLedger != null ? "MetaBackedDeadLetterStore" : "none (single-instance; DLQ sink only)");
         // Dynamic connector scheduling (§8) — always on. InMemory defs/workers single-instance;
         // Nacos-shared across the cluster.
         app.withConnectorScheduler(

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/UniRuntime.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/UniRuntime.java
@@ -220,6 +220,17 @@ public class UniRuntime {
                 "PARTITION_OWNED_PULL requires a shared MetaStore: set eventmesh.meta.type/addr"
                     + " (e.g. nacos + address) or use LOCAL_STICKY_PULL for single-instance");
         }
+        // #5377: single ownership lifecycle. EventMeshApplication.enableCluster() may have
+        // already built and started the ClusterMembership + PartitionOwnership (one fencing
+        // token, one heartbeat/assignment loop) and installed it into the ingress; creating a
+        // second pair here would give one Runtime two divergent state machines. Reuse the
+        // installed instance; only self-construct when nobody wired one (embedder path).
+        if (ingress.partitionOwnership() != null) {
+            partitionOwnership = ingress.partitionOwnership();
+            log.info("partition ownership REUSED from ingress wiring (topology={}, instance={})",
+                topology, instanceId);
+            return;
+        }
         FencingToken token = new FencingToken();
         ClusterMembership membership = new ClusterMembership(
             clusterMeta, instanceId, instanceAddress, 30_000L, System::currentTimeMillis, token);
@@ -228,6 +239,11 @@ public class UniRuntime {
         partitionOwnership.start(() -> ingress.activeTopicsClustered());
         ingress.withPartitionOwnership(partitionOwnership);
         log.info("partition ownership started (topology={}, instance={})", topology, instanceId);
+    }
+
+    /** Test accessor: the ownership instance this runtime stops on shutdown (#5377). */
+    PartitionOwnership partitionOwnershipRefForTest() {
+        return partitionOwnership;
     }
 
     /** Stop the partition ownership loop and release Meta assignment records. */

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/ClusterSubscriptionStore.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/ClusterSubscriptionStore.java
@@ -63,18 +63,22 @@ public class ClusterSubscriptionStore implements SubscriptionStore {
     public void put(String topic, String clientId, String instanceId, DistributionMode mode, String filterSpec) {
         ClusterSub sub = new ClusterSub(clientId, instanceId, mode, filterSpec);
         String k = key(topic, clientId);
-        meta.put(k, sub.encode());
-        // Update the local cache immediately — the MetaStore watch is for cross-instance propagation
-        // and may not fire (Nacos ConfigService is per-dataId, not prefix-scan), so don't rely on it
-        // to reflect this instance's own subscription back.
+        // Apply locally BEFORE the Meta write (#5376): with a synchronously-notifying store
+        // (InMemoryMetaStore), meta.put() fans the event out to every watcher INCLUDING this one,
+        // in the authoritative Meta order. A trailing own-apply after the write would escape that
+        // order and could resurrect a concurrently-deleted value in the local cache (divergent
+        // views across instances). Applying first keeps immediate local visibility for stores
+        // whose watch may not reflect own writes (Nacos per-dataId listeners) while letting the
+        // Meta-ordered notification re-assert the final value.
         applyChange(k, sub.encode(), false);
+        meta.put(k, sub.encode());
     }
 
     public boolean remove(String topic, String clientId) {
         String k = key(topic, clientId);
-        boolean removed = meta.delete(k);
+        // Apply locally BEFORE the Meta delete — see put() for the ordering argument (#5376).
         applyChange(k, null, true);
-        return removed;
+        return meta.delete(k);
     }
 
     /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/HttpForwarder.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/cluster/HttpForwarder.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.cluster;
+
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Production {@link Forwarder} (issue #5376): the partition-owning instance POSTs the event to
+ * the subscriber's instance {@code POST /internal/forward} so the target delivers through its
+ * local push path. Addressing goes through {@link ClusterMembership#addressOf(String)} so the
+ * routing follows the live membership table, not a static config.
+ *
+ * <p>The wire body is the frame's binary encoding base64-wrapped in a tiny JSON envelope
+ * ({@code {"clientId":..,"topic":..,"frameB64":..}}); the target decodes and delivers locally.
+ * Delivery failures return {@code false} so the coordinator's caller can account for them
+ * (the at-least-once bound rides on the backend's redelivery, as with any dispatch failure).</p>
+ */
+@Slf4j
+public class HttpForwarder implements Forwarder {
+
+    private final ClusterMembership membership;
+    private final HttpClient client;
+    private final String bearerToken;
+
+    public HttpForwarder(ClusterMembership membership) {
+        this(membership, null);
+    }
+
+    /**
+     * @param bearerToken optional bearer for the internal endpoint
+     *                    ({@code eventmesh.admin.token}); null/empty sends none
+     */
+    public HttpForwarder(ClusterMembership membership, String bearerToken) {
+        this.membership = membership;
+        this.bearerToken = bearerToken;
+        this.client = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(3))
+            .build();
+    }
+
+    @Override
+    public boolean forward(String targetInstance, String clientId, String topic, EventMeshFrame event) {
+        String address = membership.addressOf(targetInstance);
+        if (address == null || address.isEmpty()) {
+            log.warn("forward failed: no live address for instance {} (membership churn?)", targetInstance);
+            return false;
+        }
+        String url = "http://" + address + "/internal/forward";
+        String body = "{\"clientId\":\"" + clientId + "\",\"topic\":\"" + topic
+            + "\",\"frameB64\":\"" + Base64.getEncoder().encodeToString(event.encode()) + "\"}";
+        try {
+            HttpRequest.Builder req = HttpRequest.newBuilder(URI.create(url))
+                .timeout(Duration.ofSeconds(5))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8));
+            if (bearerToken != null && !bearerToken.isEmpty()) {
+                req.header("Authorization", "Bearer " + bearerToken);
+            }
+            HttpResponse<String> resp = client.send(req.build(), HttpResponse.BodyHandlers.ofString());
+            if (resp.statusCode() == 200) {
+                return true;
+            }
+            log.warn("forward to {} for client {} on {} returned {}", targetInstance, clientId, topic, resp.statusCode());
+            return false;
+        } catch (Exception e) {
+            log.warn("forward to {} for client {} on {} failed: {}", targetInstance, clientId, topic, e.toString());
+            return false;
+        }
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcher.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcher.java
@@ -83,7 +83,7 @@ public class ReliableDispatcher {
     // persist — tick() redelivers through it and ack() fires the callback from it. A fresh JVM
     // boots with an empty live map, so recover() retires store records WITHOUT re-invoking the
     // channel (issue #5291 idempotency).
-    private final DeliveryStateStore stateStore;
+    private DeliveryStateStore stateStore;
     /** Sub-PR C: durable DLQ ledger. When non-null, every confirmed DLQ transition is
      *  recorded via {@link DeadLetterStore#recordDeadLetter} before the delivery is
      *  retired. Null = legacy behaviour (Sub-PR A/B), the sink is the only durable
@@ -265,8 +265,39 @@ public class ReliableDispatcher {
         return this;
     }
 
+    /**
+     * #5378: swap the delivery-state store post-construction (boot wiring order: the dispatcher
+     * is built inside UniIngressService before EventMeshApplication can construct the durable
+     * stores). In-flight records already written to the default store are replayed into the
+     * replacement so none are stranded. Must be called before any delivery traffic.
+     */
+    public ReliableDispatcher withStateStore(DeliveryStateStore replacement) {
+        java.util.Objects.requireNonNull(replacement, "replacement");
+        if (pendingCount() > 0) {
+            throw new IllegalStateException("cannot swap the delivery-state store with in-flight"
+                + " deliveries; wire it before serving traffic");
+        }
+        this.stateStore = replacement;
+        return this;
+    }
+
+    /** #5378: attach the DLQ ledger post-construction (null keeps the legacy behaviour). */
+    public ReliableDispatcher withDeadLetterStore(DeadLetterStore dlqLedger) {
+        this.deadLetterStore = dlqLedger;
+        return this;
+    }
+
     public UniMetrics metrics() {
         return metrics;
+    }
+
+    /** Test accessors for the injected stores (#5378). */
+    public DeliveryStateStore stateStoreForTest() {
+        return stateStore;
+    }
+
+    public DeadLetterStore deadLetterStoreForTest() {
+        return deadLetterStore;
     }
 
     /**

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/http/UniHttpServer.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/http/UniHttpServer.java
@@ -209,6 +209,8 @@ public class UniHttpServer {
         server.createContext("/events/subscribe", this::subscribe);
         server.createContext("/events/unsubscribe", this::unsubscribe);
         server.createContext("/events/ack", this::ack);
+        // #5376: the receiving side of cross-instance forwarding (HttpForwarder POSTs here).
+        server.createContext("/internal/forward", this::internalForward);
         server.createContext("/events/poll", this::poll);
         server.createContext("/events/request", this::request);
         server.createContext("/events/reply", this::reply);
@@ -487,6 +489,49 @@ public class UniHttpServer {
             out.put("removed", ingress.unsubscribeByClient(clientId) > 0);
         }
         writeJson(exchange, 200, out);
+    }
+
+    /**
+     * #5376: receiving side of cross-instance forwarding. A partition-owning peer POSTs
+     * {@code {"clientId":..,"topic":..,"frameB64":..}}; we decode the frame and deliver through
+     * the local reliable path (same as a local poll dispatch), so ACK/redelivery semantics are
+     * identical for forwarded and local deliveries. 401 without the internal token when one is
+     * configured (the forwarder sends it from eventmesh.admin.token).
+     */
+    private void internalForward(HttpExchange exchange) throws IOException {
+        if (!"POST".equals(exchange.getRequestMethod())) {
+            writeJson(exchange, 405, error("method not allowed"));
+            return;
+        }
+        String token = System.getProperty("eventmesh.admin.token");
+        if (token != null && !token.isEmpty()) {
+            String header = exchange.getRequestHeaders().getFirst("Authorization");
+            if (header == null || !header.equals("Bearer " + token)) {
+                writeJson(exchange, 401, error("unauthorized"));
+                return;
+            }
+        }
+        JsonNode body = readJson(exchange);
+        String clientId = text(body, "clientId");
+        String topic = text(body, "topic");
+        String frameB64 = text(body, "frameB64");
+        if (clientId == null || topic == null || frameB64 == null) {
+            writeJson(exchange, 400, error("missing clientId/topic/frameB64"));
+            return;
+        }
+        try {
+            byte[] frameBytes = java.util.Base64.getDecoder().decode(frameB64);
+            org.apache.eventmesh.common.wire.EventMeshFrame frame =
+                org.apache.eventmesh.common.wire.EventMeshFrame.decode(frameBytes);
+            boolean delivered = ingress.deliverLocal(topic, clientId, frame);
+            if (delivered) {
+                writeJson(exchange, 200, ack("forwarded"));
+            } else {
+                writeJson(exchange, 404, error("no such client"));
+            }
+        } catch (IllegalArgumentException e) {
+            writeJson(exchange, 400, error("bad frame encoding: " + e.getMessage()));
+        }
     }
 
     private void ack(HttpExchange exchange) throws IOException {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/UniIngressService.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/ingress/UniIngressService.java
@@ -649,6 +649,16 @@ public class UniIngressService {
      * Enable multi-instance partition ownership (§13.2.3): when set, {@link #pullAndDispatch} polls
      * only this instance's owned partitions instead of the whole topic.
      */
+    /** The reliability dispatcher (boot wiring injects durable stores into it, #5378). */
+    public org.apache.eventmesh.runtime.delivery.ReliableDispatcher dispatcher() {
+        return dispatcher;
+    }
+
+    /** The installed ownership view, or null before {@link #withPartitionOwnership} (#5377). */
+    public org.apache.eventmesh.runtime.cluster.PartitionOwnership partitionOwnership() {
+        return partitionOwnership;
+    }
+
     public void withPartitionOwnership(org.apache.eventmesh.runtime.cluster.PartitionOwnership ownership) {
         this.partitionOwnership = ownership;
         // #5360: propagate the ownership view to the dispatcher so a fenced owner cannot write

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/boot/ClusterBootstrapCompositionTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/boot/ClusterBootstrapCompositionTest.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.boot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.eventmesh.runtime.cluster.ClusterCoordinator;
+import org.apache.eventmesh.runtime.cluster.InMemoryMetaStore;
+import org.apache.eventmesh.runtime.cluster.PartitionOwnership;
+import org.apache.eventmesh.runtime.delivery.ReliableDispatcher;
+import org.apache.eventmesh.runtime.offset.InMemoryOffsetStore;
+import org.apache.eventmesh.runtime.state.InMemoryDeliveryStateStore;
+import org.apache.eventmesh.runtime.state.MetaBackedDeadLetterStore;
+
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Issues #5376 / #5377 / #5378 acceptance: the cluster bootstrap composes ONE ownership
+ * lifecycle, a cluster-wide subscription route, and durable delivery/DLQ stores.
+ */
+class ClusterBootstrapCompositionTest {
+
+    @TempDir
+    java.nio.file.Path dir;
+
+    private UniRuntime runtime() {
+        return new UniRuntime(new StubStorage(), new InMemoryOffsetStore(),
+            20L, 50L, 100, 50L,
+            org.apache.eventmesh.runtime.cluster.DeliveryTopology.LOCAL_STICKY_PULL, "test", "test:8080");
+    }
+
+    /** #5377: with the app-layer ownership pre-installed, UniRuntime reuses it — one lifecycle. */
+    @Test
+    void runtimeReusesPreInstalledOwnership() throws Exception {
+        UniRuntime runtime = runtime();
+        InMemoryMetaStore meta = new InMemoryMetaStore();
+        // what enableCluster does: build + start ownership, install into ingress
+        org.apache.eventmesh.runtime.cluster.FencingToken token =
+            new org.apache.eventmesh.runtime.cluster.FencingToken();
+        org.apache.eventmesh.runtime.cluster.ClusterMembership membership =
+            new org.apache.eventmesh.runtime.cluster.ClusterMembership(meta, "test", "test:8080",
+                15_000L, System::currentTimeMillis, token);
+        PartitionOwnership installed = new PartitionOwnership(
+            membership, meta, runtime.storage(), "test", 5_000L, System::currentTimeMillis, token);
+        runtime.ingress().withPartitionOwnership(installed);
+        runtime.withClusterMeta(meta);
+        runtime.withTopology(org.apache.eventmesh.runtime.cluster.DeliveryTopology.PARTITION_OWNED_PULL);
+        runtime.start();
+        try {
+            assertSame(installed, runtime.ingress().partitionOwnership(),
+                "the pre-installed ownership must survive start (no second state machine)");
+            assertSame(installed, runtime.partitionOwnershipRefForTest(),
+                "UniRuntime must hold the SAME instance it stops on shutdown");
+        } finally {
+            runtime.shutdown();
+        }
+    }
+
+    /** #5376: the coordinator wired by enableCluster routes remote subscribers via forward. */
+    @Test
+    void coordinatorRoutesRemoteSubscriber() {
+        InMemoryMetaStore meta = new InMemoryMetaStore();
+        Map<String, AtomicInteger> forwards = new ConcurrentHashMap<>();
+        // instance B's subscription lands in the shared Meta (what ClusterSubscriptionStore.put does)
+        org.apache.eventmesh.runtime.cluster.ClusterSubscriptionStore storeB =
+            new org.apache.eventmesh.runtime.cluster.ClusterSubscriptionStore(meta);
+        storeB.put("orders", "client-B", "B",
+            org.apache.eventmesh.runtime.subscription.DistributionMode.BROADCAST, null);
+
+        // instance A (the partition owner) sees it through its own store view and forwards
+        org.apache.eventmesh.runtime.cluster.ClusterSubscriptionStore storeA =
+            new org.apache.eventmesh.runtime.cluster.ClusterSubscriptionStore(meta);
+        ClusterCoordinator a = new ClusterCoordinator("A", storeA,
+            (topic, clientId, event) -> false, // no local targets on A
+            (targetInstance, clientId, topic, event) -> {
+                forwards.computeIfAbsent(targetInstance + ":" + clientId, k -> new AtomicInteger())
+                    .incrementAndGet();
+                return true;
+            });
+        org.apache.eventmesh.common.wire.EventMeshFrame frame =
+            org.apache.eventmesh.common.wire.EventMeshFrame.event(
+                new java.util.LinkedHashMap<>(Map.of("id", "e-1")), new byte[] {1});
+        int delivered = a.dispatch("orders", frame);
+        assertEquals(1, delivered, "the remote subscriber receives the event via forward");
+        assertEquals(1, forwards.get("B:client-B").get(),
+            "exactly one forward to B for client-B");
+    }
+
+    /** #5378: durable delivery-state + DLQ ledger injection takes effect on the dispatcher. */
+    @Test
+    void durableStoresInjectIntoDispatcher() throws Exception {
+        UniRuntime runtime = runtime();
+        runtime.start();
+        try {
+            ReliableDispatcher dispatcher = runtime.ingress().dispatcher();
+            assertNotNull(dispatcher, "ingress exposes its dispatcher for boot wiring");
+
+            // in-flight guard: swapping with pending deliveries must fail closed
+            String id = dispatcher.deliver("orders", 0, 1L,
+                org.apache.eventmesh.common.wire.EventMeshFrame.event(
+                    new java.util.LinkedHashMap<>(), new byte[] {1}),
+                "client", (deliveryId, event, cb) -> { }, null);
+            IllegalStateException ex = org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> dispatcher.withStateStore(new InMemoryDeliveryStateStore()));
+            assertTrue(ex.getMessage().contains("in-flight"), ex.getMessage());
+            // clear the pending delivery, then the swap succeeds
+            dispatcher.ack(id);
+            InMemoryDeliveryStateStore replacement = new InMemoryDeliveryStateStore();
+            dispatcher.withStateStore(replacement);
+            assertSame(replacement, dispatcher.stateStoreForTest());
+
+            // DLQ ledger attach is a plain setter
+            MetaBackedDeadLetterStore ledger = new MetaBackedDeadLetterStore(new InMemoryMetaStore());
+            dispatcher.withDeadLetterStore(ledger);
+            assertSame(ledger, dispatcher.deadLetterStoreForTest());
+        } finally {
+            runtime.shutdown();
+        }
+    }
+
+    /** #5378: the RocksDB delivery-state store round-trips records under the data path. */
+    @Test
+    void rocksDbDeliveryStateStoreRoundTrips() throws Exception {
+        java.nio.file.Path path = dir.resolve("delivery-state");
+        org.apache.eventmesh.runtime.state.RocksDBDeliveryStateStore store =
+            new org.apache.eventmesh.runtime.state.RocksDBDeliveryStateStore(path.toString());
+        org.apache.eventmesh.runtime.state.DeliveryStateStore.Record rec =
+            new org.apache.eventmesh.runtime.state.DeliveryStateStore.Record(
+                "d-1", "orders", 0, 5L, "client-1", 1, 0L, new byte[] {1, 2, 3});
+        store.put(rec);
+        store.flush();
+        org.apache.eventmesh.runtime.state.DeliveryStateStore.Record read = store.get("d-1");
+        assertNotNull(read, "the record survives the flush");
+        assertEquals("orders", read.topic);
+        store.remove("d-1");
+        store.close();
+        assertTrue(Files.exists(path), "the RocksDB dir persists after close");
+    }
+
+    /** Minimal storage stub (mirrors EventMeshApplicationStartupTest). */
+    private static final class StubStorage implements org.apache.eventmesh.api.storage.MeshStoragePlugin {
+
+        @Override
+        public void init(java.util.Properties props) {
+            // no-op
+        }
+
+        @Override
+        public void send(String topic, org.apache.eventmesh.common.wire.EventMeshFrame frame,
+            org.apache.eventmesh.api.SendCallback callback) {
+            // no-op
+        }
+
+        @Override
+        public java.util.List<org.apache.eventmesh.common.wire.EventMeshFrame> poll(
+            String topic, int partition, long startOffset, int maxEvents, long timeoutMs) {
+            return java.util.Collections.emptyList();
+        }
+
+        @Override
+        public void assignPartitions(String topic, java.util.List<Integer> partitions) {
+            // no-op
+        }
+
+        @Override
+        public void commitOffset(String topic, int partition, long offset) {
+            // no-op
+        }
+
+        @Override
+        public int partitionCount(String topic) {
+            return 1;
+        }
+
+        @Override
+        public boolean isStarted() {
+            return true;
+        }
+
+        @Override
+        public boolean isClosed() {
+            return false;
+        }
+
+        @Override
+        public void start() {
+            // no-op
+        }
+
+        @Override
+        public void shutdown() {
+            // no-op
+        }
+    }
+}

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/StateStoreDurabilityTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/StateStoreDurabilityTest.java
@@ -200,11 +200,27 @@ class StateStoreDurabilityTest {
             assertEquals(iters, removes.get());
 
             // Final state on A: the entry is either present (last write was a put)
-            // or absent (last write was a remove). Both instances must agree.
-            String viewA = a.instanceOf("storm-client");
-            String viewB = b.instanceOf("storm-client");
-            assertEquals(viewA, viewB,
-                "both instances must agree on the final binding (convergence)");
+            // or absent (last write was a remove). Both instances must agree. The two reads
+            // are not one atomic snapshot (a late remove can land between them), so poll
+            // until the views hold STILL equal for two consecutive reads (bounded wait).
+            String prevA = null;
+            String prevB = null;
+            boolean converged = false;
+            for (int probe = 0; probe < 200; probe++) {
+                String viewA = a.instanceOf("storm-client");
+                String viewB = b.instanceOf("storm-client");
+                if (java.util.Objects.equals(viewA, viewB)
+                    && java.util.Objects.equals(viewA, prevA) && java.util.Objects.equals(viewB, prevB)
+                    && (probe > 0)) {
+                    converged = true;
+                    break;
+                }
+                prevA = viewA;
+                prevB = viewB;
+                Thread.sleep(5);
+            }
+            assertTrue(converged,
+                "both instances must agree on a stable final binding (got A=" + prevA + " B=" + prevB + ")");
             // The first-scenario write (topic-1 / client-1) must still be
             // visible to both - watch prefix is durable across put/remove storms.
             assertEquals("instance-A", a.instanceOf("client-1"));


### PR DESCRIPTION
## What this PR does

Three coupled review findings on the default cluster bootstrap — fixed together because they compose into one wiring path.

**Closes #5376 · Closes #5377 · Closes #5378**

### #5376 — cluster-wide subscription routing for PARTITION_OWNED_PULL

| Change | Effect |
|---|---|
| `enableCluster()` builds `ClusterSubscriptionStore` (Meta prefix watch) + `ClusterCoordinator` and injects via `withCluster()` | The partition owner's poll loop sees subscribers on OTHER instances (it dispatched through its LOCAL `SubscriptionManager` only → remote subscribers starved) |
| New **`HttpForwarder`** | `POST /internal/forward` to the target instance (address via `ClusterMembership.addressOf`, bearer from `eventmesh.admin.token`, frame base64-wrapped) |
| New **`POST /internal/forward`** on `UniHttpServer` | Decodes and delivers through the local reliable path — ACK/redelivery semantics identical for forwarded and local deliveries; 401 when the internal token is configured and missing |
| `ClusterSubscriptionStore` put/remove now **apply locally BEFORE the Meta write** | A trailing own-apply escaped the authoritative Meta event order and could resurrect a concurrently-deleted value in the local cache (divergent views). The storm convergence test is now poll-stable. |

### #5377 — one PartitionOwnership lifecycle per instance

`UniRuntime.startPartitionOwnership()` **reuses** the ownership that `enableCluster()` already built and installed into the ingress (one membership, one heartbeat loop, one fencing token); it self-constructs only when nobody wired one (embedder path). Previously the #5359 topology flip made `UniRuntime.start()` create a **second** `ClusterMembership` + `PartitionOwnership` with a different token and replace the ingress view — two divergent state machines per runtime.

### #5378 — durable delivery + DLQ ledger in the default bootstrap

- `ReliableDispatcher.withStateStore()` / `withDeadLetterStore()`: post-construction injection for boot wiring order; the swap **fails closed** when deliveries are in flight.
- `EventMeshApplication.main()` constructs `RocksDBDeliveryStateStore` under `<dataDir>/delivery-state` and (clustered) a `MetaBackedDeadLetterStore`, injects both, **logs the effective implementations at boot**, and closes the store on shutdown so in-flight records survive for restart recovery. The default path previously fell back to `InMemoryDeliveryStateStore` — a crash lost every pulled-but-unACKed delivery.

### Tests (new `ClusterBootstrapCompositionTest`, 4 cases)

- `runtimeReusesPreInstalledOwnership` (#5377)
- `coordinatorRoutesRemoteSubscriber` (#5376 — remote subscriber via forward, exactly one forward)
- `durableStoresInjectIntoDispatcher` (#5378 — in-flight swap fails; post-clear swap + ledger attach take effect)
- `rocksDbDeliveryStateStoreRoundTrips` (#5378 durability baseline)

Local verification (Temurin 21.0.11): runtime tests + checkstyle (maxWarnings=0) + architecture-guard tests all green.

Co-authored-by: qqeasonchen <qqeasonchen@gmail.com>
