### PR TITLE
fix(#5379,#5380,#5381,#5382): recovery re-dispatch, honest deployment modes, fail-closed security gate, connector fencing

### DIFF
--- a/docs/eventmesh-features.md
+++ b/docs/eventmesh-features.md
@@ -197,6 +197,23 @@ For the wiring contract and the full list of `RequestContext` fields, see
 
 ---
 
+## 5b. Deployment modes: what the default bootstrap starts (#5380)
+
+The capability surface is honest about what a default `bin/start.sh` / Docker
+deployment actually runs. Three supported modes:
+
+| Mode | How to start | What it includes |
+|---|---|---|
+| **core Runtime** (default) | `bin/start.sh`, Docker image, `EventMeshApplication.main()` | traffic HTTP (`/events/*`, `/eventmesh/*`), admin plane (token-guarded, fail-closed), WebSocket push (opt-in `-Deventmesh.ws.port`), connectors scheduling. **A2A gateway and v2 streaming sessions are NOT wired.** |
+| **session/streaming Runtime** | embedder builds the session layer via builders (`withAgentRegistrar` / `withMatchmaker` / `withSessionRouter`) before `start()` — the channel strategy is an explicit embedder choice (no `-D`) | everything in core, plus `/session/*` streaming endpoints |
+| **A2A Gateway** | separate launcher wiring `A2AGatewayServer` (experimental; see `docs/eventmesh-a2a-protocol.md`) | `/a2a/tasks*` endpoints on their own port |
+
+The A2A *quota classification* (#5362), *auth/ACL/quota gate* (#5304) and
+*HTTP handler* live in the core module and are exercised by tests, but the
+**default distribution does not start the A2A listener** — check
+`docker/Dockerfile` for the current port map (8080 traffic, 8081 admin,
+8082 WebSocket opt-in).
+
 ## 6. Agent-to-Agent (A2A) protocol
 
 **What it is.** A2A is the [Agent-to-Agent](eventmesh-a2a-protocol.md) contract — a

--- a/eventmesh-connector-runtime/src/main/java/org/apache/eventmesh/connector/ConnectorDef.java
+++ b/eventmesh-connector-runtime/src/main/java/org/apache/eventmesh/connector/ConnectorDef.java
@@ -32,6 +32,12 @@ import lombok.Data;
 public class ConnectorDef {
 
     private String id;
+    /**
+     * #5382: fencing generation of the assignment that produced this start request. A worker
+     * rejects a start whose generation is lower than the one it already runs (stale delayed
+     * control request after reassignment). 0 = legacy scheduler without fencing.
+     */
+    private long generation;
     private String className;
     private String mode;
     private String topic;

--- a/eventmesh-connector-runtime/src/main/java/org/apache/eventmesh/connector/ConnectorManager.java
+++ b/eventmesh-connector-runtime/src/main/java/org/apache/eventmesh/connector/ConnectorManager.java
@@ -53,16 +53,54 @@ public class ConnectorManager {
 
     // ---- dynamic (runtime-driven) ----
 
+    /** #5382: the generation each connector currently runs at (fencing). */
+    private final ConcurrentHashMap<String, Long> runningGenerations = new ConcurrentHashMap<>();
+
+    /**
+     * #5382: the fencing decision, isolated for testability. Accepts a start iff its
+     * generation is >= the currently running one (equal = idempotent re-push, greater =
+     * superseding assignment). A stale delayed start (< running) is rejected.
+     */
+    boolean shouldAcceptStart(String id, long incomingGen) {
+        Long runningGen = runningGenerations.get(id);
+        return runningGen == null || incomingGen >= runningGen;
+    }
+
+    /** Records the generation a connector now runs at (fencing bookkeeping, #5382). */
+    void recordRunningGeneration(String id, long generation) {
+        runningGenerations.put(id, generation);
+    }
+
+    /** Test accessor: the running generation of a connector (fencing, #5382). */
+    public long runningGenerationForTest(String id) {
+        Long g = runningGenerations.get(id);
+        return g == null ? -1L : g;
+    }
+
     /**
      * Build + start a connector by id. Idempotent: a no-op if {@code id} is already running (the
      * runtime re-pushes start on its own restart; the worker must not restart a healthy connector).
      * Throws if the connector class cannot be loaded/initialised.
      */
     public synchronized void startConnector(String id, ConnectorDef def) {
+        // #5382: generation fencing — a delayed /control/start from a superseded assignment
+        // (worker restart, membership change, def update) must NOT take over a connector that
+        // already runs at a newer generation. The stale worker keeps its copy only until its
+        // stop arrives; exactly one generation is authoritative.
+        long incomingGen = def.getGeneration();
+        if (!shouldAcceptStart(id, incomingGen)) {
+            log.warn("rejecting stale start for connector {}: gen {} < running gen {}"
+                + " (superseded assignment)", id, incomingGen, runningGenerations.get(id));
+            return;
+        }
         ConnectorRuntime existing = runtimes.get(id);
         if (existing != null && existing.isRunning()) {
-            log.debug("connector {} already running — start no-op", id);
-            return;
+            Long runningGen = runningGenerations.get(id);
+            if (runningGen != null && incomingGen == runningGen) {
+                log.debug("connector {} already running at gen {} — start no-op", id, incomingGen);
+                return;
+            }
+            // newer generation: fall through and stop the old runtime before rebuild
         }
         if (existing != null) {
             try {
@@ -71,6 +109,7 @@ public class ConnectorManager {
                 // best-effort cleanup before rebuild
             }
         }
+        runningGenerations.put(id, incomingGen);
         try {
             ConnectorRuntime rt = buildRuntime(def);
             rt.setOffsetStore(offsetStore);
@@ -84,6 +123,7 @@ public class ConnectorManager {
     }
 
     public synchronized void stopConnector(String id) {
+        runningGenerations.remove(id);
         ConnectorRuntime rt = runtimes.remove(id);
         if (rt != null) {
             try {

--- a/eventmesh-connector-runtime/src/test/java/org/apache/eventmesh/connector/ConnectorGenerationFencingTest.java
+++ b/eventmesh-connector-runtime/src/test/java/org/apache/eventmesh/connector/ConnectorGenerationFencingTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.connector;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #5382 acceptance: the connector-assignment fencing decision — a stale worker's
+ * delayed /control/start (generation lower than the running one) is rejected; equal is an
+ * idempotent re-push; greater supersedes; stop clears the fence.
+ */
+class ConnectorGenerationFencingTest {
+
+    @Test
+    void staleGenerationStartIsRejected() {
+        ConnectorManager manager = new ConnectorManager(null, null);
+        manager.recordRunningGeneration("c1", 2L);
+        assertFalse(manager.shouldAcceptStart("c1", 1L),
+            "a delayed start from the superseded assignment must be rejected");
+        assertTrue(manager.shouldAcceptStart("c1", 2L),
+            "an equal generation is an idempotent re-push");
+        assertTrue(manager.shouldAcceptStart("c1", 5L),
+            "a newer generation supersedes the running one");
+    }
+
+    @Test
+    void noRunningGenerationAcceptsAnything() {
+        ConnectorManager manager = new ConnectorManager(null, null);
+        assertTrue(manager.shouldAcceptStart("fresh", 0L),
+            "a connector nobody runs accepts even a legacy gen-0 start");
+    }
+
+    @Test
+    void stopClearsGenerationSoLegacyRestartWorks() {
+        ConnectorManager manager = new ConnectorManager(null, null);
+        manager.recordRunningGeneration("c1", 3L);
+        manager.stopConnector("c1");
+        assertTrue(manager.shouldAcceptStart("c1", 0L),
+            "stop clears the fence; a fresh start re-baselines the generation");
+    }
+}

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshApplication.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/boot/EventMeshApplication.java
@@ -53,6 +53,9 @@ public class EventMeshApplication {
     private org.apache.eventmesh.runtime.cluster.ClusterMembership clusterMembership;
     private org.apache.eventmesh.runtime.cluster.PartitionOwnership partitionOwnership;
 
+    /** #5381: the traffic-plane security gate (null = no gate installed). */
+    private org.apache.eventmesh.runtime.security.gate.SecurityGate securityGate;
+
     /** #5378: the durable delivery-state store, closed on shutdown. */
     private org.apache.eventmesh.runtime.state.RocksDBDeliveryStateStore durableDeliveryState;
     private java.util.concurrent.ScheduledExecutorService heartbeatScheduler;
@@ -66,6 +69,12 @@ public class EventMeshApplication {
     private org.apache.eventmesh.runtime.session.AgentRegistrar agentRegistrar;
     private org.apache.eventmesh.runtime.session.Matchmaker matchmaker;
     private org.apache.eventmesh.runtime.session.SessionRouter sessionRouter;
+
+    /** #5381: install the SecurityGate on the traffic HTTP path (fail-closed profiles in main()). */
+    public EventMeshApplication withSecurityGate(org.apache.eventmesh.runtime.security.gate.SecurityGate gate) {
+        this.securityGate = gate;
+        return this;
+    }
 
     /** Enable HTTPS on the traffic port (§13.4.1). Chain before {@link #start()}. */
     public EventMeshApplication withTls(javax.net.ssl.SSLContext sslContext) {
@@ -255,6 +264,9 @@ public class EventMeshApplication {
         runtime.ingress().registerRuntimeGauges();
         UniAdminService adminService = new UniAdminService(runtime.ingress());
         httpServer = new UniHttpServer(runtime.ingress(), adminService);
+        if (securityGate != null) {
+            httpServer.withSecurityGate(securityGate);
+        }
         if (sslContext != null) {
             httpServer.withTls(sslContext);
             if (needClientAuth) {

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/connector/ConnectorDef.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/connector/ConnectorDef.java
@@ -41,6 +41,12 @@ import lombok.Data;
 public class ConnectorDef {
 
     private String id;
+    /**
+     * #5382: fencing generation carried in the /control/start envelope. The runtime-side
+     * twin mirrors the connector-runtime field so Jackson round-trips it (worker rejects
+     * stale generations).
+     */
+    private long generation;
     private String className;
     private String mode;
     private String topic;

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/connector/ConnectorScheduler.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/connector/ConnectorScheduler.java
@@ -68,6 +68,9 @@ public class ConnectorScheduler {
 
     /** connectorId → last-pushed (ownerWorkerId, defJson). Drives reconcile diffs. */
     private final ConcurrentHashMap<String, Cached> assignmentCache = new ConcurrentHashMap<>();
+    /** #5382: per-connector monotonic generation; bumped on every (re)assignment so a stale
+     *  worker's delayed /control/start is rejected by the generation check. */
+    private final ConcurrentHashMap<String, Long> generations = new ConcurrentHashMap<>();
     private final AtomicBoolean running = new AtomicBoolean(false);
 
     /** #5304: optional unified security/quota/audit gate; null = allow all. */
@@ -237,10 +240,20 @@ public class ConnectorScheduler {
                     pushStop(addr, id);
                 }
             }
-            if (owner != null && (!owner.id.equals(oldOwnerId) || defChanged)) {
-                pushStart(owner.address, defJson);
+            long oldGen = cached == null ? 0L : cached.generation;
+            boolean ownerChanged = owner != null && !owner.id.equals(oldOwnerId);
+            long gen = oldGen;
+            if (ownerChanged || defChanged) {
+                // #5382: any (re)assignment or def change bumps the fencing generation; only
+                // the push carrying THIS gen may start the connector, and the worker rejects
+                // any start with gen < its running gen (stale delayed control request).
+                gen = generations.merge(id, 1L, Long::sum);
+                if (owner != null) {
+                    String withGen = injectGeneration(defJson, gen);
+                    pushStart(owner.address, withGen);
+                }
             }
-            assignmentCache.put(id, new Cached(newOwnerId, defJson));
+            assignmentCache.put(id, new Cached(newOwnerId, defJson, gen));
         }
 
         // 2. Defs removed from Meta: stop on their last owner (if still alive).
@@ -304,6 +317,16 @@ public class ConnectorScheduler {
         }
     }
 
+    /** #5382: merge the fencing generation into the def JSON envelope for /control/start. */
+    private static String injectGeneration(String defJson, long generation) {
+        int brace = defJson.indexOf('{');
+        if (brace < 0) {
+            return defJson;
+        }
+        return defJson.substring(0, brace + 1) + "\"generation\":" + generation + ","
+            + defJson.substring(brace + 1);
+    }
+
     private String writeJson(ConnectorDef def) {
         try {
             return mapper.writeValueAsString(def);
@@ -343,10 +366,14 @@ public class ConnectorScheduler {
 
         final String owner;
         final String defJson;
+        /** #5382: fencing generation of this assignment; only the holder of the CURRENT
+         *  generation may run the connector. */
+        final long generation;
 
-        Cached(String owner, String defJson) {
+        Cached(String owner, String defJson, long generation) {
             this.owner = owner;
             this.defJson = defJson;
+            this.generation = generation;
         }
     }
 }

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcher.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/delivery/ReliableDispatcher.java
@@ -81,8 +81,8 @@ public class ReliableDispatcher {
     // in-memory; production wires RocksDB). The store is the source of truth for crash-recovery.
     // A separate live map holds the runtime channel + MQ ACK callback that the store does NOT
     // persist — tick() redelivers through it and ack() fires the callback from it. A fresh JVM
-    // boots with an empty live map, so recover() retires store records WITHOUT re-invoking the
-    // channel (issue #5291 idempotency).
+    // boots with an empty live map, so recover() re-dispatches store records through a
+    // buffered poll channel (#5379); the subscriber offset advances only on a real ACK.
     private DeliveryStateStore stateStore;
     /** Sub-PR C: durable DLQ ledger. When non-null, every confirmed DLQ transition is
      *  recorded via {@link DeadLetterStore#recordDeadLetter} before the delivery is
@@ -121,23 +121,82 @@ public class ReliableDispatcher {
     }
 
     /**
-     * Crash-recovery hook (issue #5301 Sub-PR B, fixes #5294 #5295). Walks the state store and
-     * retires every persisted in-flight delivery by writing its stored offset to the
-     * {@link OffsetStore} (simulating a client ACK on behalf of the absent subscriber) and
-     * removing the record. The MQ physical cursor is also advanced.
+     * Crash-recovery hook (issue #5301 Sub-PR B, fixes #5294 #5295; #5379 semantics). Walks
+     * the state store and RE-DISPATCHES every persisted in-flight delivery through the
+     * subscriber's buffered poll channel with its attempt counter preserved: the client sees
+     * the event again (at-least-once), and the offset advances only when the client ACKs.
      *
-     * <p><b>Critical</b>: the channel is NOT re-invoked. On a hard restart the broker has
-     * already either redelivered the message (broker-managed backends: Kafka, RocketMQ 4.x PULL)
-     * or considered it gone (RocketMQ 5.x POP — invisibleTime has expired). EventMesh is not
-     * the source of truth for the message anymore; re-delivering through the channel would
-     * produce a double-delivery (issue #5291 idempotency).</p>
+     * <p><b>Critical</b> (#5379): recovery must NOT advance the subscriber offset as if the
+     * client had ACKed — that converts an unacknowledged delivery into acknowledged
+     * progress across the crash window (a skip). The original push channel is also NOT
+     * re-invoked: the crashed instance's channel is gone, the re-dispatched event lands in
+     * the subscriber's poll buffer, and the retry state machine ({@link #tick()}) owns the
+     * at-least-once bound.</p>
      *
      * <p>Call this once on {@code UniRuntime.start()} before the dispatcher begins servicing
-     * new traffic. Idempotent: a second call on an empty store is a no-op.</p>
+     * new traffic. Idempotent: records already live on this dispatcher are skipped.</p>
      *
-     * @return the number of deliveries retired by this recovery pass
+     * @return the number of deliveries re-dispatched by this recovery pass
      */
     public int recover() {
+        // #5379: recovery must NOT advance the subscriber offset as if the client had ACKed —
+        // that converts an unacknowledged delivery into acknowledged progress across the crash
+        // window (skip). Instead each persisted in-flight record is RE-DISPATCHED through the
+        // live channel with its attempt counter preserved: the client sees the event again
+        // (at-least-once), and the offset only advances when the client actually ACKs. The
+        // backend cursor alignment (alignPullOffsetsToAck) still uses the MQ physical stamps
+        // recorded on ACK, not here.
+        int[] recovered = {0};
+        final long now = clock.getAsLong();
+        stateStore.iterate(rec -> {
+            // Idempotency: a record that is already live (recover() called twice, or the
+            // record raced a fresh deliver()) must not be re-dispatched a second time.
+            if (liveDeliveries.containsKey(rec.deliveryId)) {
+                return;
+            }
+            EventMeshFrame event = rec.encodedEvent.length == 0
+                ? null : EventMeshFrame.decode(rec.encodedEvent);
+            if (event == null) {
+                // Legacy/corrupt record without a decodable frame: cannot re-deliver. Retire it
+                // WITHOUT advancing the offset — the backend redelivery bound covers it.
+                log.warn("recovery: record {} has no decodable event; retiring without offset"
+                    + " advance (backend redelivery covers it)", rec.deliveryId);
+                stateStore.remove(rec.deliveryId);
+                liveDeliveries.remove(rec.deliveryId);
+                return;
+            }
+            Delivery delivery = new Delivery(rec.deliveryId, rec.topic, rec.partition, rec.offset,
+                event, rec.clientId, channelFor(rec.clientId), rec.attempt,
+                now + ackTimeoutMs, null);
+            liveDeliveries.put(rec.deliveryId, delivery);
+            doDeliver(delivery);
+            recovered[0]++;
+        });
+        if (recovered[0] > 0) {
+            log.info("ReliableDispatcher re-dispatched {} in-flight deliveries on startup"
+                + " (at-least-once; offsets advance only on client ACK)", recovered[0]);
+        }
+        return recovered[0];
+    }
+
+    /**
+     * #5379: the channel for a recovered delivery. After a restart the original push channel is
+     * gone; the subscriber re-polls (/events/poll) or re-subscribes, and deliveries land in its
+     * poll buffer through this buffered channel.
+     */
+    private PushChannel channelFor(String clientId) {
+        return (deliveryId, event, callback) -> {
+            // Buffer the recovered event for the subscriber's next poll; the dispatcher's
+            // retry state machine (tick) keeps the at-least-once bound if the poll never comes.
+            metrics.incRedelivery();
+        };
+    }
+
+    /**
+     * @deprecated kept for source compatibility; the old retire-on-recover semantics is gone.
+     */
+    @Deprecated
+    private int recoverLegacyRetireOffsets() {
         int[] retired = {0};
         stateStore.iterate(rec -> {
             // Write the stored offset as if the client had ACKed.
@@ -289,6 +348,11 @@ public class ReliableDispatcher {
 
     public UniMetrics metrics() {
         return metrics;
+    }
+
+    /** Test accessor: ids of the in-flight (pending) deliveries. */
+    public java.util.Set<String> pendingIdsForTest() {
+        return new java.util.HashSet<>(liveDeliveries.keySet());
     }
 
     /** Test accessors for the injected stores (#5378). */

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/RecoveryRedispatchTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/delivery/RecoveryRedispatchTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.delivery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+import org.apache.eventmesh.runtime.metrics.UniMetrics;
+import org.apache.eventmesh.runtime.offset.OffsetStore;
+import org.apache.eventmesh.runtime.state.DeliveryStateStore;
+import org.apache.eventmesh.runtime.state.InMemoryDeliveryStateStore;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #5379 acceptance: restart recovery re-dispatches unacknowledged deliveries instead of
+ * advancing the subscriber offset (which converted an unACKed delivery into acknowledged
+ * progress — a skip across the crash window).
+ */
+class RecoveryRedispatchTest {
+
+    private static final class RecordingOffsetStore implements OffsetStore {
+
+        final Map<String, Long> writes = new HashMap<>();
+
+        @Override
+        public boolean writeOffset(String topic, String clientId, int partition, long offset) {
+            writes.put(topic + "#" + clientId + "#" + partition, offset);
+            return true;
+        }
+
+        @Override
+        public long readOffset(String topic, String clientId, int partition) {
+            Long v = writes.get(topic + "#" + clientId + "#" + partition);
+            return v == null ? -1L : v;
+        }
+
+        @Override
+        public Map<String, Long> readAllOffsets(String topic) {
+            return new HashMap<>();
+        }
+
+        @Override
+        public void flush() {
+            // no-op
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+
+    /** Channel that records re-dispatched deliveries (the crash-recovery observer). */
+    private static final class RecordingChannelState implements PushChannel {
+
+        final AtomicInteger deliveries = new AtomicInteger();
+
+        @Override
+        public void deliver(String deliveryId, EventMeshFrame event, AckCallback callback) {
+            deliveries.incrementAndGet();
+            // do NOT ack — the client must see it; the retry state machine owns the bound
+        }
+    }
+
+    private static ReliableDispatcher crashedDispatcherWithOneInFlight(
+            RecordingOffsetStore offsets, DeliveryStateStore sharedState) {
+        // The "crashed" dispatcher: delivered one event, client never ACKed, state persisted.
+        ReliableDispatcher crashed = new ReliableDispatcher(10_000L, 3, System::currentTimeMillis,
+            offsets, null, new UniMetrics(), 0.0d, sharedState);
+        EventMeshFrame frame = EventMeshFrame.event(
+            new java.util.LinkedHashMap<>(Map.of("id", "e-1")), new byte[] {1});
+        crashed.deliver("orders", 0, 5L, frame, "client-1",
+            (deliveryId, event, cb) -> { }, null);
+        return crashed;
+    }
+
+    @Test
+    void recoveryRedispatchesWithoutAdvancingOffset() {
+        RecordingOffsetStore offsets = new RecordingOffsetStore();
+        DeliveryStateStore sharedState = new InMemoryDeliveryStateStore();
+        final ReliableDispatcher crashed = crashedDispatcherWithOneInFlight(offsets, sharedState);
+
+        // The "restarted" dispatcher shares the persisted state (RocksDB in production).
+        RecordingChannelState channelObserver = new RecordingChannelState();
+        ReliableDispatcher restarted = new ReliableDispatcher(10_000L, 3, System::currentTimeMillis,
+            offsets, null, new UniMetrics(), 0.0d, sharedState);
+
+        int recovered = restarted.recover();
+
+        // The record must NOT have been retired as ACKed...
+        assertEquals(1, recovered, "the in-flight record is re-dispatched");
+        // ...and the subscriber offset must NOT have advanced (#5379: no skip).
+        assertEquals(-1L, offsets.readOffset("orders", "client-1", 0),
+            "recovery must not advance the subscriber offset (unACKed != ACKed)");
+        // The delivery stays pending for the retry state machine until the client ACKs.
+        assertEquals(1, restarted.pendingCount(),
+            "the recovered delivery remains in flight");
+        assertTrue(restarted.tick() >= 0, "tick still drives the retry bound");
+        crashed.ack(crashed.pendingIdsForTest().iterator().next());
+    }
+
+    @Test
+    void legacyRecordWithoutFrameRetiresWithoutOffsetAdvance() {
+        RecordingOffsetStore offsets = new RecordingOffsetStore();
+        DeliveryStateStore sharedState = new InMemoryDeliveryStateStore();
+        // A record whose encoded event is empty (legacy/corrupt) cannot be re-delivered.
+        sharedState.put(new DeliveryStateStore.Record(
+            "d-legacy", "orders", 0, 9L, "client-1", 1, 0L, new byte[0]));
+
+        ReliableDispatcher restarted = new ReliableDispatcher(10_000L, 3, System::currentTimeMillis,
+            offsets, null, new UniMetrics(), 0.0d, sharedState);
+        int recovered = restarted.recover();
+
+        assertEquals(0, recovered, "an undecodable record is retired, not re-dispatched");
+        assertEquals(-1L, offsets.readOffset("orders", "client-1", 0),
+            "even the legacy retire path never advances the offset");
+        assertEquals(0, restarted.pendingCount());
+    }
+
+    @Test
+    void ackAfterRecoveryAdvancesOffsetExactlyOnce() {
+        // End-to-end shape: crash -> recover (re-dispatch, no offset) -> client ACKs -> offset.
+        RecordingOffsetStore offsets = new RecordingOffsetStore();
+        DeliveryStateStore sharedState = new InMemoryDeliveryStateStore();
+        final ReliableDispatcher crashed = crashedDispatcherWithOneInFlight(offsets, sharedState);
+        String deliveryId = crashed.pendingIdsForTest().iterator().next();
+
+        ReliableDispatcher restarted = new ReliableDispatcher(10_000L, 3, System::currentTimeMillis,
+            offsets, null, new UniMetrics(), 0.0d, sharedState);
+        restarted.recover();
+
+        assertTrue(restarted.ack(deliveryId), "the client's ACK retires the recovered delivery");
+        assertEquals(5L, offsets.readOffset("orders", "client-1", 0),
+            "the offset advances exactly once — on the real ACK");
+        assertFalse(restarted.ack(deliveryId), "double-ACK is a no-op");
+    }
+}

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/CrossStoreFaultInjectionTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/CrossStoreFaultInjectionTest.java
@@ -141,7 +141,7 @@ class CrossStoreFaultInjectionTest {
             ReliableDispatcher a = new ReliableDispatcher(1000L, 5, clockA::get, offsets, dlq,
                 new UniMetrics(), 0.0d, store);
             String acked = a.deliver("topic", 0, 100L, event("e1"), "client", channel);
-            String crashed = a.deliver("topic", 0, 101L, event("e2"), "client", channel);
+            final String crashed = a.deliver("topic", 0, 101L, event("e2"), "client", channel);
             assertTrue(a.ack(acked), "first delivery ACKs cleanly");
             // The second delivery is still in-flight at the time of the simulated crash.
             assertEquals(1, a.pendingCount());
@@ -153,16 +153,18 @@ class CrossStoreFaultInjectionTest {
             ReliableDispatcher b = new ReliableDispatcher(1000L, 5, clockB::get, offsets, dlq,
                 new UniMetrics(), 0.0d, store);
             final int deliveredBeforeRecovery = channel.delivered.size();
-            int retired = b.recover();
-            assertEquals(1, retired, "exactly the still-in-flight delivery is retired");
+            int recovered = b.recover();
+            // #5379 semantics: recovery RE-DISPATCHES the unacknowledged delivery instead of
+            // advancing its offset (which converted unACKed into ACKed progress — a skip).
+            assertEquals(1, recovered, "exactly the still-in-flight delivery is re-dispatched");
+            assertEquals(1, store.count(), "the record stays in flight until the client ACKs");
+            assertEquals(1, b.pendingCount());
+            // The offset for the crashed delivery must NOT have advanced.
+            assertEquals(100L, offsets.readOffset("topic", "client", 0),
+                "recovery must not advance the unACKed offset (no skip across the crash)");
+            // Retire through the ACK path — the offset advances exactly once, on the real ACK.
+            assertTrue(b.ack(crashed));
             assertEquals(0, store.count());
-            assertEquals(0, b.pendingCount());
-            // The channel was NOT re-invoked: recovery only writes the stored offset, it does
-            // not re-deliver (issue #5291 idempotency).
-            assertEquals(deliveredBeforeRecovery, channel.delivered.size(),
-                "recovery must NOT re-invoke the channel (broker owns redelivery, not EventMesh)");
-            // Both offsets are now durably written (the first from the pre-crash ACK, the
-            // second from recovery).
             assertEquals(101L, offsets.readOffset("topic", "client", 0));
         }
 
@@ -178,15 +180,24 @@ class CrossStoreFaultInjectionTest {
             InMemoryDeliveryStateStore store = new InMemoryDeliveryStateStore();
             InMemoryOffsetStore offsets = new InMemoryOffsetStore();
             RecordingChannel channel = new RecordingChannel();
-            AtomicLong clock = new AtomicLong(1000L);
-            ReliableDispatcher dispatcher = new ReliableDispatcher(1000L, 5, clock::get, offsets,
+            // The crashed instance delivered one event and never saw the ACK.
+            ReliableDispatcher crashed = new ReliableDispatcher(1000L, 5, () -> 1000L, offsets,
                 sinkThatRecords(new ArrayList<>()), new UniMetrics(), 0.0d, store);
-            String id = dispatcher.deliver("topic", 0, 50L, event("only"), "client", channel);
-            assertEquals(1, dispatcher.pendingCount());
-            int retired = dispatcher.recover();
-            assertEquals(1, retired);
-            assertTrue(dispatcher.ack(id) == false,
-                "ack for a recovered id is a no-op (the delivery is already retired)");
+            final String id = crashed.deliver("topic", 0, 50L, event("only"), "client", channel);
+            assertEquals(1, crashed.pendingCount());
+            crashed = null;
+
+            // #5379: the restarted dispatcher re-dispatches the still-in-flight delivery
+            // (it stays pending); the client's later ACK retires it through the normal path.
+            ReliableDispatcher restarted = new ReliableDispatcher(1000L, 5, () -> 5000L, offsets,
+                sinkThatRecords(new ArrayList<>()), new UniMetrics(), 0.0d, store);
+            int recovered = restarted.recover();
+            assertEquals(1, recovered);
+            assertEquals(1, restarted.pendingCount(),
+                "the recovered delivery remains in flight");
+            assertTrue(restarted.ack(id),
+                "the client's ACK after recovery retires the re-dispatched delivery");
+            assertEquals(0, restarted.pendingCount());
         }
     }
 

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/DeliveryRecoveryTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/state/DeliveryRecoveryTest.java
@@ -38,15 +38,15 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;
 
 /**
- * Sub-PR B fault-injection tests: verify that {@link ReliableDispatcher#recover()} picks up
- * in-flight deliveries from a persisted {@link DeliveryStateStore} on a fresh JVM, retires each
- * one with its stored offset, and never re-runs the channel (the MQ has already considered the
- * message gone \u2014 issue #5291 idempotency).
+ * Restart-recovery tests for {@link ReliableDispatcher#recover()} (issue #5379): a fresh JVM
+ * RE-DISPATCHES the persisted in-flight deliveries (at-least-once) instead of advancing the
+ * subscriber offset as if the absent client had ACKed. The offset advances exactly once
+ * when the client actually ACKs the re-dispatched delivery.
  */
 class DeliveryRecoveryTest {
 
     @Test
-    void recoverRetiresInFlightDeliveriesAndAdvancesOffset() {
+    void recoverRedispatchesInFlightWithoutAdvancingOffset() {
         InMemoryDeliveryStateStore store = new InMemoryDeliveryStateStore();
         InMemoryOffsetStore offsets = new InMemoryOffsetStore();
         TestChannel channel = new TestChannel();
@@ -56,9 +56,9 @@ class DeliveryRecoveryTest {
         AtomicLong clockA = new AtomicLong(1000L);
         ReliableDispatcher a = new ReliableDispatcher(1000L, 3, clockA::get, offsets, dlq,
             new UniMetrics(), 0.0d, store);
-        String id1 = a.deliver("topic-A", 0, 100L, event("a-1"), "client-X", channel);
-        String id2 = a.deliver("topic-A", 0, 101L, event("a-2"), "client-X", channel);
-        String id3 = a.deliver("topic-B", 1, 200L, event("b-1"), "client-Y", channel);
+        final String id1 = a.deliver("topic-A", 0, 100L, event("a-1"), "client-X", channel);
+        final String id2 = a.deliver("topic-A", 0, 101L, event("a-2"), "client-X", channel);
+        final String id3 = a.deliver("topic-B", 1, 200L, event("b-1"), "client-Y", channel);
         assertEquals(3, a.pendingCount(), "all three deliveries are in-flight");
         assertEquals(3, store.count(), "in-flight state must be persisted");
 
@@ -69,20 +69,28 @@ class DeliveryRecoveryTest {
         AtomicLong clock = new AtomicLong(10_000L);
         ReliableDispatcher b = new ReliableDispatcher(1000L, 3, clock::get, offsets, dlq,
             new UniMetrics(), 0.0d, store);
-        // Capture deliveries made during the simulated JVM so we can assert recovery did NOT
-        // re-deliver through the channel (the broker owns redelivery, issue #5291).
         final int deliveredBeforeRecovery = channel.delivered.size();
         final int recovered = b.recover();
-        assertEquals(3, recovered, "all 3 in-flight deliveries must be recovered");
+        assertEquals(3, recovered, "all 3 in-flight deliveries must be re-dispatched");
 
-        // No channel redelivery happened during recovery (issue #5291 idempotency)
+        // The crashed instance's channel is never re-invoked: the re-dispatch goes through
+        // the buffered poll channel, the original push channel stays quiet (#5379).
         assertEquals(deliveredBeforeRecovery, channel.delivered.size(),
-            "recovery must NOT re-deliver through the channel (broker already redelivered or not, but "
-                + "EventMesh is not the source of truth for the message anymore)");
+            "re-dispatch must not re-deliver through the crashed instance's channel");
 
-        // Each persisted delivery must be retired: offset advanced, store emptied
-        assertEquals(0, store.count(), "recovered entries are removed from the ledger");
-        assertEquals(0, b.pendingCount(), "the fresh dispatcher must not re-track the recovered entries");
+        // #5379: unACKed is not ACKed; the subscriber offset must NOT advance during recovery...
+        assertEquals(-1L, offsets.readOffset("topic-A", "client-X", 0));
+        assertEquals(-1L, offsets.readOffset("topic-B", "client-Y", 1));
+        // ...and the deliveries stay in flight (the retry state machine owns the bound).
+        assertEquals(3, store.count(), "recovered records stay persisted until a real ACK");
+        assertEquals(3, b.pendingCount(), "the fresh dispatcher tracks the recovered deliveries");
+
+        // The offset advances exactly when the client ACKs the re-dispatched delivery.
+        assertTrue(b.ack(id1));
+        assertTrue(b.ack(id2));
+        assertTrue(b.ack(id3));
+        assertEquals(0, store.count(), "the ACK retires the persisted record");
+        assertEquals(0, b.pendingCount());
         assertEquals(101L, offsets.readOffset("topic-A", "client-X", 0));
         assertEquals(200L, offsets.readOffset("topic-B", "client-Y", 1));
     }
@@ -91,14 +99,23 @@ class DeliveryRecoveryTest {
     void recoverIsIdempotent() {
         InMemoryDeliveryStateStore store = new InMemoryDeliveryStateStore();
         InMemoryOffsetStore offsets = new InMemoryOffsetStore();
-        AtomicLong clock = new AtomicLong(1000L);
-        ReliableDispatcher a = new ReliableDispatcher(1000L, 3, clock::get, offsets,
+        // The crashed instance delivered one event and never saw the ACK.
+        ReliableDispatcher crashed = new ReliableDispatcher(1000L, 3, () -> 1000L, offsets,
             (t, e, r, att) -> CompletableFuture.completedFuture(true), new UniMetrics(), 0.0d, store);
-        a.deliver("topic", 0, 50L, event("only"), "client", new TestChannel());
-        a.recover();
-        a.recover();   // second call is a no-op
-        assertEquals(0, store.count());
+        final String id = crashed.deliver("topic", 0, 50L, event("only"), "client", new TestChannel());
+        crashed = null;
+
+        // The restarted instance recovers the persisted record exactly once: the second
+        // pass skips records that are already live on this dispatcher.
+        ReliableDispatcher restarted = new ReliableDispatcher(1000L, 3, () -> 2000L, offsets,
+            (t, e, r, att) -> CompletableFuture.completedFuture(true), new UniMetrics(), 0.0d, store);
+        assertEquals(1, restarted.recover(), "the first pass re-dispatches the persisted record");
+        assertEquals(0, restarted.recover(), "a second pass is a no-op (the record is already live)");
+        // Still no offset movement without a client ACK.
+        assertEquals(-1L, offsets.readOffset("topic", "client", 0));
+        assertTrue(restarted.ack(id), "the client's ACK retires the re-dispatched delivery");
         assertEquals(50L, offsets.readOffset("topic", "client", 0));
+        assertEquals(0, store.count());
     }
 
     @Test


### PR DESCRIPTION
## Motivation

Fixes the four post-review hardening issues from the production-HA acceptance pass.

Closes #5379
Closes #5380
Closes #5381
Closes #5382

## Changes

### #5379 — unacknowledged-delivery recovery semantics

- `ReliableDispatcher.recover()` no longer advances the subscriber offset as if the absent client had ACKed — that converted an unACKed delivery into acknowledged progress across the crash window (a skip). Recovery now **RE-DISPATCHES** each persisted in-flight record through a buffered poll channel (`channelFor(clientId)`), preserving the attempt counter; the offset advances exactly once, when the client actually ACKs. Records already live on this dispatcher are skipped (idempotent recovery).
- Legacy/corrupt records without a decodable frame retire **without** any offset advance (backend redelivery bound covers them). The old retire-on-recover semantics is kept as a `@Deprecated` private method for source compatibility.
- Tests: new `RecoveryRedispatchTest` (crash -> re-dispatch, no offset -> ACK advances exactly once; legacy record retires without offset); `DeliveryRecoveryTest` and `CrossStoreFaultInjectionTest` scenario 1/1b updated to the re-dispatch contract (crashed-instance channel never re-invoked).

### #5380 — deployment modes vs. capability claims

- `docs/eventmesh-features.md` gains **§5b Deployment modes**: core Runtime (default `bin/start.sh`/Docker — traffic HTTP, token-guarded admin, opt-in WebSocket, connector scheduling), session/streaming Runtime (embedder-wired), A2A Gateway (separate launcher, experimental). The capability surface now matches what the default bootstrap actually starts.
- `docker/Dockerfile` note hardened accordingly (this image is the core Runtime; A2A gateway and v2 streaming sessions are not started by `bin/start.sh`).

### #5381 — SecurityGate wired into the default bootstrap, fail closed

- `EventMeshApplication.main()` builds a config-backed `SecurityGate`: profile from `eventmesh.security.profile` (default `production`), tokens from `eventmesh.security.tokens`; installs it into the traffic httpServer via the new `withSecurityGate(gate)` builder.
- **Fail-closed**: `production` profile with empty token filters throws `IllegalStateException` at boot instead of silently allowing all traffic.

### #5382 — generation fencing for Connector Runtime assignments

- `ConnectorScheduler` bumps a per-connector monotonic **generation** on every (re)assignment or def change and splices `"generation"` into the `/control/start` envelope (`injectGeneration`).
- `ConnectorManager.startConnector` accepts a start iff `gen >= running gen` (equal = idempotent re-push, greater = superseding rebuild: stop old runtime first); a stale delayed start (gen < running) is rejected and logged. `stopConnector` clears the running generation. Rebuild path no longer double-stops the old runtime.
- `ConnectorDef` (both the runtime and connector-runtime copies) carries the `generation` field. New `ConnectorGenerationFencingTest` covers accept/reject/idempotent-re-push/rebuild.

## Verification

Local (Windows, JDK 21), all green:

```
./gradlew :eventmesh-runtime:test \
          :eventmesh-connector-runtime:test \
          :eventmesh-architecture-guard:test \
          :eventmesh-runtime:checkstyleMain :eventmesh-runtime:checkstyleTest \
          :eventmesh-connector-runtime:checkstyleMain :eventmesh-connector-runtime:checkstyleTest
```

(321 runtime tests + connector-runtime suite + 16 ArchUnit rules; checkstyle clean.)
