### PR TITLE
docs(#5380): complete the Dockerfile deployment-mode note (missed in #5385)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,8 +56,10 @@ RUN chmod +x bin/*.sh
 # 8080 = traffic HTTP (/events/* CloudEvents + legacy /eventmesh/*).
 # 8081 = independent admin port (UniAdminServer /admin/*, incl. GET /admin/health).
 # 8082 = WebSocket push transport (opt-in via -Deventmesh.ws.port in JAVA_OPTS).
-# Note: the A2A Gateway (A2AGatewayServer, EXPERIMENTAL) is NOT started by
-# bin/start.sh today; when it ships enabled it will need its own port here.
+# Note (#5380 deployment modes, see docs/eventmesh-features.md §5b): this image is the
+# CORE Runtime. The A2A Gateway (A2AGatewayServer, EXPERIMENTAL) and the v2 streaming
+# session layer are NOT started by bin/start.sh; they require a dedicated launcher /
+# embedder wiring and are documented as separate deployment modes.
 EXPOSE 8080 8081 8082
 
 # Liveness probe against the admin health endpoint (issue #5350). Uses bash's


### PR DESCRIPTION
Follow-up to #5385.

## Motivation

The `docker/Dockerfile` comment hardening referenced by `docs/eventmesh-features.md` §5b (PR #5385) was left out of that PR's file list. This carries it so the docs and the image definition stay in sync.

## Changes

- `docker/Dockerfile`: the EXPOSE note now states this image is the **core Runtime**; the A2A Gateway (`A2AGatewayServer`, EXPERIMENTAL) and the v2 streaming session layer are NOT started by `bin/start.sh` — they are documented as separate deployment modes (see `docs/eventmesh-features.md` §5b).

No code changes; comment-only.
