### PR TITLE
fix(#5387): use immutable frame for MQ offset/partition stamps

### DIFF
--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/it/RealBrokerIntegrationTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/it/RealBrokerIntegrationTest.java
@@ -27,6 +27,7 @@ import org.apache.eventmesh.spi.EventMeshExtensionFactory;
 import java.net.URI;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -121,13 +122,31 @@ class RealBrokerIntegrationTest {
             }
 
             // 4. The offset advanced only on ACK — the core at-least-once contract, now over real MQ.
-            long offset = runtime.ingress().getOffsetStore().readOffset(topic, clientId, 0);
+            //    Scan every partition of this client: the broker picks the queue the event lands on
+            //    (a RocketMQ default topic has 4), so reading partition 0 alone fails ~3 runs in 4.
+            long offset = maxAckedOffset(runtime, topic, clientId);
             if (offset < 1) {
                 throw new AssertionError("offset did not advance after ACK: " + offset);
             }
         } finally {
             runtime.shutdown();
         }
+    }
+
+    /**
+     * Highest offset recorded for {@code clientId} across all partitions of {@code topic}, or -1 if
+     * none. The broker picks the queue the published event lands on, so the offset cannot be read
+     * from a hard-coded partition.
+     */
+    private static long maxAckedOffset(UniRuntime runtime, String topic, String clientId) {
+        long max = -1L;
+        String prefix = clientId + "#";
+        for (Map.Entry<String, Long> e : runtime.ingress().getOffsetStore().readAllOffsets(topic).entrySet()) {
+            if (e.getKey().startsWith(prefix)) {
+                max = Math.max(max, e.getValue());
+            }
+        }
+        return max;
     }
 
     @SuppressWarnings("unused")

--- a/eventmesh-storage-plugin/eventmesh-storage-kafka/src/main/java/org/apache/eventmesh/storage/kafka/storage/KafkaMeshStoragePlugin.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-kafka/src/main/java/org/apache/eventmesh/storage/kafka/storage/KafkaMeshStoragePlugin.java
@@ -183,15 +183,13 @@ public class KafkaMeshStoragePlugin
             // before the frame migration) are converted to a frame via the codec.
             try {
                 EventMeshFrame frame = EventMeshFrame.decode(record.value());
-                stampMqOffset(frame, record.partition(), record.offset());
-                frames.add(frame);
+                frames.add(stampMqOffset(frame, record.partition(), record.offset()));
             } catch (Exception decodeEx) {
                 // fall back: legacy CloudEvents-JSON → CE → frame
                 CloudEvent legacy = deserialize(record.value());
                 if (legacy != null) {
                     EventMeshFrame frame = EventMeshFrame.fromCloudEvent(legacy);
-                    stampMqOffset(frame, record.partition(), record.offset());
-                    frames.add(frame);
+                    frames.add(stampMqOffset(frame, record.partition(), record.offset()));
                 }
             }
         }
@@ -205,9 +203,14 @@ public class KafkaMeshStoragePlugin
      * cursor on restart for at-least-once (Kafka is broker-unmanaged: no invisibleTime, so a
      * crash between poll and client ACK would otherwise lose the gap messages).
      */
-    private static void stampMqOffset(EventMeshFrame frame, int partition, long offset) {
-        frame.attributes().put("emmqoffset", Long.toString(offset));
-        frame.attributes().put("emmqpartition", Integer.toString(partition));
+    private static EventMeshFrame stampMqOffset(EventMeshFrame frame, int partition, long offset) {
+        // Frames are immutable and attributes() is an unmodifiable view, so mutating it in place
+        // throws UnsupportedOperationException. The caller's catch (Exception decodeEx) swallowed
+        // that and retried the legacy CloudEvents-JSON fallback against a binary frame body, so
+        // every polled event was silently dropped and subscribers never received anything.
+        // Derive a new frame with the stamps instead.
+        return frame.withAttribute("emmqoffset", Long.toString(offset))
+            .withAttribute("emmqpartition", Integer.toString(partition));
     }
 
     /**

--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/main/java/org/apache/eventmesh/storage/rocketmq/storage/RocketMQRemotingStoragePlugin.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq/src/main/java/org/apache/eventmesh/storage/rocketmq/storage/RocketMQRemotingStoragePlugin.java
@@ -92,7 +92,10 @@ public class RocketMQRemotingStoragePlugin
 
         org.apache.rocketmq.remoting.netty.NettyClientConfig config = new org.apache.rocketmq.remoting.netty.NettyClientConfig();
         config.setClientWorkerThreads(4);
-        config.setConnectTimeoutMillis(2000);
+        // 8000ms matches the rocketmq5 plugin: 2000ms is too tight for the first remoting connect
+        // on anything but a loopback broker (container/overlay networking, cold broker start), and
+        // the failure surfaced as an opaque "send failed" during init rather than a timeout.
+        config.setConnectTimeoutMillis(8000);
         remotingClient = new org.apache.rocketmq.remoting.netty.NettyRemotingClient(config);
         remotingClient.start();
 
@@ -241,17 +244,13 @@ public class RocketMQRemotingStoragePlugin
                             EventMeshFrame frame = EventMeshFrame.decode(msg.getBody());
                             // Stamp MQ physical offset/partition for restart-cursor alignment
                             // (Frame-native replacement of develop's OffsetExtensions).
-                            frame.attributes().put("emmqoffset", Long.toString(msg.getQueueOffset()));
-                            frame.attributes().put("emmqpartition", Integer.toString(msg.getQueueId()));
-                            frames.add(frame);
+                            frames.add(stampMqOffset(frame, msg.getQueueId(), msg.getQueueOffset()));
                         } catch (Exception decodeEx) {
                             // fall back: legacy CloudEvents-JSON → CE → frame
                             CloudEvent legacy = deserialize(msg.getBody());
                             if (legacy != null) {
                                 EventMeshFrame frame = EventMeshFrame.fromCloudEvent(legacy);
-                                frame.attributes().put("emmqoffset", Long.toString(msg.getQueueOffset()));
-                                frame.attributes().put("emmqpartition", Integer.toString(msg.getQueueId()));
-                                frames.add(frame);
+                                frames.add(stampMqOffset(frame, msg.getQueueId(), msg.getQueueOffset()));
                             }
                         }
                     }
@@ -580,5 +579,17 @@ public class RocketMQRemotingStoragePlugin
             log.warn("failed to deserialize CloudEvent from RocketMQ: {}", e.toString());
             return null;
         }
+    }
+
+    /**
+     * Stamp the MQ physical offset/partition onto the frame attributes so the dispatcher can record
+     * them in the OffsetStore on client ACK. Frames are immutable and {@code attributes()} is an
+     * unmodifiable view, so the stamps must be applied by deriving a new frame — mutating in place
+     * threw UnsupportedOperationException, which the caller's catch-all then misread as a decode
+     * failure and silently dropped the event.
+     */
+    private static EventMeshFrame stampMqOffset(EventMeshFrame frame, int queueId, long queueOffset) {
+        return frame.withAttribute("emmqoffset", Long.toString(queueOffset))
+            .withAttribute("emmqpartition", Integer.toString(queueId));
     }
 }

--- a/eventmesh-storage-plugin/eventmesh-storage-rocketmq5/src/main/java/org/apache/eventmesh/storage/rocketmq5/storage/RocketMQ5RemotingStoragePlugin.java
+++ b/eventmesh-storage-plugin/eventmesh-storage-rocketmq5/src/main/java/org/apache/eventmesh/storage/rocketmq5/storage/RocketMQ5RemotingStoragePlugin.java
@@ -271,8 +271,11 @@ public class RocketMQ5RemotingStoragePlugin
                         try {
                             org.apache.eventmesh.common.wire.EventMeshFrame frame =
                                 org.apache.eventmesh.common.wire.EventMeshFrame.decode(msg.getBody());
+                            // Frames are immutable and attributes() is an unmodifiable view, so
+                            // stamping in place threw UnsupportedOperationException — which the
+                            // catch-all below misread as a decode failure and dropped the event.
                             if (popCk != null) {
-                                frame.attributes().put(POP_CK_KEY, popCk);
+                                frame = frame.withAttribute(POP_CK_KEY, popCk);
                             }
                             frames.add(frame);
                             if (frames.size() >= maxEvents) {


### PR DESCRIPTION
fix(#5357): use immutable frame for MQ offset/partition stamps

## Summary

#5357 turned `EventMeshFrame` into an immutable value object whose
`attributes()` returns an unmodifiable map. All three storage plugins
were left mutating the frame in place to stamp the MQ physical
offset/partition after decoding each polled event. The
`UnsupportedOperationException` was swallowed by the surrounding
`catch (Exception decodeEx)`, which then retried the legacy
CloudEvents-JSON fallback against a binary frame body. Every polled
event was silently dropped.

## Changes

| File | Change |
|---|---|
| `eventmesh-storage-plugin/eventmesh-storage-kafka/.../KafkaMeshStoragePlugin.java` | `stampMqOffset` returns a new `EventMeshFrame` via `withAttribute`; both decode + CE-JSON fallback paths keep the return value. |
| `eventmesh-storage-plugin/eventmesh-storage-rocketmq/.../RocketMQRemotingStoragePlugin.java` | New `stampMqOffset` helper (same shape as Kafka); replaces two in-place `attributes().put` calls in the pull loop. |
| `eventmesh-storage-plugin/eventmesh-storage-rocketmq5/.../RocketMQ5RemotingStoragePlugin.java` | POP-mode `popCk` stamp via `frame.withAttribute(POP_CK_KEY, popCk)`. |
| `eventmesh-runtime/.../it/RealBrokerIntegrationTest.java` | `maxAckedOffset()` walks every partition of the client — the broker picks the queue, so partition 0 alone flaked 3 runs in 4 against a RocketMQ default topic. |
| `eventmesh-storage-plugin/eventmesh-storage-rocketmq/.../RocketMQRemotingStoragePlugin.java` | `NettyClientConfig.connectTimeoutMillis` 2000 → 8000 to match the RocketMQ 5.x plugin (cold container / overlay network on first connect). |

## Impact

Single root cause produced four previously intermittent-looking test
failures. All trace back to the swallowed `UnsupportedOperationException`:

| Symptom | Root cause |
|---|---|
| `KafkaClientE2EIntegrationTest` "event delivered within 40s" | `KafkaMeshStoragePlugin.stampMqOffset` mutation |
| `StreamingSdkE2ETest` token order shuffled | `RocketMQ5RemotingStoragePlugin` POP `popCk` mutation on lite topics |
| `StreamingSdkE2ETest` "SSE stream closed by server" | same — broken framing surfaces as disconnect |
| `RealBrokerIntegrationTest` offset assertion flaky | separate bug — partition 0 hard-code vs broker queue selection |

## Verification

- Full `./gradlew check -x spotlessJava -x :eventmesh-architecture-guard:test` (mirrors `.github/workflows/ci.yml` excluding the spotless-JDK21 known incompatibility) — BUILD SUCCESSFUL, 291 tasks, all `test` + `checkstyleMain` + `spotbugsMain` + jacoco across `eventmesh-runtime`, the three storage plugins, and all transitive modules green.
- End-to-end suite against containerized brokers (docker compose in `e2e-infra/`):
  - `:eventmesh-runtime:e2eTest5x --tests "*StreamingSdkE2ETest*"` — 5 passing, 1 skipped (requires real LLM API key).
  - `:eventmesh-runtime:e2eTest5x --tests "*RocketMQ5*"` — passing.
  - `:eventmesh-runtime:e2eTest4 --tests "*RocketMQ4*"` — passing.
  - `:eventmesh-runtime:e2eTest5x --tests "*KafkaClient*"` — passing.
  - `:eventmesh-runtime:e2eTest4 --tests "*RealBrokerIntegrationTest*"` — passing.

## Reproduction (against any local RocketMQ 5.x)

```sh
docker compose -f e2e-infra/docker-compose.rmq5.yml up -d --wait
./gradlew :eventmesh-runtime:e2eTest5x \
  --tests "org.apache.eventmesh.runtime.it.KafkaClientE2EIntegrationTest" \
  -Dit.storage=kafka -Dit.kafka.bootstrap=127.0.0.1:9092 \
  -Dit.kafka.user=eventmesh -Dit.kafka.password=eventmesh-pass
```

The Kafka test was the cleanest 100 % reproducer.

## Follow-ups (not in this PR)

- `MultiInstanceRocketMqIntegrationTest` first-publish rejection under
  two-runtime + Nacos — separate investigation.
- `spotlessJava` task broken under JDK 21 (google-java-format
  incompatibility). CI excludes it via `-x spotlessJava`; should be
  filed separately.