### PR TITLE
test(e2e): real-broker coverage for BatchPublish, Unsubscribe, RateLimit, RequestReply

### DIFF
--- a/eventmesh-runtime/build.gradle
+++ b/eventmesh-runtime/build.gradle
@@ -122,6 +122,18 @@ final List<String> BROKER_IT_4_CLASSES = [
     'org.apache.eventmesh.runtime.it.MultiInstanceRocketMqIntegrationTest'
 ]
 
+// Feature-level e2e tests over a real broker. Each one pairs an in-process
+// `*IntegrationTest` (gate-tested by the `test` task) with a counterpart that drives the same
+// feature path through UniRuntime + a real storage plugin, so a regression in the broker boundary
+// (serialization, topic routing, subscription lifecycle, rate-limit token bucket, RR routing)
+// surfaces here. Skipped cleanly when no broker is configured.
+final List<String> BROKER_FEATURE_IT_CLASSES = [
+    'org.apache.eventmesh.runtime.it.BatchPublishOverBrokerTest',
+    'org.apache.eventmesh.runtime.it.UnsubscribeOverBrokerTest',
+    'org.apache.eventmesh.runtime.it.RateLimitOverBrokerTest',
+    'org.apache.eventmesh.runtime.it.RequestReplyOverBrokerTest'
+]
+
 test {
     jvmArgs('-XX:MaxDirectMemorySize=512m', '-Xmx1024m', '-Dio.netty.noPreferDirect=true')
     ['it.storage', 'it.topic', 'it.namesrv', 'it.nacos', 'it.storage5', 'it.namesrv5',
@@ -131,8 +143,8 @@ test {
             systemProperty k, v
         }
     }
-    // Exclude all broker ITs - they run on-demand via `e2e-test`.
-    (BROKER_IT_5X_CLASSES + BROKER_IT_4_CLASSES).each { cls -> filter { excludeTestsMatching cls } }
+    // Exclude all broker ITs - they run on-demand via `e2e-test` / `e2eFeature`.
+    (BROKER_IT_5X_CLASSES + BROKER_IT_4_CLASSES + BROKER_FEATURE_IT_CLASSES).each { cls -> filter { excludeTestsMatching cls } }
 }
 
 // --- isolated classpath for the 4.9 broker ITs (excludes storage-rocketmq5 so 4.9.5 wins) ---
@@ -181,6 +193,32 @@ task('e2e-test') {
     group = 'verification'
     description = 'Runs all broker integration tests (auto-detect real brokers via E2EConfig).'
     dependsOn 'e2eTest5x', 'e2eTest4'
+}
+
+// On-demand: run feature-level e2e tests that pair an in-process integration test with the
+// matching real-broker exercise. Select a single class with -Pfeature.test=FQN (otherwise all
+// four run). The harness skips cleanly when no broker is configured.
+//   gradle :eventmesh-runtime:e2eFeature \
+//       -Dit.feature.storage=rocketmq4 -Dit.namesrv=host:9876
+//   gradle :eventmesh-runtime:e2eFeature -Pfeature.test=RateLimitOverBrokerTest \
+//       -Dit.feature.storage=rocketmq5 -Dit.namesrv5=host:9876
+task e2eFeature(type: Test) {
+    group = 'verification'
+    description = 'Runs real-broker feature e2e tests (BatchPublish/Unsubscribe/RateLimit/RequestReply).'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = configurations.rocketmq4TestRuntimeClasspath + sourceSets.main.output + sourceSets.test.output
+    useJUnitPlatform()
+    if (project.hasProperty('feature.test')) {
+        filter { includeTestsMatching project.property('feature.test') }
+    } else {
+        BROKER_FEATURE_IT_CLASSES.each { cls -> filter { includeTestsMatching cls } }
+    }
+    jvmArgs('-XX:MaxDirectMemorySize=512m', '-Xmx1024m', '-Dio.netty.noPreferDirect=true')
+    // Forward both it.namesrv + it.namesrv5 — the harness reads whichever the active backend uses.
+    ['it.storage', 'it.topic', 'it.namesrv', 'it.storage5', 'it.namesrv5', 'it.feature.storage'].each { k ->
+        def v = System.getProperty(k)
+        if (v != null) { systemProperty k, v }
+    }
 }
 
 // One-command demo runner: boots an in-process EventMeshApplication + StreamingAgent (mock LLM)

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/it/BatchPublishOverBrokerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/it/BatchPublishOverBrokerTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.it;
+
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+import org.apache.eventmesh.runtime.push.BufferedEvent;
+import org.apache.eventmesh.runtime.subscription.DistributionMode;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+
+/**
+ * Batch publish over a REAL message broker — exercises {@code UniIngressService.publishBatch()}
+ * end-to-end against the configured storage backend. Pairs with the in-process coverage in
+ * {@link BatchPublishIntegrationTest} by adding the storage round-trip the in-memory stub elides.
+ *
+ * <p><b>Skipped</b> unless {@code -Dit.feature.storage=rocketmq4|rocketmq5} is set; the test
+ * aborts via {@code Assumptions} when the backend or its SPI registration is missing so CI runs
+ * without a broker stay green.</p>
+ *
+ * <p>Run with:
+ * <pre>
+ *   gradle :eventmesh-runtime:e2eFeature \
+ *     -Pfeature.test=BatchPublishOverBrokerTest \
+ *     -Dit.feature.storage=rocketmq4 -Dit.namesrv=host:9876
+ * </pre>
+ * </p>
+ */
+@EnabledIfSystemProperty(named = "it.feature.storage", matches = "rocketmq|rocketmq4|rocketmq5")
+class BatchPublishOverBrokerTest {
+
+    @Test
+    void publishBatchAllArrivesOverBroker() throws Exception {
+        try (FeatureBrokerHarness fx = FeatureBrokerHarness.of("rocketmq4")) {
+            fx.start();
+
+            String topic = "em-it-batch-" + System.nanoTime();
+            String clientId = "batch-broker-client";
+            BrokerDiscoverer.ensureTopicOnReachableBroker(
+                System.getProperty("it.namesrv",
+                    System.getProperty("it.namesrv5", "localhost:9876")),
+                topic, 4);
+
+            // Subscribe before publishing — same constraint that forces LiteStreamCall to wait.
+            fx.runtime().ingress().subscribe(topic, clientId, DistributionMode.BROADCAST, null);
+            Thread.sleep(2_000L);
+
+            // Build the batch (10 events, deterministic ids so we can verify no events vanished or
+            // duplicated, and so we never collide with rerun garbage in the topic).
+            List<CloudEvent> batch = new ArrayList<>();
+            Set<String> expected = new HashSet<>();
+            for (int i = 0; i < 10; i++) {
+                String id = "broker-batch-" + i + "-" + System.nanoTime();
+                expected.add(id);
+                batch.add(CloudEventBuilder.v1()
+                    .withId(id)
+                    .withSource(URI.create("broker://batch"))
+                    .withType("broker.batch")
+                    .withDataContentType("text/plain")
+                    .withData(("m" + i).getBytes(StandardCharsets.UTF_8))
+                    .build());
+            }
+            fx.runtime().ingress().publishBatch(topic, batch).get(15, TimeUnit.SECONDS);
+
+            // Pull-loop uses LitePullConsumer on RocketMQ; it rebalances once and starts delivering
+            // within ~3s of subscribe. Give it up to 30s for the whole batch to land.
+            Set<String> received = new HashSet<>();
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+            while (received.size() < expected.size() && System.nanoTime() < deadline) {
+                List<BufferedEvent> drained = fx.runtime().ingress().poll(clientId, 50, 500L);
+                for (BufferedEvent d : drained) {
+                    EventMeshFrame frame = d.getEvent();
+                    received.add(frame.toCloudEvent().getId());
+                    fx.runtime().ingress().ack(d.getDeliveryId());
+                }
+            }
+            if (!received.equals(expected)) {
+                throw new AssertionError("batch failed: expected " + expected + " got " + received);
+            }
+        }
+    }
+}

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/it/BrokerDiscoverer.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/it/BrokerDiscoverer.java
@@ -30,6 +30,11 @@ package org.apache.eventmesh.runtime.it;
  */
 final class BrokerDiscoverer {
 
+    /** Serialize admin RPC across the whole test JVM so concurrent BrokerDiscoverer callers do
+     * not pile up on the broker's topic-create / heartbeat thread (single-shard bottlenecks
+     * turned a 4-test batch run into a flaky mess — see PR #5389). */
+    private static final Object ADMIN_LOCK = new Object();
+
     private BrokerDiscoverer() {
     }
 
@@ -44,21 +49,23 @@ final class BrokerDiscoverer {
         if (!"rocketmq".equalsIgnoreCase(System.getProperty("it.storage", "rocketmq"))) {
             return; // kafka auto-creates topics
         }
-        org.apache.rocketmq.tools.admin.DefaultMQAdminExt admin =
-            new org.apache.rocketmq.tools.admin.DefaultMQAdminExt();
-        admin.setNamesrvAddr(namesrv);
-        admin.start();
-        try {
+        synchronized (ADMIN_LOCK) {
+            org.apache.rocketmq.tools.admin.DefaultMQAdminExt admin =
+                new org.apache.rocketmq.tools.admin.DefaultMQAdminExt();
+            admin.setNamesrvAddr(namesrv);
+            admin.start();
             try {
-                org.apache.rocketmq.common.protocol.body.ClusterInfo info = admin.examineBrokerClusterInfo();
-                String cluster = info.getClusterAddrTable().keySet().iterator().next();
-                admin.createTopic(cluster, topic, queueNum);
-            } catch (org.apache.rocketmq.client.exception.MQClientException e) {
-                // already exists — safe to ignore
+                try {
+                    org.apache.rocketmq.common.protocol.body.ClusterInfo info = admin.examineBrokerClusterInfo();
+                    String cluster = info.getClusterAddrTable().keySet().iterator().next();
+                    admin.createTopic(cluster, topic, queueNum);
+                } catch (org.apache.rocketmq.client.exception.MQClientException e) {
+                    // already exists — safe to ignore
+                }
+                waitForRoute(admin, topic);
+            } finally {
+                admin.shutdown();
             }
-            waitForRoute(admin, topic);
-        } finally {
-            admin.shutdown();
         }
     }
 

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/it/FeatureBrokerHarness.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/it/FeatureBrokerHarness.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.it;
+
+import org.apache.eventmesh.api.storage.MeshStoragePlugin;
+import org.apache.eventmesh.runtime.boot.UniRuntime;
+import org.apache.eventmesh.runtime.offset.InMemoryOffsetStore;
+import org.apache.eventmesh.spi.EventMeshExtensionFactory;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Assumptions;
+
+/**
+ * Shared bootstrap for "feature" e2e tests that exercise the uni runtime against a REAL message
+ * broker. Picks the right backend per system property, skips cleanly when the broker is not
+ * configured so the test never fails spuriously in CI without an environment.
+ *
+ * <p>Usage:
+ * <pre>
+ *   {@code
+ *   @EnabledIfSystemProperty(named = "it.feature.storage", matches = "rocketmq4")
+ *   class FooOverBrokerTest {
+ *       @Test
+ *       void foo() throws Exception {
+ *           try (var fx = FeatureBrokerHarness.of("rocketmq4")) { fx.start(); ... }
+ *       }
+ *   }
+ *   }
+ * </pre>
+ *
+ * <p>Backends:
+ * <ul>
+ *   <li>{@code rocketmq} — RocketMQ 4.9.x namesrv (SPI key {@code rocketmq}, system property
+ *       {@code it.namesrv}, default {@code localhost:9876}).</li>
+ *   <li>{@code rocketmq5} — RocketMQ 5.x namesrv (SPI key {@code rocketmq5}, system property
+ *       {@code it.namesrv5}, default {@code localhost:9876}).</li>
+ * </ul>
+ *
+ * <p>Skipped when neither backend is configured — the test reports as ASSUMED and the build
+ * proceeds with the rest of the suite.
+ */
+final class FeatureBrokerHarness implements AutoCloseable {
+
+    private final UniRuntime runtime;
+
+    private FeatureBrokerHarness(UniRuntime runtime) {
+        this.runtime = runtime;
+    }
+
+    UniRuntime runtime() {
+        return runtime;
+    }
+
+    /** Resolve backend from {@code -Dit.feature.storage}, or skip the test. */
+    static FeatureBrokerHarness of(String defaultBackend) {
+        String backend = System.getProperty("it.feature.storage", defaultBackend);
+        if (backend == null || backend.isEmpty()) {
+            throw newAssumed("no it.feature.storage set — skipping real-broker feature test");
+        }
+        // Backwards-compatible alias: 'rocketmq4' still means the 4.9 plugin (SPI key 'rocketmq').
+        String spiKey = "rocketmq4".equals(backend) ? "rocketmq" : backend;
+        return switch (spiKey) {
+            case "rocketmq" -> rocketMq4();
+            case "rocketmq5" -> rocketMq5();
+            default -> throw newAssumed("unsupported feature backend: " + backend);
+        };
+    }
+
+    private static FeatureBrokerHarness rocketMq4() {
+        String namesrv = System.getProperty("it.namesrv", "localhost:9876");
+        // SPI key is "rocketmq" — the storage plugin file registers with that name, not "rocketmq4".
+        return build("rocketmq", namesrv);
+    }
+
+    private static FeatureBrokerHarness rocketMq5() {
+        String namesrv = System.getProperty("it.namesrv5", "localhost:9876");
+        return build("rocketmq5", namesrv);
+    }
+
+    private static FeatureBrokerHarness build(String storageType, String namesrv) {
+        MeshStoragePlugin storage = lookup(storageType);
+        Properties props = new Properties();
+        props.setProperty("namesrvAddr", namesrv);
+        props.setProperty("eventMesh.server.rocketmq.namesrvAddr", namesrv);
+        props.setProperty("eventMesh.server.kafka.namesrvAddr", namesrv);
+        // BrokerDiscoverer.ensureTopicOnReachableBroker() keys off `it.storage` (the legacy
+        // system property used by every other broker IT), so propagate our backend name into
+        // that slot before the test method touches it.
+        if (System.getProperty("it.storage") == null) {
+            System.setProperty("it.storage", storageType);
+        }
+        UniRuntime rt = new UniRuntime(storage, new InMemoryOffsetStore(), 200L, 500L, 100, 500L);
+        rt.withStorageConfig(props);
+        return new FeatureBrokerHarness(rt);
+    }
+
+    private static MeshStoragePlugin lookup(String type) {
+        MeshStoragePlugin p = EventMeshExtensionFactory.getExtension(MeshStoragePlugin.class, type);
+        if (p == null) {
+            throw newAssumed("no MeshStoragePlugin registered for '" + type
+                + "' — declare the storage plugin on the runtime test classpath");
+        }
+        return p;
+    }
+
+    /** Boot the runtime and settle the broker connection (the pull consumer needs ~3s for rebalance). */
+    void start() throws Exception {
+        runtime.start();
+        Thread.sleep(3_000L);
+    }
+
+    @Override
+    public void close() {
+        try {
+            runtime.shutdown();
+        } catch (Exception ignored) {
+            // best-effort: a leaked plugin close after a failed assertion is preferable to test crashes
+        }
+    }
+
+    private static RuntimeException newAssumed(String message) {
+        Assumptions.abort(message);
+        // unreachable — Assumptions.abort throws TestAbortedException, but the compiler doesn't know
+        return new IllegalStateException(message);
+    }
+}

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/it/RateLimitOverBrokerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/it/RateLimitOverBrokerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.it;
+
+import org.apache.eventmesh.runtime.ratelimit.RateLimitedException;
+import org.apache.eventmesh.runtime.subscription.DistributionMode;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+
+/**
+ * Real-broker version of {@link RateLimitIntegrationTest}. {@code UniIngressService.setTopicRateLimit}
+ * is invoked against the live runtime (not the in-memory harness), the configured limit is consumed
+ * by a burst of publishes, and the rejection is observed via {@code RateLimitedException} on the
+ * publish futures plus the {@code rateLimited} metric counter.
+ *
+ * <p>This is the canonical production failure mode an operator reaches when they set a too-tight
+ * rate on a hot topic — the request returns an exception synchronously and the {@code eventmesh_rate_limited}
+ * counter on the Prometheus scrape climbs. Both must hold end-to-end, including the broker storage
+ * call, because an over-broad publish must not silently drop.</p>
+ *
+ * <p>Run: {@code -Dit.feature.storage=rocketmq4 -Dit.namesrv=host:9876}. Skipped otherwise.</p>
+ */
+@EnabledIfSystemProperty(named = "it.feature.storage", matches = "rocketmq|rocketmq4|rocketmq5")
+class RateLimitOverBrokerTest {
+
+    @Test
+    void burstOverCapacityIsRateLimited() throws Exception {
+        try (FeatureBrokerHarness fx = FeatureBrokerHarness.of("rocketmq4")) {
+            fx.start();
+
+            String topic = "em-it-ratelimit-" + System.nanoTime();
+            String clientId = "ratelimit-broker-client";
+            String namesrv = System.getProperty("it.namesrv",
+                System.getProperty("it.namesrv5", "localhost:9876"));
+            BrokerDiscoverer.ensureTopicOnReachableBroker(namesrv, topic, 4);
+            fx.runtime().ingress().subscribe(topic, clientId, DistributionMode.BROADCAST, null);
+            Thread.sleep(2_000L);
+
+            // 2-token bucket, refill rate 0/s — the bucket exhausts after 2 publishes and never
+            // refills during this test window. The first 2 publishes succeed, the rest fail.
+            fx.runtime().ingress().setTopicRateLimit(topic, 2L, 0.0d);
+
+            long before = fx.runtime().ingress().getMetrics().getRateLimited();
+            int success = 0;
+            int rejected = 0;
+            for (int i = 0; i < 5; i++) {
+                CloudEvent e = CloudEventBuilder.v1()
+                    .withId("rl-" + System.nanoTime() + "-" + i)
+                    .withSource(URI.create("broker://rl"))
+                    .withType("broker.rl")
+                    .withDataContentType("text/plain")
+                    .withData(("m" + i).getBytes(StandardCharsets.UTF_8))
+                    .build();
+                CompletableFuture<Void> f = fx.runtime().ingress().publish(topic, e);
+                try {
+                    f.get(10, TimeUnit.SECONDS);
+                    success++;
+                } catch (ExecutionException ex) {
+                    if (ex.getCause() instanceof RateLimitedException) {
+                        rejected++;
+                    } else {
+                        throw ex; // a non-rate-limit failure is a real test failure
+                    }
+                }
+            }
+            long after = fx.runtime().ingress().getMetrics().getRateLimited();
+            long rejectedCounter = after - before;
+
+            if (success != 2) {
+                throw new AssertionError("expected 2 successful publishes (bucket=2), got " + success);
+            }
+            if (rejected != 3) {
+                throw new AssertionError("expected 3 rejected publishes, got " + rejected);
+            }
+            if (rejectedCounter != 3) {
+                throw new AssertionError("rateLimited metric expected +3, delta was " + rejectedCounter);
+            }
+        }
+    }
+}

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/it/RequestReplyOverBrokerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/it/RequestReplyOverBrokerTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.it;
+
+import org.apache.eventmesh.client.cloudevents.CloudEventsClient;
+import org.apache.eventmesh.runtime.admin.UniAdminService;
+import org.apache.eventmesh.runtime.http.UniHttpServer;
+import org.apache.eventmesh.runtime.subscription.DistributionMode;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import io.cloudevents.CloudEvent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Real-broker request-reply end-to-end: responder subscribes via HTTP long-poll, broker-side
+ * pull-loop dispatches, requester calls {@code /req} and waits for the reply. Pairs with the
+ * in-process {@link RequestReplyHttpIntegrationTest}; the value here is verifying the request
+ * survives the full store → broker → topic → rebalance → subscriber path on at least one round-trip.
+ *
+ * <p>Run: {@code -Dit.feature.storage=rocketmq4 -Dit.namesrv=host:9876}. Skipped otherwise.</p>
+ */
+@EnabledIfSystemProperty(named = "it.feature.storage", matches = "rocketmq|rocketmq4|rocketmq5")
+class RequestReplyOverBrokerTest {
+
+    @Test
+    void requestReplyRoundTripOverBroker() throws Exception {
+        try (FeatureBrokerHarness fx = FeatureBrokerHarness.of("rocketmq4")) {
+            fx.start();
+
+            // Build a paired HTTP server using the same UniIngressService, so request/reply flows
+            // through the live runtime — not a side-channel stub.
+            UniAdminService admin = new UniAdminService(fx.runtime().ingress());
+            UniHttpServer http = new UniHttpServer(fx.runtime().ingress(), admin);
+            int httpPort = http.start(0);
+            try {
+                String topic = "em-it-req-" + System.nanoTime();
+                String namesrv = System.getProperty("it.namesrv",
+                    System.getProperty("it.namesrv5", "localhost:9876"));
+                BrokerDiscoverer.ensureTopicOnReachableBroker(namesrv, topic, 4);
+
+                // Both ends register the same subscription so the broker treats them as broadcast
+                // receivers; the server-side long-poll is how the /req handler picks up the request
+                // and returns once the responder's reply comes back through the runtime.
+                fx.runtime().ingress().subscribe(topic, "req-rr-broker", DistributionMode.BROADCAST, null);
+
+                String runtimeUrl = "http://localhost:" + httpPort;
+CloudEventsClient responder = CloudEventsClient.builder()
+                        .runtimeUrl(runtimeUrl).clientId("rr-responder-" + UUID.randomUUID()).pollIntervalMs(200L).build();
+                try {
+                    responder.subscribe(topic, "BROADCAST", event -> {
+                        Object corr = event.getExtension("emcorrelationid");
+                        if (corr != null && !corr.toString().isEmpty()) {
+                            CloudEvent reply = CloudEventsClient.event(
+                                "rr-reply-" + System.nanoTime(),
+                                "responder",
+                                "rr.reply",
+                                "reply-payload".getBytes(StandardCharsets.UTF_8));
+                            responder.reply(corr.toString(), reply);
+                        }
+                    });
+                    Thread.sleep(2_000L); // let subscribe + first rebalance settle
+
+                    CloudEventsClient requester = CloudEventsClient.builder()
+                        .runtimeUrl(runtimeUrl).clientId("rr-requester-" + UUID.randomUUID()).build();
+                    try {
+                        CloudEvent req = CloudEventsClient.event(
+                            "rr-req-" + System.nanoTime(),
+                            "requester",
+                            "rr.request",
+                            "req-payload".getBytes(StandardCharsets.UTF_8));
+                        CloudEvent reply = requester.request(topic, req, 25_000L);
+                        assertNotNull(reply, "request should be answered over real broker before timeout");
+                        assertEquals("rr.reply", reply.getType(), "reply type should match responder");
+                    } finally {
+                        requester.shutdown();
+                    }
+                } finally {
+                    responder.shutdown();
+                }
+            } finally {
+                http.stop();
+            }
+        }
+    }
+}

--- a/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/it/UnsubscribeOverBrokerTest.java
+++ b/eventmesh-runtime/src/test/java/org/apache/eventmesh/runtime/it/UnsubscribeOverBrokerTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.eventmesh.runtime.it;
+
+import org.apache.eventmesh.common.wire.EventMeshFrame;
+import org.apache.eventmesh.runtime.push.BufferedEvent;
+import org.apache.eventmesh.runtime.subscription.DistributionMode;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+
+/**
+ * Real-broker version of {@link UnsubscribeTopicIntegrationTest}: subscribe to two topics via real
+ * MQ, unsubscribe from one, publish to both, and confirm the surviving subscription still receives
+ * while the dropped one does not. The in-process test covers the same dispatch logic but mocks the
+ * storage, so it cannot catch failures where the dispatcher confuses topics at the broker boundary.
+ *
+ * <p>Run: {@code -Dit.feature.storage=rocketmq4 -Dit.namesrv=host:9876}. Skipped otherwise.</p>
+ */
+@EnabledIfSystemProperty(named = "it.feature.storage", matches = "rocketmq|rocketmq4|rocketmq5")
+class UnsubscribeOverBrokerTest {
+
+    @Test
+    void unsubscribeOneTopicKeepsOther() throws Exception {
+        try (FeatureBrokerHarness fx = FeatureBrokerHarness.of("rocketmq4")) {
+            fx.start();
+
+            String topicA = "em-it-unsub-a-" + System.nanoTime();
+            String topicB = "em-it-unsub-b-" + System.nanoTime();
+            String clientId = "unsub-broker-client";
+            String namesrv = System.getProperty("it.namesrv",
+                System.getProperty("it.namesrv5", "localhost:9876"));
+            BrokerDiscoverer.ensureTopicOnReachableBroker(namesrv, topicA, 4);
+            BrokerDiscoverer.ensureTopicOnReachableBroker(namesrv, topicB, 4);
+
+            // 1. Subscribe to both topics.
+            String subA = fx.runtime().ingress().subscribe(topicA, clientId, DistributionMode.BROADCAST, null);
+            String subB = fx.runtime().ingress().subscribe(topicB, clientId, DistributionMode.BROADCAST, null);
+            // Re-balance window before producing — broker learns about consumer first.
+            Thread.sleep(3_000L);
+
+            // 2. Unsubscribe one of them (the contract under test).
+            boolean removed = fx.runtime().ingress().unsubscribe(subA);
+            if (!removed) {
+                throw new AssertionError("unsubscribe(topicA) returned false — sub not tracked");
+            }
+
+            // 3. Publish one event to each topic; tag by id prefix so we can route the received events
+            //    back to their originating topic on the single polling client.
+            long token = System.nanoTime();
+            String aId = "ua-" + token;
+            String bId = "ub-" + token;
+            fx.runtime().ingress().publish(topicA, CloudEventBuilder.v1()
+                .withId(aId).withSource(URI.create("broker://ua"))
+                .withType("ua").withDataContentType("text/plain")
+                .withData("ua-payload".getBytes(StandardCharsets.UTF_8)).build()).get(10, TimeUnit.SECONDS);
+            fx.runtime().ingress().publish(topicB, CloudEventBuilder.v1()
+                .withId(bId).withSource(URI.create("broker://ub"))
+                .withType("ub").withDataContentType("text/plain")
+                .withData("ub-payload".getBytes(StandardCharsets.UTF_8)).build()).get(10, TimeUnit.SECONDS);
+
+            // 4. Drain the buffer; we expect ONLY the B-side event to arrive.
+            Set<String> receivedIds = new HashSet<>();
+            List<String> receivedTypes = new ArrayList<>();
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(25);
+            while (receivedIds.size() < 1 && System.nanoTime() < deadline) {
+                List<BufferedEvent> drained = fx.runtime().ingress().poll(clientId, 50, 500L);
+                for (BufferedEvent d : drained) {
+                    EventMeshFrame frame = d.getEvent();
+                    String id = frame.toCloudEvent().getId();
+                    receivedIds.add(id);
+                    receivedTypes.add(frame.toCloudEvent().getType());
+                    fx.runtime().ingress().ack(d.getDeliveryId());
+                }
+            }
+
+            if (!receivedIds.contains(bId)) {
+                throw new AssertionError("topic B event was not delivered: received=" + receivedIds);
+            }
+            if (receivedIds.contains(aId)) {
+                throw new AssertionError("topic A event leaked after unsubscribe: received=" + receivedIds);
+            }
+            if (receivedTypes.contains("ua")) {
+                throw new AssertionError("topic A type leaked after unsubscribe: receivedTypes=" + receivedTypes);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What this PR adds

Four feature-level e2e tests under `:eventmesh-runtime:test-e2e`, each driving a real RocketMQ broker end-to-end. These were previously covered only via `UniIngressService` + in-memory `MeshStoragePlugin` stubs, which means regressions in the broker-boundary code path (`EventMeshFrame` serialization, subscription lifecycle crossing the storage layer, partition routing in lite-pull consumer) had no failing signal.

| Test | What it pins down |
|---|---|
| `BatchPublishOverBrokerTest` | A 10-event `publishBatch` round-trips over real `LitePullConsumer` — every event ID arrives. |
| `UnsubscribeOverBrokerTest` | After `unsubscribe(topicA)`, topic A events no longer reach the subscriber while topic B continues — this is the case the in-process stub cannot catch, since dispatcher bookkeeping ≠ real-broker delivery routing. |
| `RateLimitOverBrokerTest` | A 2-token bucket with 0 refill: 5 publishes produce 2 successes + 3 `RateLimitedException` rejects, AND the `rateLimited` counter ticks up by 3. The counter assertion is what catches "the limiter silently drops instead of rejecting". |
| `RequestReplyOverBrokerTest` | A `/req` round-trip completes end-to-end over the broker, proving the request survives subscription rebalance before the responder's reply comes back. |

## Supporting changes

1. `FeatureBrokerHarness`: shared bootstrap that picks `rocketmq` (4.9 plugin) or `rocketmq5` based on `-Dit.feature.storage`, looks up the storage plugin via SPI (the same path production uses), boots `UniRuntime`, and tears it down. Skips cleanly when the plugin class is not present, so CI without a broker stays green.
2. `e2eFeature` gradle task: runs all four (or a selected one with `-Pfeature.test=FQN`). Reuses the existing `rocketmq4TestRuntimeClasspath` so `storage-rocketmq5` is excluded and the 4.9 plugin wins — same contract as `e2eTest4`.
3. `BrokerDiscoverer`: serialize admin RPC across the test JVM with a static lock. Without it, four tests creating topics back-to-back thrash the broker's single-shard topic-create / heartbeat thread and the namesrv route doesn't propagate in time (`"no broker for topic queue 0"`).

## Verified

- All four tests pass **in isolation** against RocketMQ 4.9.5 over real `UniRuntime` on macOS / aarch64.
- `./gradlew check -x spotlessJava -x :eventmesh-architecture-guard:test` remains green across storage-plugin (rocketmq, rocketmq5, kafka) and runtime modules.
- The `e2eFeature` task is gated on `-Dit.feature.storage`; CI without a broker stays green. CI does not run it (opt-in gradle task outside the default `build` chain), so this PR adds no CI surface.

## Known broker artifact

Running all four tests in a single `gradle :eventmesh-runtime:e2eFeature` invocation on a single-broker cluster is flaky under topic-creation pressure — the broker's topic-create / heartbeat thread becomes the bottleneck and routes don't propagate in time. Per-test (`-Pfeature.test=FQN`) runs are deterministic. Prefer `-Pfeature.test=…` in CI scripts that opt into this gate.

Builds on #5388 (eventmesh-frame immutability, which made these tests viable again on RocketMQ5).
