### PR TITLE
docs: update all stale doc references after the docs/ restructure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ process (releases, PMC, voting), see the
 
 ## Before you open a PR
 
-1. Read the [EventMesh architecture guard](docs/architecture-guard.md)
+1. Read the [EventMesh architecture guard](docs/feature/architecture-guard.md)
    if your change touches any of these modules:
    - `eventmesh-common`
    - `eventmesh-runtime`
@@ -25,7 +25,7 @@ process (releases, PMC, voting), see the
    ```
 
 2. If your change adds or modifies a **storage plugin capability**,
-   update the [Storage SPI capability matrix](docs/storage-spi.md).
+   update the [Storage SPI capability matrix](docs/feature/storage-spi.md).
 
 3. Make sure the build is green on your local:
 
@@ -51,7 +51,7 @@ If you are introducing a new module (say `eventmesh-foo`):
    `eventmesh-architecture-guard/build.gradle` if the new module's
    packages should be analysed.
 2. Add an entry in the analysed-modules table in
-   `docs/architecture-guard.md`.
+   `docs/feature/architecture-guard.md`.
 3. Add an `on: pull_request: paths:` entry in
    `.github/workflows/architecture-guard.yml` so violations are
    flagged on PR.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,7 +47,7 @@ Apache EventMesh 提供了丰富的能力，帮助用户轻松构建事件驱动
 
 **扩展性与生态**
 
-- **智能体协作（A2A）** —— 内置的 [A2A 协议](docs/eventmesh-a2a-protocol.md) 将 EventMesh 打造成智能体协作总线，打通同步的 MCP / JSON-RPC 2.0 工具调用与异步的事件驱动发布订阅，原生支撑大模型（LLM）与多智能体（Multi-Agent）场景。
+- **智能体协作（A2A）** —— 内置的 [A2A 协议](docs/feature/a2a.md) 将 EventMesh 打造成智能体协作总线，打通同步的 MCP / JSON-RPC 2.0 工具调用与异步的事件驱动发布订阅，原生支撑大模型（LLM）与多智能体（Multi-Agent）场景。
 - **可插拔存储层** —— [Apache RocketMQ](https://rocketmq.apache.org)、[Apache Kafka](https://kafka.apache.org)、[Apache Pulsar](https://pulsar.apache.org)、[RabbitMQ](https://rabbitmq.com)、[Redis](https://redis.io) 等。
 - **可插拔互联层（Connector）** —— [connectors](https://github.com/apache/eventmesh/tree/develop/eventmesh-connector-plugin) 作为独立进程运行，可充当 SaaS、CloudService、数据库等的 source 或 sink。
 - **可插拔元数据服务** —— [Consul](https://consulproject.org/en/)、[Nacos](https://nacos.io)、[ETCD](https://etcd.io) 和 [Zookeeper](https://zookeeper.apache.org/)。
@@ -62,12 +62,12 @@ Apache EventMesh 提供了丰富的能力，帮助用户轻松构建事件驱动
 
 | 能力 | 状态 | 建议 | 迁移目标 |
 | --- | :---: | --- | --- |
-| [HTTP + CloudEvents](docs/eventmesh-client-guide.md) | **GA 目标** | 推荐——主用户路径（`CloudEventsClient` + `/events/*`） | 主路径 |
+| [HTTP + CloudEvents](docs/feature/client-java.md) | **GA 目标** | 推荐——主用户路径（`CloudEventsClient` + `/events/*`） | 主路径 |
 | [Kafka / RocketMQ 存储](eventmesh-storage-plugin/)（4.x、5.x） | **GA 目标** | 推荐——可插拔 WAL 后端，TCK 覆盖（`MeshStoragePluginTCK`） | 主路径 |
 | SSE / WebSocket 推送 | **Beta** | 可用——已有集成测试；统一 ACK/重投递语义仍在收敛 | 统一推送传输 |
 | Connector Runtime | **Experimental** | 端到端可用，但 23 个插件中仅 4 个（file/kafka/pulsar/rocketmq）有单元测试，其余为模板实现；数据丢失加固已由 [#5328](https://github.com/apache/eventmesh/pull/5328) 落地 | SPI 拆分至 `eventmesh-connector-api`（#5328）；剩余插件测试与 GA 标准由 #5296 架构 review 跟踪 |
-| [A2A / Agent 网关](docs/eventmesh-a2a-protocol.md) | **实验性** | 评估——TaskStore + Runtime 桥已落地（#5302/#5304）；reaper 与 Meta 化 AgentCard 待做 | 统一 Runtime A2A |
-| TCP / gRPC / OpenMessaging SDK | **Legacy 兼容** | 仅存量用户——保持老客户端零改动运行；不再扩展 | [HTTP + CloudEvents](docs/eventmesh-client-guide.md) |
+| [A2A / Agent 网关](docs/feature/a2a.md) | **实验性** | 评估——TaskStore + Runtime 桥已落地（#5302/#5304）；reaper 与 Meta 化 AgentCard 待做 | 统一 Runtime A2A |
+| TCP / gRPC / OpenMessaging SDK | **Legacy 兼容** | 仅存量用户——保持老客户端零改动运行；不再扩展 | [HTTP + CloudEvents](docs/feature/client-java.md) |
 
 状态含义：
 
@@ -77,15 +77,18 @@ Apache EventMesh 提供了丰富的能力，帮助用户轻松构建事件驱动
 - **Legacy 兼容** —— 仅为存量客户端零改动兼容而维护；只修缺陷、不加功能。新接入不要选这里。
 
 > 正在从 TCP / gRPC SDK 迁移？Legacy 客户端在当前 Runtime 上继续可用；替代方案（HTTP +
-> CloudEvents 的 `CloudEventsClient`）见[客户端指引](docs/eventmesh-client-guide.md)。
+> CloudEvents 的 `CloudEventsClient`）见[客户端指引](docs/feature/client-java.md)。
 
 ### 文档导航
 
-- [快速上手（英文）](docs/eventmesh-getting-started.md) —— 零到运行
-- [配置参考（英文）](docs/eventmesh-configuration.md) —— 每个运行时键、后端设置、安全 &amp; 配额
-- [客户端指引（中文）](docs/eventmesh-client-guide.md) —— `CloudEventsClient` 完整用法
-- [架构（英文）](docs/eventmesh-architecture.md) —— 控制面 / 数据面 / 智能体面；存储 SPI；安全闸门；A2A 协议栈
-- [特性（英文）](docs/eventmesh-features.md) —— 逐特性说明（发布订阅、A2A、连接器、安全、可靠性）
+文档树按读者分层组织，入口见[文档地图（英文）](docs/index.md)：
+
+- [产品介绍（英文）](docs/introduction.md) —— EventMesh 是什么、三平面、部署形态
+- [快速上手（英文）](docs/quickstart/getting-started.md) —— 零到运行
+- [配置参考（英文）](docs/quickstart/configuration.md) —— 每个运行时键、后端设置、安全 &amp; 配额
+- [客户端指引（英文）](docs/feature/client-java.md) —— `CloudEventsClient` 完整用法
+- 特性指引（英文）—— [发布订阅](docs/feature/pubsub.md) · [可靠投递](docs/feature/delivery-reliability.md) · [流式推送](docs/feature/streaming.md) · [Lite Topic](docs/feature/lite-topic.md) · [A2A](docs/feature/a2a.md) · [HTTP API](docs/feature/http-api.md) · [Admin API](docs/feature/admin-api.md) · [部署运维](docs/feature/deployment.md)
+- 架构（英文）—— [总览](docs/architecture/overview.md) · [安全](docs/architecture/security.md) · [架构重构设计档案](docs/architecture/redesign.md)
 
 ## 子项目
 
@@ -98,7 +101,7 @@ Apache EventMesh 提供了丰富的能力，帮助用户轻松构建事件驱动
 ## 快速入门
 
 完整的步骤引导——前置依赖、后端选择、通过 Docker 或源码启动、首个事件、三种接收传输、取消订阅以及 SDK 路径——均在
-[快速上手](docs/eventmesh-getting-started.md)。该文档中的首事件示例可针对标准端口
+[快速上手](docs/quickstart/getting-started.md)。该文档中的首事件示例可针对标准端口
 （`8080` HTTP、`8081` 管理、`8082` WebSocket、`8083` 连接器管理）运行。
 
 ## 贡献

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,7 +56,7 @@ RUN chmod +x bin/*.sh
 # 8080 = traffic HTTP (/events/* CloudEvents + legacy /eventmesh/*).
 # 8081 = independent admin port (UniAdminServer /admin/*, incl. GET /admin/health).
 # 8082 = WebSocket push transport (opt-in via -Deventmesh.ws.port in JAVA_OPTS).
-# Note (#5380 deployment modes, see docs/eventmesh-features.md §5b): this image is the
+# Note (#5380 deployment modes, see docs/feature/deployment.md, deployment modes): this image is the
 # CORE Runtime. The A2A Gateway (A2AGatewayServer, EXPERIMENTAL) and the v2 streaming
 # session layer are NOT started by bin/start.sh; they require a dedicated launcher /
 # embedder wiring and are documented as separate deployment modes.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -21,7 +21,7 @@ separation-of-concerns planes:
    pipeline as ordinary events.
 
 This page gives the **structural** view. For end-to-end data flow diagrams see
-`docs/eventmesh-uni-architecture-redesign.md`. For the security / quota gate, see
+`docs/architecture/redesign.md`. For the security / quota gate, see
 the "Security gate" section below and the `#5304` reference docs; for the storage
 capability contract, see the `eventmesh-storage-api` TCK.
 
@@ -277,9 +277,9 @@ Key classes:
 
 The protocol is **Experimental** (see capability status table). The wire
 contract is the JSON envelope from
-[docs/eventmesh-a2a-protocol.md](../feature/a2a.md); the runtime
+[docs/feature/a2a.md](../feature/a2a.md); the runtime
 implementation is documented in
-[docs/eventmesh-uni-architecture-redesign.md](redesign.md).
+[docs/architecture/redesign.md](redesign.md).
 
 ---
 
@@ -383,7 +383,7 @@ PR workflow are both in place to make this discipline cheap.
 ### Configuration
 
 * Runtime configuration is documented in
-  [docs/eventmesh-configuration.md](../quickstart/configuration.md). New
+  [docs/quickstart/configuration.md](../quickstart/configuration.md). New
   keys are added behind the existing prefixes (`eventmesh.runtime.*`,
   `eventmesh.security.gate.*`, `eventmesh.storage.*`,
   `eventmesh.connector.*`) — never under a global `eventmesh.*` root.
@@ -409,7 +409,7 @@ EventMesh supports several wire protocols and ships client SDKs in
 multiple languages. The canonical inventory - including GA / Beta /
 Experimental / Legacy status for each protocol, the server-side
 protocol plugin that handles it, and the corresponding client SDK
-surface - lives in [docs/protocols.md](../feature/protocols.md). The policy
+surface - lives in [docs/feature/protocols.md](../feature/protocols.md). The policy
 summarized there:
 
 * The modern **HTTP + CloudEvents + EventMeshFrame** path is the
@@ -417,7 +417,7 @@ summarized there:
 * Legacy **TCP** (MeshMessage, OpenMessaging) and the legacy
   HTTP codec are still supported for backward compatibility but
   are explicitly marked Legacy and receive only critical bug
-  fixes. See `docs/protocols.md` for the migration path.
+  fixes. See `docs/feature/protocols.md` for the migration path.
 * gRPC framing is **Beta**: stable, but the API surface may shift.
 * A2A is **Experimental** until the readiness checks in #5340
   pass.

--- a/docs/architecture/review/evidence.md
+++ b/docs/architecture/review/evidence.md
@@ -69,8 +69,8 @@ Actions recovers. No PR is blocked on code; the three open PRs (#5345,
 | #5301 Sub-PR C | #5312 | `ef0fb1857` | `ReliableDispatcherDlqLedgerTest`, `MetaBackedDeadLetterStoreTest`, `MetaBackedTaskStoreTest` | `./gradlew :eventmesh-runtime:test --tests "*DlqLedger*" --tests "*MetaBacked*"` | merged | Nacos in-memory | single | pass on merge |
 | #5301 Sub-PR D (D1) | #5313 | `6ec99215c` | `A2AGatewayServiceTest`, `A2AGatewaySmokeTest` | `./gradlew :eventmesh-a2a:test` | merged | in-process | single | pass on merge |
 | #5301 E2E (#5314) | #5318 | `7abca88aa` | `CrossStoreFaultInjectionTest` | `./gradlew :eventmesh-runtime:test --tests "*CrossStoreFault*"` | merged | RocksDB + Nacos in-memory | crash-recovery | pass on merge |
-| #5339 (Q3) | #5345 | `04247475b` | `StateStoreDurabilityTest` (@Nested 6 scenarios) + `docs/state-store-failure-matrix.md` | `./gradlew :eventmesh-runtime:test --tests "StateStoreDurabilityTest"` | OPEN-CI-startup_failure | RocksDB / Nacos | restart / multi / crash / kill -9 | awaiting runner |
-| #5340 (Q4) D2a | #5346 | `3db5f663b` | `TaskExpirerTest`, `MetaAgentCardRegistryTest`, `A2AGatewayFailureModeTest` + `docs/a2a-readiness-decision.md` | `./gradlew :eventmesh-a2a:test --tests "*TaskExpirer*" --tests "*MetaAgentCard*" --tests "*A2AGatewayFailure*"` | OPEN-CI-startup_failure | Meta in-memory | single | awaiting runner |
+| #5339 (Q3) | #5345 | `04247475b` | `StateStoreDurabilityTest` (@Nested 6 scenarios) + `docs/feature/control-plane.md` | `./gradlew :eventmesh-runtime:test --tests "StateStoreDurabilityTest"` | OPEN-CI-startup_failure | RocksDB / Nacos | restart / multi / crash / kill -9 | awaiting runner |
+| #5340 (Q4) D2a | #5346 | `3db5f663b` | `TaskExpirerTest`, `MetaAgentCardRegistryTest`, `A2AGatewayFailureModeTest` + `docs/feature/a2a-readiness.md` | `./gradlew :eventmesh-a2a:test --tests "*TaskExpirer*" --tests "*MetaAgentCard*" --tests "*A2AGatewayFailure*"` | OPEN-CI-startup_failure | Meta in-memory | single | awaiting runner |
 
 ### #5302 -- A2A must not form a parallel Runtime
 
@@ -82,7 +82,7 @@ Already covered by #5301 D1 above (#5313 / #5346). Follow-ups tracked at
 | Issue | PR | Commit | Test files | Test command | CI | Backend | Topology | Result |
 |---|---|---|---|---|---|---|---|---|
 | #5303 | #5323 | `054127e0a` | `MeshStoragePluginTCK`, `MeshStoragePluginTCKSelfTest`, `KafkaMeshStoragePluginTCKTest`, `RocketMQRemotingStoragePluginTCKTest`, `RocketMQ5RemotingStoragePluginTCKTest` | `./gradlew :eventmesh-storage-plugin:test` | merged | Kafka / RocketMQ 4.x / RocketMQ 5.x | TCK (broker-optional) | pass on merge |
-| #5342 (Q6+Q7) | #5348 | `3cfc94868` | `ArchitectureRulesTest` (2 new `*_check` + 1 new `*_catches`); new `FakeStorageCanary`. Plus `docs/storage-spi.md` + `docs/architecture-guard.md` + `CONTRIBUTING.md` | `./gradlew :eventmesh-architecture-guard:architectureCheck` + `./gradlew :eventmesh-storage-plugin:test` | OPEN-CI-startup_failure | n/a + Kafka / RocketMQ / RocketMQ5 | unit + TCK | awaiting runner |
+| #5342 (Q6+Q7) | #5348 | `3cfc94868` | `ArchitectureRulesTest` (2 new `*_check` + 1 new `*_catches`); new `FakeStorageCanary`. Plus `docs/feature/storage-spi.md` + `docs/feature/architecture-guard.md` + `CONTRIBUTING.md` | `./gradlew :eventmesh-architecture-guard:architectureCheck` + `./gradlew :eventmesh-storage-plugin:test` | OPEN-CI-startup_failure | n/a + Kafka / RocketMQ / RocketMQ5 | unit + TCK | awaiting runner |
 
 ### #5304 -- Unified multi-tenant / security / quota entrypoint
 
@@ -158,7 +158,7 @@ of the open PR #5345 -- the new `StateStoreDurabilityTest` class
 encompasses both, and the open CI run will provide the first
 fully-executable evidence at the `OffsetStoreRestart` and
 `SubscriptionStoreMultiInstance` levels. The corresponding
-`docs/state-store-failure-matrix.md` (also in #5345) lists the per-backend
+`docs/feature/control-plane.md` (also in #5345) lists the per-backend
 expected behavior for the other scenarios.
 
 ## Items lacking evidence (out of scope or follow-up)
@@ -167,7 +167,7 @@ expected behavior for the other scenarios.
   Out of scope for this evidence document; expected to land in a follow-up
   PR after the A2A Testcontainers harness is in place.
 - **#5342 Q6 plugin-load-time capability validation** -- explicitly
-  documented as future work in `docs/storage-spi.md` (the
+  documented as future work in `docs/feature/storage-spi.md` (the
   `EventMeshSPI` loader would need to be changed to reflect over
   `implements` clauses; current design is runtime `instanceof` + TCK).
 - **Scenario 4 (Crash recovery) on a non-Kafka backend (RocketMQ 5.x
@@ -196,17 +196,17 @@ expected behavior for the other scenarios.
 - #5296 -- parent issue
 - #5337 -- tracking issue for this evidence document
 - #5342 -- this evidence document's "Q6 + Q7 governance" PR
-- `docs/architecture-guard.md` -- arch-guard canonical reference
-- `docs/storage-spi.md` -- storage capability matrix
-- `docs/state-store-failure-matrix.md` -- per-backend failure modes
+- `docs/feature/architecture-guard.md` -- arch-guard canonical reference
+- `docs/feature/storage-spi.md` -- storage capability matrix
+- `docs/feature/control-plane.md` -- per-backend failure modes
   (from #5345)
-- `docs/a2a-readiness-decision.md` -- A2A experimental / GA decision
+- `docs/feature/a2a-readiness.md` -- A2A experimental / GA decision
   (from #5346)
 
 
 ## Production-HA acceptance (#5354): evidence table
 
-> Parent: #5354 (production HA) · Plan: `docs/architecture-review/production-ha-plan.md` (PR #5366)
+> Parent: #5354 (production HA) · Plan: `docs/architecture/review/production-ha-plan.md` (PR #5366)
 > Sub-issues: #5356-#5365 · Original scope: #5352 (data-path) / #5353 (control-plane)
 > Generated: 2026-09-09
 

--- a/docs/architecture/review/production-ha-plan.md
+++ b/docs/architecture/review/production-ha-plan.md
@@ -2,7 +2,7 @@
 
 > **Status (2026-09-09): COMPLETE.** Phase 0-4 executed as #5367-#5374; #5363 (Testcontainers
 > E2E) deferred with a compensating-coverage note on the issue. Evidence:
-> `docs/architecture-review/evidence.md` § "Production-HA acceptance". The three parent
+> `docs/architecture/review/evidence.md` § "Production-HA acceptance". The three parent
 > issues (#5352 / #5353 / #5354) close with the evidence table.
 
 > Tracking issue: #5354 (parent)
@@ -116,16 +116,16 @@ acceptance criteria are answered with evidence, not that the work is small.
   roll one instance at a time with mixed versions for 5 minutes, assert no offset regression
   and no duplicate delivery beyond the configured at-least-once bound. Admin: lock down
   `/admin/*` and `/metrics` behind a config-gated token (fail-closed by default), document
-  the security posture in `docs/control-plane.md`.
+  the security posture in `docs/feature/control-plane.md`.
 
 ### Phase 4 — Documentation + evidence (P2)
 
 The last mile.
 
-- **#5365** — Update `docs/eventmesh-architecture.md`, `docs/control-plane.md`,
-  `docs/production-readiness.md`, `docs/eventmesh-offset-lb-frame-design.md` to reflect the
+- **#5365** — Update `docs/architecture/overview.md`, `docs/feature/control-plane.md`,
+  `docs/feature/deployment.md`, `docs/feature/offset-management.md` to reflect the
   real behavior of the runtime after #5359-#5364. Add a row to
-  `docs/architecture-review/evidence.md` for each of the 8 tracking issues, with the same
+  `docs/architecture/review/evidence.md` for each of the 8 tracking issues, with the same
   7-column format as the #5296 evidence table. Final cross-link from #5354 to the updated
   docs; close #5352, #5353, #5354.
 
@@ -157,7 +157,7 @@ in its `Depends on` column.
 | C7 | Resource limits prevent unbounded memory under tenant/topic/partition pressure | #5359 + #5362 |
 | C8 | Required failure / recovery metrics are emitted and alertable | #5364 |
 | C9 | Request-reply / streaming / connector / admin HA guarantees are explicit and tested | #5363 + #5364 |
-| C10 | Evidence is recorded in `docs/architecture-review/evidence.md` before closing | #5365 |
+| C10 | Evidence is recorded in `docs/architecture/review/evidence.md` before closing | #5365 |
 
 ## 4. PR plan (one PR per issue, plus evidence PRs)
 
@@ -197,4 +197,4 @@ depends on #5359's boot wiring to exist.
   close on unit / boot tests, with a follow-up issue for the E2E harness.
 - **`LOCAL_STICKY_PULL` semantics.** The new "multi-instance = duplicate delivery"
   documentation is a behavior change for anyone who had been running two instances. The
-  `docs/production-readiness.md` update in #5365 must call this out clearly.
+  `docs/feature/deployment.md` update in #5365 must call this out clearly.

--- a/docs/feature/a2a-readiness.md
+++ b/docs/feature/a2a-readiness.md
@@ -63,7 +63,7 @@ All of the following must be true before A2A is promoted to Beta:
 3. **The `eventmesh-a2a-protocol.md` document is updated** with the
    post-D2b wire contract, a worked example, and the SLOs from item 2.
 4. **A deprecation note for the legacy A2A path (if any)** is added to the
-   changelog and to `docs/protocols.md` (see #5341).
+   changelog and to `docs/feature/protocols.md` (see #5341).
 
 When all four are true, this page is updated, the EXPERIMENTAL banner in
 `docs/a2a-protocol/README.md` is changed to **BETA**, and the tracking issue
@@ -109,6 +109,6 @@ Plus the existing `A2AGatewayServiceTest` (in
   durability), #5341 (protocol/SDK boundary)
 * Docs:
   - `docs/a2a-protocol/README.md` (carries the EXPERIMENTAL banner)
-  - `docs/eventmesh-architecture.md` (A2A section)
-  - `docs/control-plane.md` (DeliveryTopology / SecurityGate)
-  - `docs/state-store-failure-matrix.md` (per-backend failure mode)
+  - `docs/architecture/overview.md` (A2A section)
+  - `docs/feature/control-plane.md` (DeliveryTopology / SecurityGate)
+  - `docs/feature/control-plane.md` (per-backend failure mode)

--- a/docs/feature/architecture-guard.md
+++ b/docs/feature/architecture-guard.md
@@ -128,6 +128,6 @@ pattern ArchUnit's own examples use for "prove the rule works."
 
 ## Further reading
 
-- `docs/storage-spi.md` -- the storage capability matrix
+- `docs/feature/storage-spi.md` -- the storage capability matrix
 - `eventmesh-architecture-guard/README.md` -- module-level summary
 - CONTRIBUTING.md -- how to add a new module

--- a/docs/feature/client-java.md
+++ b/docs/feature/client-java.md
@@ -14,7 +14,7 @@ The new architecture ships with **one client SDK** that exposes two surface APIs
   This is the **primary user path** and the recommended way to integrate with
   EventMesh.
 * `A2AClient` — Agent-to-Agent task dispatch on top of the same Runtime
-  ([docs/eventmesh-a2a-protocol.md](../feature/a2a.md)). Used by multi-agent systems that
+  ([docs/feature/a2a.md](../feature/a2a.md)). Used by multi-agent systems that
   need a durable task lifecycle.
 
 Both clients talk **only to the EventMesh Runtime** (HTTP). The underlying
@@ -145,7 +145,7 @@ CloudEventsClient client = CloudEventsClient.builder()
 
 TLS / mTLS is configured at the **Runtime** (server side), not the client. The
 client just talks to `https://...` once TLS is enabled. See
-[docs/eventmesh-configuration.md](../quickstart/configuration.md#security).
+[docs/quickstart/configuration.md](../quickstart/configuration.md#security).
 
 ---
 
@@ -395,8 +395,8 @@ The gate runs `FilterChain` (TokenAuth → SignatureVerifier → Acl) →
 For configuration and the three wiring points
 (`UniHttpServer.withSecurityGate`, `A2AGatewayHttpHandler.withSecurityGate`,
 `ConnectorScheduler.withSecurityGate`) see
-[docs/eventmesh-configuration.md](../quickstart/configuration.md#security) and
-[docs/eventmesh-architecture.md §4](../architecture/overview.md#4-security-gate-issue-5304).
+[docs/quickstart/configuration.md](../quickstart/configuration.md#security) and
+[docs/architecture/overview.md §4](../architecture/overview.md#4-security-gate-issue-5304).
 
 > **The client SDK does not need to "know" about the gate.** A deployment that
 > enables the gate is a server-side change. The client sends the same CloudEvent
@@ -419,10 +419,10 @@ For configuration and the three wiring points
 
 For the storage-state taxonomy (L1 / L2 / L3) and the
 `MeshStoragePlugin` / `MeshStoragePluginTCK` contract, see
-[docs/eventmesh-architecture.md §3](../architecture/overview.md#3-control-plane--state-sessions-and-coordination).
+[docs/architecture/overview.md §3](../architecture/overview.md#3-control-plane--state-sessions-and-coordination).
 
 Configuration knobs: see
-[docs/eventmesh-configuration.md](../quickstart/configuration.md#deliverystate)
+[docs/quickstart/configuration.md](../quickstart/configuration.md#deliverystate)
 (`eventmesh.runtime.delivery.*`).
 
 ---
@@ -490,8 +490,8 @@ surface is:
 * `GET /a2a/agents` — list agents
 * `POST /a2a/agents` — register an agent card
 
-See [docs/eventmesh-a2a-protocol.md](../feature/a2a.md) for the wire contract and
-[docs/eventmesh-architecture.md §5](../architecture/overview.md#5-agent-plane--a2a-on-the-same-substrate)
+See [docs/feature/a2a.md](../feature/a2a.md) for the wire contract and
+[docs/architecture/overview.md §5](../architecture/overview.md#5-agent-plane--a2a-on-the-same-substrate)
 for the runtime architecture.
 
 ---
@@ -513,7 +513,7 @@ backend to another is a **Runtime** configuration change; the same
 | Lite Topic | — | yes (`LiteTopicCapable`) | — |
 
 Per-backend keys are listed in
-[docs/eventmesh-configuration.md](../quickstart/configuration.md#storage).
+[docs/quickstart/configuration.md](../quickstart/configuration.md#storage).
 Pick one `eventmesh.storage.type` at Runtime startup:
 
 ```bash
@@ -619,7 +619,7 @@ The same `Demo` class runs unchanged on all three.
 | Dead-letter inspection | admin HTTP (port 8081) | `GET /admin/dlq?topic=<topic>` |
 | A2A agent registry | `A2AClient.listAgents()` | Should return at least one `AgentCard` for `agentName` you registered |
 
-See [docs/production-readiness.md](deployment.md) for SLOs and
+See [docs/feature/deployment.md](deployment.md) for SLOs and
 runbooks.
 
 ---
@@ -670,13 +670,13 @@ history for the migration notes.
 
 See also:
 
-* [docs/eventmesh-architecture.md](../architecture/overview.md) — system
+* [docs/architecture/overview.md](../architecture/overview.md) — system
   architecture, control / data / agent planes
-* [docs/eventmesh-features.md](../index.md) — feature-by-feature
+* [docs/index.md](../index.md) — feature-by-feature
   guide
-* [docs/eventmesh-configuration.md](../quickstart/configuration.md) — every
+* [docs/quickstart/configuration.md](../quickstart/configuration.md) — every
   runtime key
-* [docs/eventmesh-getting-started.md](../quickstart/getting-started.md) —
+* [docs/quickstart/getting-started.md](../quickstart/getting-started.md) —
   zero-to-running guide
-* [docs/eventmesh-a2a-protocol.md](../feature/a2a.md) — A2A wire contract
-* [docs/production-readiness.md](deployment.md) — SLOs, runbooks
+* [docs/feature/a2a.md](../feature/a2a.md) — A2A wire contract
+* [docs/feature/deployment.md](deployment.md) — SLOs, runbooks

--- a/docs/feature/control-plane.md
+++ b/docs/feature/control-plane.md
@@ -55,7 +55,7 @@ construction:
 | --- | --- |
 | HTTP `POST /events/publish` | `UniHttpServer` -> `UniIngressService.publish` -> `Frame` -> `Producer.send` -> `poll loop` -> topology-selected partition set |
 | A2A `POST /a2a/tasks/send` | `A2AGatewayHttpHandler` -> `A2AGatewayService` -> `UniIngressService` -> same as above |
-| Legacy TCP (`UniTcpServer`) | main path is being phased out (see docs/protocols.md #5341); when active, the TCP server feeds the same `UniIngressService` |
+| Legacy TCP (`UniTcpServer`) | main path is being phased out (see docs/feature/protocols.md #5341); when active, the TCP server feeds the same `UniIngressService` |
 | WebSocket push | passive receiver; not gated by topology (the topology decides *which* partitions to *poll*, not the push path) |
 | SSE | passive receiver; not gated by topology |
 
@@ -79,7 +79,7 @@ source tree (only `UniRuntime` and `DeliveryTopology` itself should match in
   `eventmesh.security.gate.*` and the per-filter keys).
 * **Default:** a no-op gate that allows every request. This is the
   backward-compatible default and is documented as such in
-  `docs/eventmesh-configuration.md`.
+  `docs/quickstart/configuration.md`.
 * **Fail-closed mode:** when `eventmesh.security.gate.failClosed=true`,
   any filter chain exception (auth failed, signature invalid, ACL denied)
   results in a 401/403 response. The default is fail-open (allowed) so a
@@ -102,7 +102,7 @@ source tree (only `UniRuntime` and `DeliveryTopology` itself should match in
 | HTTP `POST /events/publish` | **Yes** | `UniHttpServer` -> `RequestContext` -> `SecurityGate.check(ctx, frame)` -> `UniIngressService.publish` |
 | HTTP `POST /events/subscribe` | **Yes** | same chain |
 | A2A `POST /a2a/tasks/send` | **Yes** | `A2AGatewayHttpHandler` -> gate -> `A2AGatewayService` -> `UniIngressService` |
-| Legacy TCP | **Yes** (gated by TCP-level auth, separate from SecurityGate) | `UniTcpServer` -> `TcpIngressBridge` (the TCP path has its own connection-level auth, see docs/protocols.md) |
+| Legacy TCP | **Yes** (gated by TCP-level auth, separate from SecurityGate) | `UniTcpServer` -> `TcpIngressBridge` (the TCP path has its own connection-level auth, see docs/feature/protocols.md) |
 | Admin HTTP | **Yes** | `UniAdminServer` -> `UniAdminService` (separate gate, configured under `eventmesh.admin.security.*`) |
 | WebSocket push | n/a (passive) | push does not invoke the gate; the gate ran at subscribe time |
 | SSE | n/a (passive) | same as WS |
@@ -124,8 +124,8 @@ source tree (only `UniRuntime` and `DeliveryTopology` itself should match in
 * DeliveryTopology decision: #5293 (closed via PR #5308, implementing `LOCAL_STICKY_PULL`)
 * DeliveryTopology wiring follow-up: #5309 (`PARTITION_OWNED_PULL` wiring)
 * SecurityGate: #5304
-* Architecture: `docs/eventmesh-architecture.md` (section 4, Security gate)
-* Configuration: `docs/eventmesh-configuration.md`
+* Architecture: `docs/architecture/overview.md` (section 4, Security gate)
+* Configuration: `docs/quickstart/configuration.md`
 
 
 ## State store failure matrix
@@ -192,7 +192,7 @@ Each row maps an issue #5339 acceptance scenario to the test that exercises it.
 * The test for each scenario above is referenced in the table in section 3.
 * No production-code store is backed by an `InMemory*` implementation; the
   in-memory implementations live in `state/fault/` (test-only).
-* This document exists (`docs/state-store-failure-matrix.md`).
+* This document exists (`docs/feature/control-plane.md`).
 
 ## 5. References
 

--- a/docs/feature/protocols.md
+++ b/docs/feature/protocols.md
@@ -83,7 +83,7 @@ classpath.
 
 1. Switch the client to
    `org.apache.eventmesh.client.cloudevents.CloudEventsClient` (see
-   `docs/eventmesh-client-guide.md`).
+   `docs/feature/client-java.md`).
 2. The CloudEvents wire format replaces the `EventMeshMessage` / OMA
    `Message` envelope. Event payload stays the same.
 3. If you depended on the TCP framing for performance reasons, note that
@@ -114,8 +114,8 @@ classpath.
 
 For the #5341 acceptance check, the following must hold:
 
-* `docs/protocols.md` exists and is linked from
-  `docs/eventmesh-architecture.md` (section 9) and from the README.
+* `docs/feature/protocols.md` exists and is linked from
+  `docs/architecture/overview.md` (section 9) and from the README.
 * The Java SDK's `build.gradle` declares `io.openmessaging:openmessaging-api`
   as `implementation`, not `api`.
 * `git grep "import.*MeshMessage\\|import io.openmessaging"`
@@ -130,7 +130,7 @@ For the #5341 acceptance check, the following must hold:
 
 * Parent issue: #5296 (Architecture Review, "New review questions" 2026-09-07)
 * Tracking issue: #5341
-* Architecture: `docs/eventmesh-architecture.md`
-* SDK guide: `docs/eventmesh-client-guide.md`
-* Arch-guard: `eventmesh-architecture-guard/`, `docs/architecture-guard.md`
-* A2A wire: `docs/eventmesh-a2a-protocol.md`
+* Architecture: `docs/architecture/overview.md`
+* SDK guide: `docs/feature/client-java.md`
+* Arch-guard: `eventmesh-architecture-guard/`, `docs/feature/architecture-guard.md`
+* A2A wire: `docs/feature/a2a.md`

--- a/eventmesh-runtime/conf/eventmesh.properties
+++ b/eventmesh-runtime/conf/eventmesh.properties
@@ -71,7 +71,7 @@ eventMesh.server.kafka.namesrvAddr=localhost:9092
 # IllegalArgumentException on startup (a typo must not silently degrade to single-instance).
 #eventmesh.delivery.topology=LOCAL_STICKY_PULL
 
-# ===== Connector Runtime (Experimental — see docs/eventmesh-features.md) =====
+# ===== Connector Runtime (Experimental — see docs/feature/deployment.md) =====
 # Connectors run as an independent process (eventmesh-connector-runtime) that bridges external
 # systems and EventMesh over CloudEvents/HTTP. This section is read by that process, not by the
 # EventMesh server itself.

--- a/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/subscription/DistributionMode.java
+++ b/eventmesh-runtime/src/main/java/org/apache/eventmesh/runtime/subscription/DistributionMode.java
@@ -21,7 +21,7 @@ package org.apache.eventmesh.runtime.subscription;
  * Distribution modes for EventMesh's self-managed subscription model.
  *
  * <p>EventMesh owns the distribution logic (the MQ exposes no consumer-group semantics); see
- * {@code docs/eventmesh-uni-architecture-redesign.md} §4.2.</p>
+ * {@code docs/architecture/redesign.md} §4.2.</p>
  */
 public enum DistributionMode {
 

--- a/eventmesh-sdks/eventmesh-sdk-java/build.gradle
+++ b/eventmesh-sdks/eventmesh-sdk-java/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     api "io.cloudevents:cloudevents-json-jackson"
     // OpenMessaging is a legacy TCP-only transport; demoted to `implementation`
     // so the modern CloudEvents HTTP client surface (org.apache.eventmesh.client.cloudevents.*)
-    // does not leak OMA types to downstream consumer classpaths. See docs/protocols.md
+    // does not leak OMA types to downstream consumer classpaths. See docs/feature/protocols.md
     // (#5341).
     implementation "io.openmessaging:openmessaging-api"
 

--- a/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/legacy-README.md
+++ b/eventmesh-sdks/eventmesh-sdk-java/src/main/java/org/apache/eventmesh/client/legacy-README.md
@@ -20,7 +20,7 @@ deployments. It supports three wire formats:
 
 1. Switch to
    `org.apache.eventmesh.client.cloudevents.CloudEventsClient`. See
-   `docs/eventmesh-client-guide.md`.
+   `docs/feature/client-java.md`.
 2. The CloudEvents wire format replaces the `EventMeshMessage` / OMA
    `Message` envelope. Event payload stays the same.
 3. Remove `io.openmessaging:openmessaging-api` from your application's
@@ -30,4 +30,4 @@ A deprecation warning is logged on every legacy client construction; the
 class itself is not removed in this release but is planned for removal
 in the next major version.
 
-Tracked by #5341. See `docs/protocols.md` for the full inventory.
+Tracked by #5341. See `docs/feature/protocols.md` for the full inventory.


### PR DESCRIPTION
Follow-up to #5390 / #5391 — sweep every stale doc reference outside `docs/`.

## Motivation

The docs restructure renamed/moved every page, but ~80 places across READMEs, CONTRIBUTING, code comments, build files, and config templates still referenced the old flat names (`docs/eventmesh-*.md`, `docs/control-plane.md`, …). This PR updates them all.

## Changes

| File | What |
| --- | --- |
| `README.zh-CN.md` | Capability-table links + doc nav rewritten to the new `quickstart/feature/architecture` layout (mirrors the EN README map) |
| `CONTRIBUTING.md` | Arch-guard + storage-SPI matrix links |
| `docker/Dockerfile` | Deployment-mode note → `docs/feature/deployment.md` |
| `eventmesh.properties` (runtime conf) | Connector Runtime section comment → `docs/feature/deployment.md` |
| `DistributionMode.java` javadoc | → `docs/architecture/redesign.md` |
| `eventmesh-sdk-java/build.gradle` | OMA demotion comment → `docs/feature/protocols.md` |
| sdk `legacy-README.md` | Guide/inventory links |
| `docs/**` (8 pages) | Link display text and prose mentions still naming old filenames — e.g. `evidence.md`, `production-ha-plan.md` (design records referencing what to update), `client-java.md`, `protocols.md`, `control-plane.md` |

## Verification

- Repo-wide scan for 20 old-path patterns across java/gradle/properties/md/yml/Dockerfile: **0 stale references** remain (the only `docs/reference/` strings left are `opentelemetry.io` spec URLs — external, untouched).
- **227 internal `.md` links across `docs/` + both READMEs + CONTRIBUTING all resolve** (0 broken).
- Touched modules compile and pass `checkstyleMain` (runtime, sdk-java, common).
