### PR TITLE
docs: fix README factual drift (branch targets, ports, plugin claims)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <br />
 
 [![CI status](https://img.shields.io/github/actions/workflow/status/apache/eventmesh/ci.yml?logo=github&style=for-the-badge)](https://github.com/apache/eventmesh/actions/workflows/ci.yml)
-[![CodeCov](https://img.shields.io/codecov/c/gh/apache/eventmesh/master?logo=codecov&style=for-the-badge)](https://codecov.io/gh/apache/eventmesh)
+[![CodeCov](https://img.shields.io/codecov/c/gh/apache/eventmesh/develop?logo=codecov&style=for-the-badge)](https://codecov.io/gh/apache/eventmesh)
 [![Code Scanning](https://img.shields.io/github/actions/workflow/status/apache/eventmesh/code-scanning.yml?label=code%20scanning&logo=github&style=for-the-badge)](https://github.com/apache/eventmesh/actions/workflows/code-scanning.yml)
 
 [![License](https://img.shields.io/github/license/apache/eventmesh?style=for-the-badge)](https://www.apache.org/licenses/LICENSE-2.0.html)
@@ -14,7 +14,7 @@
   
 
 [📦 Documentation](https://eventmesh.apache.org/docs/introduction) |
-[📔 Examples](https://github.com/apache/eventmesh/tree/master/eventmesh-examples) |
+[📔 Examples](https://github.com/apache/eventmesh/tree/develop/eventmesh-examples) |
 [⚙️ Roadmap](https://eventmesh.apache.org/docs/roadmap) |
 [🌐 简体中文](README.zh-CN.md)
 </div>
@@ -47,9 +47,9 @@ Apache EventMesh is packed with features that help users build event-driven appl
 **Extensibility & ecosystem**
 
 - **Agent-to-Agent (A2A) collaboration** — a built-in [A2A protocol](docs/feature/a2a.md) turns EventMesh into an agent collaboration bus, bridging synchronous MCP / JSON-RPC 2.0 tool calls and asynchronous event-driven pub/sub for LLM and multi-agent systems.
-- **Pluggable storage layer** — [Apache RocketMQ](https://rocketmq.apache.org), [Apache Kafka](https://kafka.apache.org), [Apache Pulsar](https://pulsar.apache.org), [RabbitMQ](https://rabbitmq.com), [Redis](https://redis.io), and more.
+- **Pluggable storage layer** — [Apache RocketMQ](https://rocketmq.apache.org) (4.x / 5.x) and [Apache Kafka](https://kafka.apache.org) ship today; more backends via the `MeshStoragePlugin` SPI.
 - **Pluggable interconnector layer** — [connectors](https://github.com/apache/eventmesh/tree/develop/eventmesh-connector-plugin) run as standalone processes acting as the source or sink of SaaS, CloudService, Database, etc.
-- **Pluggable meta service** — [Consul](https://consulproject.org/en/), [Nacos](https://nacos.io), [ETCD](https://etcd.io), and [Zookeeper](https://zookeeper.apache.org/).
+- **Pluggable meta service** — [Nacos](https://nacos.io) ships today (multi-instance coordination); more backends via the same storage SPI.
 - **Event schema management** via catalog service.
 - **Powerful event orchestration** through the [Serverless workflow](https://serverlessworkflow.io/) engine.
 - **Powerful event filtering and transformation.**
@@ -106,7 +106,7 @@ A full step-by-step walkthrough — prerequisites, backend choice, run via Docke
 or from source, first publish, three receive transports, unsubscribe, and the SDK
 path — lives in [Getting started](docs/quickstart/getting-started.md). The
 first-event examples in that guide work against the standard ports
-(`8080` HTTP, `8081` admin, `8082` WebSocket, `8083` connector admin).
+(`8080` HTTP, `8081` admin, `8082` WebSocket opt-in).
 
 ## Contributing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 <br />
 
 [![CI status](https://img.shields.io/github/actions/workflow/status/apache/eventmesh/ci.yml?logo=github&style=for-the-badge)](https://github.com/apache/eventmesh/actions/workflows/ci.yml)
-[![CodeCov](https://img.shields.io/codecov/c/gh/apache/eventmesh/master?logo=codecov&style=for-the-badge)](https://codecov.io/gh/apache/eventmesh)
+[![CodeCov](https://img.shields.io/codecov/c/gh/apache/eventmesh/develop?logo=codecov&style=for-the-badge)](https://codecov.io/gh/apache/eventmesh)
 [![Code Scanning](https://img.shields.io/github/actions/workflow/status/apache/eventmesh/code-scanning.yml?label=code%20scanning&logo=github&style=for-the-badge)](https://github.com/apache/eventmesh/actions/workflows/code-scanning.yml)
 
 [![License](https://img.shields.io/github/license/apache/eventmesh?style=for-the-badge)](https://www.apache.org/licenses/LICENSE-2.0.html)
@@ -14,7 +14,7 @@
 [![Slack Status](https://img.shields.io/badge/slack-join_chat-blue.svg?logo=slack&style=for-the-badge)](https://join.slack.com/t/apacheeventmesh/shared_invite/zt-1t1816dli-I0t3OE~IpdYWrZbIWhMbXg)
 
 [📦 文档(英文)](https://eventmesh.apache.org/docs/introduction) |
-[📔 例子](https://github.com/apache/eventmesh/tree/master/eventmesh-examples) |
+[📔 例子](https://github.com/apache/eventmesh/tree/develop/eventmesh-examples) |
 [⚙️ 路线图](https://eventmesh.apache.org/docs/roadmap) |
 [🌐 英文版](README.zh-CN.md)
 </div>
@@ -48,9 +48,9 @@ Apache EventMesh 提供了丰富的能力，帮助用户轻松构建事件驱动
 **扩展性与生态**
 
 - **智能体协作（A2A）** —— 内置的 [A2A 协议](docs/feature/a2a.md) 将 EventMesh 打造成智能体协作总线，打通同步的 MCP / JSON-RPC 2.0 工具调用与异步的事件驱动发布订阅，原生支撑大模型（LLM）与多智能体（Multi-Agent）场景。
-- **可插拔存储层** —— [Apache RocketMQ](https://rocketmq.apache.org)、[Apache Kafka](https://kafka.apache.org)、[Apache Pulsar](https://pulsar.apache.org)、[RabbitMQ](https://rabbitmq.com)、[Redis](https://redis.io) 等。
+- **可插拔存储层** —— [Apache RocketMQ](https://rocketmq.apache.org)（4.x / 5.x）与 [Apache Kafka](https://kafka.apache.org) 已随包提供；更多后端经 `MeshStoragePlugin` SPI 接入。
 - **可插拔互联层（Connector）** —— [connectors](https://github.com/apache/eventmesh/tree/develop/eventmesh-connector-plugin) 作为独立进程运行，可充当 SaaS、CloudService、数据库等的 source 或 sink。
-- **可插拔元数据服务** —— [Consul](https://consulproject.org/en/)、[Nacos](https://nacos.io)、[ETCD](https://etcd.io) 和 [Zookeeper](https://zookeeper.apache.org/)。
+- **可插拔元数据服务** —— [Nacos](https://nacos.io) 已随包提供（多实例协调）；更多后端经同一存储 SPI 接入。
 - **事件模式管理** —— 通过目录（catalog）服务实现。
 - **强大的事件编排** —— 基于 [Serverless workflow](https://serverlessworkflow.io/) 引擎。
 - **强大的事件过滤与转换能力。**
@@ -102,7 +102,7 @@ Apache EventMesh 提供了丰富的能力，帮助用户轻松构建事件驱动
 
 完整的步骤引导——前置依赖、后端选择、通过 Docker 或源码启动、首个事件、三种接收传输、取消订阅以及 SDK 路径——均在
 [快速上手](docs/quickstart/getting-started.md)。该文档中的首事件示例可针对标准端口
-（`8080` HTTP、`8081` 管理、`8082` WebSocket、`8083` 连接器管理）运行。
+（`8080` HTTP、`8081` 管理、`8082` WebSocket 可选）运行。
 
 ## 贡献
 

--- a/docs/quickstart/getting-started.md
+++ b/docs/quickstart/getting-started.md
@@ -49,7 +49,7 @@ sudo docker run -d --name eventmesh \
 ```
 
 Ports: `8080` = traffic HTTP (`/events/*`), `8081` = admin HTTP (`/admin/*`). The WebSocket
-push port (`8082`) and the connector runtime admin port (`8083`) are opt-in.
+push port (`8082`) is opt-in.
 
 ### Option B — From source
 


### PR DESCRIPTION
User-reported: the READMEs were not fully updated. Beyond the doc-path sweep in #5392, this fixes the remaining factual drift in both READMEs (and one quickstart line).

## Fixes

| Issue | Reality (verified against code/branches) | Fix |
| --- | --- | --- |
| CodeCov badge targeted `master` | `master` is the legacy 1.x line (44 old top-level modules, e.g. `eventmesh-admin-server`); `develop` is the mainline | badge URL → `develop` |
| Examples header link → `tree/master/eventmesh-examples` | same — master examples are the old line | → `tree/develop/eventmesh-examples` |
| Quick start claimed a standard **8083 connector admin** port | No such default: `connector.admin.port` defaults to `0` (auto-assign) in `ConnectorApplication`; `docker/Dockerfile` EXPOSEs only 8080/8081/8082 | removed from EN/zh READMEs + `getting-started.md` |
| "Pluggable storage layer — RocketMQ, Kafka, Pulsar, RabbitMQ, Redis, and more" | Shipping storage plugins are RocketMQ 4.x / 5.x + Kafka only | scoped to shipping plugins + `MeshStoragePlugin` SPI path |
| "Pluggable meta service — Consul, Nacos, ETCD, Zookeeper" | Shipping meta backend is Nacos (+ in-memory single-instance) | scoped to Nacos + SPI path |

Applied symmetrically to `README.md` and `README.zh-CN.md`.

## Verification

- Residual scan: no `8083`, `tree/master`, codecov-`master`, Pulsar/RabbitMQ/Consul claims remain in either README or the quickstart.
- All **227 internal `.md` links across docs/ + READMEs + CONTRIBUTING still resolve (0 broken)**.
