### PR TITLE
docs(connector): add per-plugin guides for all 23 connectors

### DIFF
--- a/docs/feature/connectors/README.md
+++ b/docs/feature/connectors/README.md
@@ -1,0 +1,140 @@
+# Connectors
+
+**Audience:** operators and developers wiring EventMesh to external systems —
+message queues, databases, chat platforms, AI services. Covers the connector
+model, the 23 shipped plugins, how to configure and run them. For the API a
+plugin implements see [Connector API split plan](../connector-api-split.md);
+for runtime configuration of the connector scheduler see
+[Configuration reference](../../quickstart/configuration.md).
+
+---
+
+## The connector model
+
+A **connector** moves CloudEvents between EventMesh and an external system on
+one direction:
+
+- a **Source** pulls (or receives) data from the external system and the
+  connector runtime publishes it into EventMesh over HTTP;
+- a **Sink** long-polls EventMesh for deliveries and writes them into the
+  external system.
+
+The contract lives in `eventmesh-connector-api`:
+
+| Method | Source | Sink |
+| --- | --- | --- |
+| `init(Properties)` | configure from `-D` flags | configure from `-D` flags |
+| `resume(String)` / `poll()` | resume from an offset marker; pull the next batch | — |
+| `put(List<CloudEvent>)` | — | write a batch (throw on failure → no ACK → redelivery) |
+| `commit(...)` | checkpoint after EventMesh accepted the publish | checkpoint after the write |
+
+Delivery semantics are **at-least-once**: sources checkpoint only after the
+runtime accepted the publish, and a failing sink write leaves the delivery
+un-ACKed so EventMesh redelivers (dedup by event id downstream).
+
+## Running a connector
+
+Each plugin ships inside the connector-runtime image; `bin/start-connector.sh`
+starts a worker:
+
+```bash
+# CONNECTOR_OPTS carries the plugin class and every -D flag the plugin reads
+CONNECTOR_OPTS="-Dconnector.class=org.apache.eventmesh.connector.kafka.source.KafkaSourceConnector \
+  -Dconnector.mode=source \
+  -Dconnector.topic=my-topic \
+  -DbootstrapServers=broker:9092" \
+bin/start-connector.sh
+```
+
+Common flags: `eventmesh.runtime.url` (default `http://localhost:8080`),
+`connector.offset.mode` (`remote` | `rocksdb` | `inmemory`), and for multiple
+connectors per process the numbered form `-Dconnector.1.class=...`,
+`-Dconnector.2.class=...` (any `-Dconnector.N.*` key is passed through to the
+plugin's `init`). The runtime can also schedule connectors dynamically via
+`/admin/connectors` — see the [Admin API](../admin-api.md).
+
+## Plugin catalog
+
+**Message queues**
+
+- [Kafka connector](kafka.md)
+- [RocketMQ 4.x connector](rocketmq.md)
+- [RabbitMQ connector](rabbitmq.md)
+- [Pulsar connector](pulsar.md)
+- [Pravega connector](pravega.md)
+
+**Web & serverless**
+
+- [HTTP connector](http.md)
+- [Knative connector](knative.md)
+- [OpenFunction connector](openfunction.md)
+
+**Framework bridges**
+
+- [Spring connector](spring.md)
+
+**Databases**
+
+- [JDBC connector](jdbc.md)
+- [Canal (MySQL CDC) connector](canal.md)
+- [MongoDB connector](mongodb.md)
+
+**Storage**
+
+- [Amazon S3 connector](s3.md)
+- [File connector](file.md)
+- [Redis connector](redis.md)
+
+**Observability**
+
+- [Prometheus connector](prometheus.md)
+
+**AI & chat**
+
+- [ChatGPT (OpenAI) connector](chatgpt.md)
+- [MCP (Model Context Protocol) connector](mcp.md)
+
+**Chat & IM**
+
+- [DingTalk connector](dingtalk.md)
+- [Lark / Feishu connector](lark.md)
+- [Slack connector](slack.md)
+- [WeChat Official Account connector](wechat.md)
+- [WeCom (WeChat Work) connector](wecom.md)
+
+
+## Plugin matrix
+
+| Plugin | Source | Sink | Client dependency |
+| --- | :-: | :-: | --- |
+| [Kafka](kafka.md) | ✓ | ✓ | kafka-clients 3.9.0 |
+| [RocketMQ 4.x](rocketmq.md) | ✓ | ✓ | rocketmq-client |
+| [RabbitMQ](rabbitmq.md) | ✓ | ✓ | amqp-client 5.22.0 |
+| [Pulsar](pulsar.md) | ✓ | ✓ | pulsar-client |
+| [Pravega](pravega.md) | ✓ | ✓ | pravega-client 0.11.0 |
+| [HTTP](http.md) | ✓ | ✓ | — |
+| [Knative](knative.md) | ✓ | ✓ | — |
+| [OpenFunction](openfunction.md) | ✓ | ✓ | — |
+| [Spring](spring.md) | ✓ | ✓ | — |
+| [JDBC](jdbc.md) | ✓ | ✓ | — |
+| [Canal (MySQL CDC)](canal.md) | ✓ | ✓ | canal.client 1.1.7 |
+| [MongoDB](mongodb.md) | ✓ | ✓ | mongodb-driver-sync 4.11.0 |
+| [Amazon S3](s3.md) | ✓ | ✓ | aws-sdk-s3 |
+| [File](file.md) | ✓ | ✓ | — |
+| [Redis](redis.md) | ✓ | ✓ | redisson |
+| [Prometheus](prometheus.md) | ✓ | ✓ | — |
+| [ChatGPT (OpenAI)](chatgpt.md) | ✓ | ✓ | — |
+| [MCP (Model Context Protocol)](mcp.md) | ✓ | ✓ | — |
+| [DingTalk](dingtalk.md) | ✓ | ✓ | — |
+| [Lark / Feishu](lark.md) | ✓ | ✓ | — |
+| [Slack](slack.md) | ✓ | ✓ | — |
+| [WeChat Official Account](wechat.md) | ✓ | ✓ | — |
+| [WeCom (WeChat Work)](wecom.md) | ✓ | ✓ | — |
+
+## Adding a plugin
+
+Implement `SourceConnector` / `SinkConnector` from `eventmesh-connector-api`
+in a new `eventmesh-connector-plugin/eventmesh-connector-<name>` module,
+register the module in `settings.gradle`, and model the implementation on an
+existing plugin of the same style (pull-based like kafka/jdbc, push-receiver
+like http/dingtalk, or writer like rabbitmq/mongodb).

--- a/docs/feature/connectors/_category_.json
+++ b/docs/feature/connectors/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Connectors",
+  "position": 9,
+  "collapsed": true
+}

--- a/docs/feature/connectors/canal.md
+++ b/docs/feature/connectors/canal.md
@@ -1,0 +1,39 @@
+# Canal (MySQL CDC) connector
+
+**Audience:** operators bridging EventMesh with Canal (MySQL CDC). MySQL change-data-capture via a deployed canal server. Source consumes binlog entries over the canal TCP protocol (batch ack only after EventMesh accepted the publish); sink replays row-change CloudEvents into a target MySQL as one all-or-nothing JDBC batch.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.canal.source.CanalSourceConnector` | `CanalConnector.getWithoutAck(batchSize)` each poll; ROWDATA entries become CloudEvents (`subject` = `logfile:offset` position). `commit()` acks the pending batch — at-least-once. |
+| Sink | `org.apache.eventmesh.connector.canal.sink.CanalSinkConnector` | Executes each event's SQL (`subject`) in a single JDBC transaction; any failure rolls back and throws → no ACK → redelivery. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.canalHost` | `localhost` | Canal server host |
+| `connector.canalPort` | `11111` | Canal server port |
+| `connector.destination` | `example` | Canal destination (instance) |
+| `connector.username` | `` | Canal auth username |
+| `connector.password` | `` | Canal auth password |
+| `connector.subscribeFilter` | `.*\..*` | Binlog subscription filter (db.table regex) |
+| `connector.batchSize` | `100` | Max entries per canal batch |
+| `connector.pollTimeoutMs` | `1000` | Poll interval in ms |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.jdbcUrl` | `jdbc:mysql://localhost:3306/test` | Target MySQL JDBC URL |
+| `connector.dbUser` | `root` | Database user |
+| `connector.dbPassword` | `` | Database password |
+
+## Running
+
+```bash
+bin/start-connector.sh with -Dconnector.class=...CanalSourceConnector -Dconnector.mode=source -Dconnector.canalHost=canal -Dconnector.destination=example -Dconnector.subscribeFilter=mydb\\..*
+```

--- a/docs/feature/connectors/chatgpt.md
+++ b/docs/feature/connectors/chatgpt.md
@@ -1,0 +1,34 @@
+# ChatGPT (OpenAI) connector
+
+**Audience:** operators bridging EventMesh with ChatGPT (OpenAI). OpenAI bridge. Source exposes an HTTP prompt endpoint: a client POSTs a prompt, the connector optionally completes it through the OpenAI REST API and emits both as a CloudEvent. Sink forwards events to a webhook (generic).
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.chatgpt.source.ChatgptSourceConnector` | JDK `HttpServer` on `connector.port`+`connector.path` accepts `{"prompt": ...}`; with `connector.openaiApiKey` set it calls chat-completions (`connector.model`) and emits `{prompt, answer}`; without a key it emits the prompt only. `poll()` drains the buffer. |
+| Sink | `org.apache.eventmesh.connector.chatgpt.sink.ChatgptSinkConnector` | POSTs each CloudEvent's payload to `connector.webhookUrl`. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.port` | `8090` | HTTP listen port |
+| `connector.path` | `/chatgpt` | HTTP listen path |
+| `connector.openaiApiKey` | `` | OpenAI API key (empty = no completion) |
+| `connector.model` | `gpt-3.5-turbo` | Chat-completion model |
+| `connector.pollTimeoutMs` | `1000` | Buffer drain wait in ms |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.webhookUrl` | `` | Webhook to POST events into |
+
+## Running
+
+```bash
+curl -X POST http://worker:8090/chatgpt -d '{"prompt":"hi"}' then bin/start-connector.sh with -Dconnector.class=...ChatgptSourceConnector -Dconnector.mode=source -Dconnector.openaiApiKey=sk-...
+```

--- a/docs/feature/connectors/dingtalk.md
+++ b/docs/feature/connectors/dingtalk.md
@@ -1,0 +1,32 @@
+# DingTalk connector
+
+**Audience:** operators bridging EventMesh with DingTalk. DingTalk bridge. Source receives robot outgoing-callback messages (with HMAC signature verification); sink posts events to a DingTalk group-robot webhook.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.dingtalk.source.DingtalkSourceConnector` | JDK `HttpServer` on `connector.port`+`connector.path`; verifies `timestamp`+`sign` headers as base64(HMAC-SHA256(`timestamp + "\n" + appSecret`)) when `connector.appSecret` is set; accepted pushes become CloudEvents and `poll()` drains them. |
+| Sink | `org.apache.eventmesh.connector.dingtalk.sink.DingtalkSinkConnector` | POSTs each CloudEvent's payload to `connector.webhookUrl`. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.port` | `8091` | HTTP listen port |
+| `connector.path` | `/dingtalk` | HTTP listen path |
+| `connector.appSecret` | `` | Robot app secret for signature verification (empty = skip verify) |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.webhookUrl` | `` | DingTalk robot webhook URL |
+
+## Running
+
+```bash
+Configure the robot's outgoing callback to http://worker:8091/dingtalk; bin/start-connector.sh with -Dconnector.class=...DingtalkSourceConnector -Dconnector.mode=source -Dconnector.appSecret=...
+```

--- a/docs/feature/connectors/file.md
+++ b/docs/feature/connectors/file.md
@@ -1,0 +1,30 @@
+# File connector
+
+**Audience:** operators bridging EventMesh with File. Local file bridge — the simplest way to try connectors. Source reads a text file line by line; sink appends each CloudEvent as a line to a file.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.file.source.FileSourceConnector` | `BufferedReader.readLine()` per poll (a small batch each tick), tracking the read position in memory. |
+| Sink | `org.apache.eventmesh.connector.file.sink.FileSinkConnector` | Appends each CloudEvent (`id` + payload text) as a line via `PrintStream` (append mode). |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.filePath` | `/tmp/source.txt` | File to tail |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.filePath` | `/tmp/sink.txt` | File to append into |
+
+## Running
+
+```bash
+bin/start-connector.sh with -Dconnector.class=...FileSourceConnector -Dconnector.mode=source -Dconnector.topic=lines -Dconnector.filePath=/var/log/app.log
+```

--- a/docs/feature/connectors/http.md
+++ b/docs/feature/connectors/http.md
@@ -1,0 +1,31 @@
+# HTTP connector
+
+**Audience:** operators bridging EventMesh with HTTP. Generic HTTP bridge. Source is a webhook receiver: any system can POST events into EventMesh without an SDK. Sink forwards each CloudEvent to an HTTP endpoint.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.http.source.HttpSourceConnector` | JDK `HttpServer` (virtual threads) accepts POSTs on `connector.port`+`connector.path` into a buffer; `poll()` drains it as CloudEvents. |
+| Sink | `org.apache.eventmesh.connector.http.sink.HttpSinkConnector` | POSTs each CloudEvent's data to `connector.url`. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.port` | `8082` | Listen port for the webhook |
+| `connector.path` | `/webhook` | Listen path |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.url` | `http://localhost:9090/sink` | Target endpoint to POST into |
+
+## Running
+
+```bash
+bin/start-connector.sh with -Dconnector.class=...HttpSourceConnector -Dconnector.mode=source -Dconnector.topic=incoming -Dconnector.port=8082
+```

--- a/docs/feature/connectors/jdbc.md
+++ b/docs/feature/connectors/jdbc.md
@@ -1,0 +1,33 @@
+# JDBC connector
+
+**Audience:** operators bridging EventMesh with JDBC. Database bridge over plain JDBC. Source tails a table by a monotonically increasing id column; sink inserts each CloudEvent into a table via a parameterized INSERT.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.jdbc.source.JdbcSourceConnector` | Runs `connector.query` (with the last-seen id substituted for the `?`) each poll; each row (`id`, `data` columns) becomes a CloudEvent and advances the cursor. |
+| Sink | `org.apache.eventmesh.connector.jdbc.sink.JdbcSinkConnector` | Executes `connector.insertSql` per CloudEvent (id = event id, data = payload bytes). |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.jdbcUrl` | `jdbc:mysql://localhost:3306/test` | JDBC URL |
+| `connector.query` | `SELECT * FROM events WHERE id > ? ORDER BY id LIMIT 100` | Tail query (`?` = last id) |
+| `connector.lastId` | `0` | Initial cursor |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.jdbcUrl` | `jdbc:mysql://localhost:3306/test` | JDBC URL |
+| `connector.insertSql` | `INSERT INTO events (id, data) VALUES (?, ?)` | Insert statement |
+
+## Running
+
+```bash
+bin/start-connector.sh with -Dconnector.class=...JdbcSourceConnector -Dconnector.mode=source -Dconnector.jdbcUrl=jdbc:mysql://db:3306/mydb
+```

--- a/docs/feature/connectors/kafka.md
+++ b/docs/feature/connectors/kafka.md
@@ -1,0 +1,34 @@
+# Kafka connector
+
+**Audience:** operators bridging EventMesh with Kafka. Move events between EventMesh topics and an Apache Kafka cluster. The source consumes a Kafka topic with a consumer group and commits offsets only after EventMesh accepted the publish; the sink writes CloudEvent payloads to a target topic.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.kafka.source.KafkaSourceConnector` | Polls a source topic via `KafkaConsumer` (manual offset commit); each record becomes a CloudEvent (`id = topic-partition-offset`). `commit()` runs `commitSync` after the runtime accepted the batch. |
+| Sink | `org.apache.eventmesh.connector.kafka.sink.KafkaSinkConnector` | Produces each CloudEvent's data bytes to the target topic via `KafkaProducer`. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `bootstrapServers` | `localhost:9092` | Kafka bootstrap servers |
+| `topic` | `source-topic` | Topic to consume |
+| `groupId` | `eventmesh-connector-source` | Consumer group id |
+| `pollTimeoutMs` | `1000` | Kafka poll timeout in ms |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `bootstrapServers` | `localhost:9092` | Kafka bootstrap servers |
+| `topic` | `sink-topic` | Target topic to produce into |
+
+## Running
+
+```bash
+bin/start-connector.sh with CONNECTOR_OPTS="-Dconnector.class=org.apache.eventmesh.connector.kafka.source.KafkaSourceConnector -Dconnector.mode=source -Dconnector.topic=my-topic -DbootstrapServers=broker:9092"
+```

--- a/docs/feature/connectors/knative.md
+++ b/docs/feature/connectors/knative.md
@@ -1,0 +1,31 @@
+# Knative connector
+
+**Audience:** operators bridging EventMesh with Knative. Knative eventing bridge. Source receives CloudEvents pushed by a Knative broker (the source acts as the Knative subscriber); sink forwards events to a Knative service/endpoint.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.knative.source.KnativeSourceConnector` | JDK `HttpServer` on `connector.port`+`connector.path` buffers Knative-delivered CloudEvents; `poll()` drains the buffer. |
+| Sink | `org.apache.eventmesh.connector.knative.sink.KnativeSinkConnector` | POSTs each CloudEvent to `connector.sinkUrl`. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.port` | `8080` | Listen port for broker deliveries |
+| `connector.path` | `/` | Listen path |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.sinkUrl` | `http://localhost:8080/sink` | Knative service endpoint |
+
+## Running
+
+```bash
+bin/start-connector.sh with -Dconnector.class=...KnativeSourceConnector -Dconnector.mode=source -Dconnector.port=8080
+```

--- a/docs/feature/connectors/lark.md
+++ b/docs/feature/connectors/lark.md
@@ -1,0 +1,32 @@
+# Lark / Feishu connector
+
+**Audience:** operators bridging EventMesh with Lark / Feishu. Lark (Feishu) bridge. Source receives event-subscription callbacks (answering the `url_verification` challenge automatically); sink posts events to a Lark custom-bot webhook.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.lark.source.LarkSourceConnector` | JDK `HttpServer` on `connector.port`+`connector.path`; answers `url_verification` by echoing the challenge, verifies the callback `token` against `connector.verificationToken` when set, and emits event pushes as CloudEvents. |
+| Sink | `org.apache.eventmesh.connector.lark.sink.LarkSinkConnector` | POSTs each CloudEvent's payload to `connector.webhookUrl`. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.port` | `8092` | HTTP listen port |
+| `connector.path` | `/lark` | HTTP listen path |
+| `connector.verificationToken` | `` | Event-subscription verification token (empty = skip verify) |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.webhookUrl` | `` | Lark custom-bot webhook URL |
+
+## Running
+
+```bash
+Set the app event-subscription request URL to http://worker:8092/lark; bin/start-connector.sh with -Dconnector.class=...LarkSourceConnector -Dconnector.mode=source
+```

--- a/docs/feature/connectors/mcp.md
+++ b/docs/feature/connectors/mcp.md
@@ -1,0 +1,33 @@
+# MCP (Model Context Protocol) connector
+
+**Audience:** operators bridging EventMesh with MCP (Model Context Protocol). MCP server bridge over JSON-RPC 2.0. Source receives server-initiated notifications (e.g. resource updates) on an HTTP endpoint; sink forwards each CloudEvent to an MCP server as a JSON-RPC request.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.mcp.source.McpSourceConnector` | JDK `HttpServer` on `connector.port`+`connector.path` accepts JSON-RPC notifications; each becomes a CloudEvent (`type` = `mcp.<method>`) and `poll()` drains them. |
+| Sink | `org.apache.eventmesh.connector.mcp.sink.McpSinkConnector` | POSTs a JSON-RPC 2.0 request per CloudEvent (`method` = `connector.method`, `params` = event payload) to `connector.mcpServerUrl`; non-2xx throws → no ACK → redelivery. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.port` | `8096` | HTTP listen port |
+| `connector.path` | `/mcp` | HTTP listen path |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.mcpServerUrl` | `http://localhost:3333/mcp` | MCP server endpoint |
+| `connector.method` | `eventmesh.notify` | JSON-RPC method to invoke |
+| `connector.timeoutMs` | `10000` | Request timeout in ms |
+
+## Running
+
+```bash
+bin/start-connector.sh with -Dconnector.class=...McpSinkConnector -Dconnector.mode=sink -Dconnector.mcpServerUrl=http://mcp:3333/mcp
+```

--- a/docs/feature/connectors/mongodb.md
+++ b/docs/feature/connectors/mongodb.md
@@ -1,0 +1,34 @@
+# MongoDB connector
+
+**Audience:** operators bridging EventMesh with MongoDB. MongoDB bridge. Source tails a collection's insert stream; sink inserts each CloudEvent as a document.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.mongodb.source.MongodbSourceConnector` | Watches the collection (`watch()` cursor) and buffers change documents for `poll()`. |
+| Sink | `org.apache.eventmesh.connector.mongodb.sink.MongodbSinkConnector` | Inserts a document per CloudEvent (`_id` = event id, `data` = payload). |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.mongoUri` | `mongodb://localhost:27017` | MongoDB connection URI |
+| `connector.database` | `test` | Database |
+| `connector.collection` | `events` | Collection to watch |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.mongoUri` | `mongodb://localhost:27017` | MongoDB connection URI |
+| `connector.database` | `test` | Database |
+| `connector.collection` | `sink` | Target collection |
+
+## Running
+
+```bash
+bin/start-connector.sh with -Dconnector.class=...MongodbSourceConnector -Dconnector.mode=source -Dconnector.mongoUri=mongodb://mongo:27017 -Dconnector.database=events
+```

--- a/docs/feature/connectors/openfunction.md
+++ b/docs/feature/connectors/openfunction.md
@@ -1,0 +1,32 @@
+# OpenFunction connector
+
+**Audience:** operators bridging EventMesh with OpenFunction. OpenFunction bridge. Source receives function output pushes (the function runtime POSTs its result to the connector endpoint); sink invokes a function's HTTP trigger with CloudEvent headers (`Ce-Id`/`Ce-Type`/`Ce-Source`).
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.openfunction.source.OpenfunctionSourceConnector` | JDK `HttpServer` on `connector.port`+`connector.path` receives function outputs (`X-Function-Name` header → CloudEvent subject); `poll()` drains. |
+| Sink | `org.apache.eventmesh.connector.openfunction.sink.OpenfunctionSinkConnector` | POSTs each CloudEvent (data + Ce-* headers) to `connector.functionUrl`; non-2xx throws → no ACK → redelivery. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.port` | `8097` | Listen port for function outputs |
+| `connector.path` | `/openfunction` | Listen path |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.functionUrl` | `http://localhost:8081/function` | Function HTTP trigger URL |
+| `connector.timeoutMs` | `30000` | Connect/read timeout in ms |
+
+## Running
+
+```bash
+bin/start-connector.sh with -Dconnector.class=...OpenfunctionSinkConnector -Dconnector.mode=sink -Dconnector.functionUrl=http://fn.default.svc.cluster.local:8080
+```

--- a/docs/feature/connectors/pravega.md
+++ b/docs/feature/connectors/pravega.md
@@ -1,0 +1,36 @@
+# Pravega connector
+
+**Audience:** operators bridging EventMesh with Pravega. Move events between EventMesh and a Pravega stream. The source reads through a reader group (offsets managed natively by Pravega); the sink appends events to a stream, creating the scope/stream on first start.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.pravega.source.PravegaSourceConnector` | `EventStreamReader` reads up to the read-timeout each poll; a `ReinitializationRequiredException` (reader-group rebalance) closes the reader and recreates it on the next poll. |
+| Sink | `org.apache.eventmesh.connector.pravega.sink.PravegaSinkConnector` | `EventStreamWriter.writeEvent(routingKey=id, bytes)` for each CloudEvent; the batch is joined before returning (throw on failure → no ACK → redelivery). |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.scope` | `scope` | Pravega scope |
+| `connector.stream` | `stream` | Stream to read |
+| `connector.controllerUri` | `tcp://localhost:9090` | Controller URI |
+| `connector.readTimeoutMs` | `1000` | Per-poll read window in ms |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.scope` | `scope` | Pravega scope (created on start) |
+| `connector.stream` | `stream` | Target stream (created on start) |
+| `connector.controllerUri` | `tcp://localhost:9090` | Controller URI |
+| `connector.txnTimeoutMs` | `30000` | Writer transaction timeout in ms |
+
+## Running
+
+```bash
+bin/start-connector.sh with -Dconnector.class=...PravegaSourceConnector -Dconnector.mode=source -Dconnector.scope=my-scope -Dconnector.stream=my-stream
+```

--- a/docs/feature/connectors/prometheus.md
+++ b/docs/feature/connectors/prometheus.md
@@ -1,0 +1,33 @@
+# Prometheus connector
+
+**Audience:** operators bridging EventMesh with Prometheus. Metrics bridge. Source scrapes a Prometheus `/metrics` endpoint on each poll and emits the exposition text as a CloudEvent; sink pushes metric samples (text exposition format) to a Pushgateway.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.prometheus.source.PrometheusSourceConnector` | GETs `connector.metricsUrl` each poll; the response body becomes one CloudEvent. |
+| Sink | `org.apache.eventmesh.connector.prometheus.sink.PrometheusSinkConnector` | Merges the batch's payloads into one text-exposition document and POSTs it to the Pushgateway; non-2xx throws → no ACK → redelivery. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.metricsUrl` | `http://localhost:9090/metrics` | Metrics endpoint to scrape |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.pushgatewayUrl` | `http://localhost:9091` | Pushgateway base URL |
+| `connector.job` | `eventmesh` | Pushgateway job label |
+| `connector.instance` | `connector-1` | Pushgateway instance label |
+| `connector.timeoutMs` | `10000` | Push timeout in ms |
+
+## Running
+
+```bash
+bin/start-connector.sh with -Dconnector.class=...PrometheusSinkConnector -Dconnector.mode=sink -Dconnector.pushgatewayUrl=http://pg:9091 -Dconnector.job=eventmesh
+```

--- a/docs/feature/connectors/pulsar.md
+++ b/docs/feature/connectors/pulsar.md
@@ -1,0 +1,32 @@
+# Pulsar connector
+
+**Audience:** operators bridging EventMesh with Pulsar. Bridge EventMesh topics with an Apache Pulsar cluster. Source subscribes to a topic; sink produces to a persistent topic.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.pulsar.source.PulsarSourceConnector` | Subscribes via `PulsarClient` consumer (bytes schema) and buffers messages for `poll()`. |
+| Sink | `org.apache.eventmesh.connector.pulsar.sink.PulsarSinkConnector` | Produces each CloudEvent's data bytes via a Pulsar bytes producer. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.serviceUrl` | `pulsar://localhost:6650` | Pulsar service URL |
+| `connector.topic` | `persistent://public/default/source` | Topic to subscribe |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.serviceUrl` | `pulsar://localhost:6650` | Pulsar service URL |
+| `connector.topic` | `persistent://public/default/sink` | Target topic |
+
+## Running
+
+```bash
+bin/start-connector.sh with -Dconnector.class=...PulsarSourceConnector -Dconnector.mode=source -Dconnector.topic=persistent://public/default/my-topic
+```

--- a/docs/feature/connectors/rabbitmq.md
+++ b/docs/feature/connectors/rabbitmq.md
@@ -1,0 +1,35 @@
+# RabbitMQ connector
+
+**Audience:** operators bridging EventMesh with RabbitMQ. Move events between EventMesh and a RabbitMQ broker over AMQP 0-9-1. Source consumes a queue; sink publishes to an exchange with an optional routing key.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.rabbitmq.source.RabbitmqSourceConnector` | `basicConsume` on the configured queue (auto-ack) into an internal buffer drained by `poll()`. |
+| Sink | `org.apache.eventmesh.connector.rabbitmq.sink.RabbitmqSinkConnector` | `basicPublish` each CloudEvent's data to the exchange with the routing key. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.host` | `localhost` | AMQP host |
+| `connector.port` | `5672` | AMQP port |
+| `connector.queue` | `source` | Queue to consume |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.host` | `localhost` | AMQP host |
+| `connector.port` | `5672` | AMQP port |
+| `connector.exchange` | `` | Target exchange (empty = default) |
+| `connector.routingKey` | `` | Routing key |
+
+## Running
+
+```bash
+bin/start-connector.sh with -Dconnector.class=...RabbitmqSinkConnector -Dconnector.mode=sink -Dconnector.clientId=c1 -Dconnector.exchange=amq.topic -Dconnector.routingKey=events
+```

--- a/docs/feature/connectors/redis.md
+++ b/docs/feature/connectors/redis.md
@@ -1,0 +1,32 @@
+# Redis connector
+
+**Audience:** operators bridging EventMesh with Redis. Redis pub/sub bridge over Redisson. Source listens on a channel; sink publishes each CloudEvent to a channel.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.redis.source.RedisSourceConnector` | Redisson topic listener buffers channel messages; `poll()` drains them as CloudEvents. |
+| Sink | `org.apache.eventmesh.connector.redis.sink.RedisSinkConnector` | Publishes each CloudEvent's payload to the Redis topic. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.redisUrl` | `redis://localhost:6379` | Redis address |
+| `connector.topic` | `source` | Channel to subscribe |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.redisUrl` | `redis://localhost:6379` | Redis address |
+| `connector.topic` | `sink` | Channel to publish |
+
+## Running
+
+```bash
+bin/start-connector.sh with -Dconnector.class=...RedisSourceConnector -Dconnector.mode=source -Dconnector.redisUrl=redis://redis:6379 -Dconnector.topic=events
+```

--- a/docs/feature/connectors/rocketmq.md
+++ b/docs/feature/connectors/rocketmq.md
@@ -1,0 +1,34 @@
+# RocketMQ 4.x connector
+
+**Audience:** operators bridging EventMesh with RocketMQ 4.x. Bridge EventMesh topics with an Apache RocketMQ 4.x cluster (nameserver-based). Source pulls from a consumer group; sink produces with a producer group.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.rocketmq.source.RocketmqSourceConnector` | Consumes a topic via `DefaultMQPushConsumer`; messages buffer into an internal queue that `poll()` drains. |
+| Sink | `org.apache.eventmesh.connector.rocketmq.sink.RocketmqSinkConnector` | Sends each CloudEvent via `DefaultMQProducer` to the configured topic. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.namesrvAddr` | `localhost:9876` | Name server address |
+| `connector.topic` | `source-topic` | Topic to consume |
+| `connector.group` | `connector-source` | Consumer group name |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.namesrvAddr` | `localhost:9876` | Name server address |
+| `connector.group` | `connector-sink` | Producer group name |
+| `connector.topic` | `sink-topic` | Target topic (set via producer topic config) |
+
+## Running
+
+```bash
+bin/start-connector.sh with -Dconnector.class=...RocketmqSourceConnector -Dconnector.mode=source -Dconnector.topic=my-topic -Dconnector.namesrvAddr=ns:9876
+```

--- a/docs/feature/connectors/s3.md
+++ b/docs/feature/connectors/s3.md
@@ -1,0 +1,31 @@
+# Amazon S3 connector
+
+**Audience:** operators bridging EventMesh with Amazon S3. S3 object bridge. Source lists new objects in a bucket (cursor = last key); sink writes each CloudEvent as an object keyed by the event id.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.s3.source.S3SourceConnector` | `ListObjectsV2` with `startAfter(lastKey)` each poll; new objects are fetched and emitted as CloudEvents, advancing the cursor. |
+| Sink | `org.apache.eventmesh.connector.s3.sink.S3SinkConnector` | Puts each CloudEvent's payload as an object (`id` = key) into the target bucket. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.bucket` | `events` | Source bucket |
+| `connector.prefix` | `` | Key prefix filter |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.bucket` | `sink` | Target bucket |
+
+## Running
+
+```bash
+bin/start-connector.sh with -Dconnector.class=...S3SourceConnector -Dconnector.mode=source -Dconnector.bucket=incoming -Dconnector.prefix=2026/
+```

--- a/docs/feature/connectors/slack.md
+++ b/docs/feature/connectors/slack.md
@@ -1,0 +1,32 @@
+# Slack connector
+
+**Audience:** operators bridging EventMesh with Slack. Slack bridge. Source receives Events API callbacks (verifying the v0 HMAC request signature and answering the challenge); sink posts events to a Slack incoming webhook.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.slack.source.SlackSourceConnector` | JDK `HttpServer` on `connector.port`+`connector.path`; when `connector.signingSecret` is set, verifies `X-Slack-Signature` (v0 = HMAC-SHA256 of `v0:timestamp:body`) + timestamp; answers `url_verification` challenges; event pushes become CloudEvents. |
+| Sink | `org.apache.eventmesh.connector.slack.sink.SlackSinkConnector` | POSTs each CloudEvent's payload to `connector.webhookUrl`. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.port` | `8093` | HTTP listen port |
+| `connector.path` | `/slack` | HTTP listen path |
+| `connector.signingSecret` | `` | Slack app signing secret (empty = skip verify) |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.webhookUrl` | `` | Slack incoming webhook URL |
+
+## Running
+
+```bash
+Point the Slack app's Events API request URL at http://worker:8093/slack; bin/start-connector.sh with -Dconnector.class=...SlackSourceConnector -Dconnector.mode=source -Dconnector.signingSecret=...
+```

--- a/docs/feature/connectors/spring.md
+++ b/docs/feature/connectors/spring.md
@@ -1,0 +1,30 @@
+# Spring connector
+
+**Audience:** operators bridging EventMesh with Spring. Spring application bridge. Source buffers events published by Spring code (register a producer that feeds the buffer); sink exposes an injectable `EventForwarder` so the hosting Spring context receives EventMesh deliveries as native events.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.spring.source.SpringSourceConnector` | A `LinkedBlockingQueue` feeds `poll()`; host Spring code (e.g. an `@EventListener` adapter) enqueues CloudEvents. |
+| Sink | `org.apache.eventmesh.connector.spring.sink.SpringSinkConnector` | Calls the injected `EventForwarder.forward(event)` per CloudEvent. **Fail-fast**: until the Spring context wires a forwarder via `setForwarder(...)`, `put()` throws so the runtime redelivers instead of silently dropping events. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `(none)` | `—` | The source needs no external config |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `(none)` | `—` | Wire the forwarder programmatically from the Spring context |
+
+## Running
+
+```bash
+Host inside a Spring Boot app; call SpringSinkConnector.setForwarder(event -> publisher.publishEvent(...)) after init
+```

--- a/docs/feature/connectors/wechat.md
+++ b/docs/feature/connectors/wechat.md
@@ -1,0 +1,32 @@
+# WeChat Official Account connector
+
+**Audience:** operators bridging EventMesh with WeChat Official Account. WeChat Official Account bridge. Source handles the platform's server-to-server callback — the GET echostr verification (SHA-1 of token/timestamp/nonce) and POST XML message pushes; sink posts events to a webhook.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.wechat.source.WechatSourceConnector` | JDK `HttpServer` on `connector.port`+`connector.path`; GET answers the server verification (echostr when `sha1(sort(token,timestamp,nonce))` matches); POST parses the XML message (FromUserName/MsgType/MsgId) into a CloudEvent and replies `success`. |
+| Sink | `org.apache.eventmesh.connector.wechat.sink.WechatSinkConnector` | POSTs each CloudEvent's payload to `connector.webhookUrl`. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.port` | `8094` | HTTP listen port |
+| `connector.path` | `/wechat` | HTTP listen path |
+| `connector.token` | `eventmesh` | Server-verification token configured in the WeChat admin console |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.webhookUrl` | `` | Webhook to POST events into |
+
+## Running
+
+```bash
+Set the account's server URL to http://worker:8094/wechat with the matching token; bin/start-connector.sh with -Dconnector.class=...WechatSourceConnector -Dconnector.mode=source
+```

--- a/docs/feature/connectors/wecom.md
+++ b/docs/feature/connectors/wecom.md
@@ -1,0 +1,32 @@
+# WeCom (WeChat Work) connector
+
+**Audience:** operators bridging EventMesh with WeCom (WeChat Work). WeCom bridge. Source receives WeCom callback events (plain-token verification mode: answers the GET echostr challenge, accepts POST JSON events); sink posts events to a WeCom group-robot webhook.
+
+---
+
+## Classes
+
+| Direction | Class | Behavior |
+| --- | --- | --- |
+| Source | `org.apache.eventmesh.connector.wecom.source.WecomSourceConnector` | JDK `HttpServer` on `connector.port`+`connector.path`; GET echoes the `echostr` (URL challenge); POST parses the JSON event (`event_type`, `from.user_id`, `msgid`) into a CloudEvent and replies `{"errcode":0}`. |
+| Sink | `org.apache.eventmesh.connector.wecom.sink.WecomSinkConnector` | POSTs each CloudEvent's payload to `connector.webhookUrl`. |
+
+## Source configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.port` | `8095` | HTTP listen port |
+| `connector.path` | `/wecom` | HTTP listen path |
+| `connector.token` | `eventmesh` | Callback token configured in the WeCom admin console |
+
+## Sink configuration
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `connector.webhookUrl` | `` | WeCom group-robot webhook URL |
+
+## Running
+
+```bash
+Set the app's receive-message URL to http://worker:8095/wecom; bin/start-connector.sh with -Dconnector.class=...WecomSourceConnector -Dconnector.mode=source
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,10 @@ too.
   task lifecycle, JSON-RPC/MCP bridge, REST + SDK usage
   *(Experimental)*; [readiness decision](feature/a2a-readiness.md).
 
+- [Connectors](feature/connectors/README.md) — bridge EventMesh with external
+  systems (Kafka, RocketMQ, RabbitMQ, databases, chat platforms): the connector
+  model, running a worker, and a per-plugin guide for all 23 shipped plugins.
+
 **Internals & mechanisms**
 
 - [Offset management](feature/offset-management.md) — the two offset layers,


### PR DESCRIPTION
## What

Adds a complete connector documentation set under `docs/feature/connectors/`: one overview (model, running, catalog, matrix) plus one page per plugin for all 23 shipped connectors.

Follow-up to #5394 (the 16 incomplete connector implementations fix) — now every plugin also has operator-facing docs, replacing the master-era website `03-connect` docs (which only covered 9 plugins) with full coverage of the new-architecture contract.

## Structure

- `docs/feature/connectors/README.md` — the connector model (Source/Sink contract table from `eventmesh-connector-api`), at-least-once semantics, running a worker (`bin/start-connector.sh` + `CONNECTOR_OPTS`), common flags (`connector.offset.mode`, numbered `-Dconnector.N.*` form, `/admin/connectors` dynamic scheduling), plugin catalog grouped by category, and a 23-row plugin matrix (source/sink support + client dependency).
- `docs/feature/connectors/<plugin>.md` × 23 — per plugin: Classes table (source/sink implementation classes + behavior summary), Source/Sink configuration tables (key / default / description, defaults taken from the actual `props.getProperty` calls in each connector), and a runnable example (`bin/start-connector.sh` with the plugin's `CONNECTOR_OPTS`).
- `docs/feature/connectors/_category_.json` — sidebar position.
- `docs/index.md` — adds a Connectors bullet to the Core features section.

## Plugins covered

Message queues: kafka, rocketmq (4.x), rabbitmq, pulsar, pravega · Databases & storage: mongodb, redis, canal, jdbc, s3, file · Cloud & runtime: knative, openfunction, spring, http, prometheus · Chat & SaaS: dingtalk, lark, slack, wechat, wecom · AI: chatgpt, mcp

## Notes

- Config tables were derived from the real `getProperty` defaults in each connector source, so the documented values match the code (including the 16 connectors completed in #5394).
- Docs-only change; no code touched.
